### PR TITLE
Filter api expose objects

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -56,6 +57,10 @@ func (e *ensurer) InjectClient(client client.Client) error {
 
 // EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerService(ctx context.Context, ectx genericmutator.EnsurerContext, new, old *corev1.Service) error {
+	if v1beta1helper.IsAPIServerExposureManaged(new) {
+		return nil
+	}
+
 	// TODO: Assuming seed kubernetes version is >= 1.12. Validate it correctly
 	if new.Annotations == nil {
 		new.Annotations = make(map[string]string)
@@ -66,6 +71,10 @@ func (e *ensurer) EnsureKubeAPIServerService(ctx context.Context, ectx genericmu
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, new, old *appsv1.Deployment) error {
+	if v1beta1helper.IsAPIServerExposureManaged(new) {
+		return nil
+	}
+
 	cluster, err := controller.GetCluster(ctx, e.client, new.Namespace)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not mutate kube-apiserver exposure resources when gardener manages those. See https://github.com/gardener/gardener/pull/1929

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

~~This is WIP as https://github.com/gardener/gardener/commit/40864019e030923c80657ac5d46a34130bcf337d is still not available in any tags and vendor folder manually updated~~

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Do not mutate `kube-apiserver` exposure resources which Gardener marks as managed by it with `core.gardener.cloud/apiserver-exposure: gardener-managed` label.
```
