### PR TITLE
Adapt terraformer Pod spec to the latest image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.20.0"
+  tag: "v1.0.0"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gardener/etcd-druid v0.1.3
 	github.com/gardener/gardener v1.1.1-0.20200330051317-a326f96cf32b
 	github.com/gardener/gardener-extension-networking-calico v1.3.0
-	github.com/gardener/gardener-extensions v1.5.1-0.20200330101454-c65957bd80b5
+	github.com/gardener/gardener-extensions v1.5.1-0.20200402091828-df061f8dae06
 	github.com/gardener/machine-controller-manager v0.26.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/gardener/gardener v1.1.1-0.20200330051317-a326f96cf32b/go.mod h1:lGAx
 github.com/gardener/gardener-extension-networking-calico v1.3.0 h1:pxztFZRvWR0ZOpifaJYVFPqE06RFMwZNe+tpz+KDSLs=
 github.com/gardener/gardener-extension-networking-calico v1.3.0/go.mod h1:7SpCZoWGAV1EDCicfMI7NDwDY7cwmlZ69jTDDLSevKU=
 github.com/gardener/gardener-extensions v1.3.0/go.mod h1:FoPT/v8gUT8BdufAAzGSMzJiiQvqr7+DMmippm1Mc9w=
-github.com/gardener/gardener-extensions v1.5.1-0.20200330101454-c65957bd80b5 h1:zDXG4369jfXvZlPNQe4YX38VA0h5SDq2xk8dqLg73e4=
-github.com/gardener/gardener-extensions v1.5.1-0.20200330101454-c65957bd80b5/go.mod h1:+0MkNqbRaTvPMfEe/MoS31L5FM8W32WYvhpH4Y53Y5s=
+github.com/gardener/gardener-extensions v1.5.1-0.20200402091828-df061f8dae06 h1:ZMAxjMWvydRD1ndHAFfa/ItQp4JEy9OPsVmNc1gc0og=
+github.com/gardener/gardener-extensions v1.5.1-0.20200402091828-df061f8dae06/go.mod h1:+0MkNqbRaTvPMfEe/MoS31L5FM8W32WYvhpH4Y53Y5s=
 github.com/gardener/gardener-resource-manager v0.9.1-0.20200124091350-6ea41bbae81f/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=

--- a/vendor/github.com/gardener/gardener-extensions/pkg/controller/backupbucket/reconciler.go
+++ b/vendor/github.com/gardener/gardener-extensions/pkg/controller/backupbucket/reconciler.go
@@ -95,7 +95,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.BackupBucket) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, bb); err != nil {
-		r.logger.Info("failed to ensure finalizer on backup bucket, %v", err)
+		r.logger.Error(err, "failed to ensure finalizer on backup bucket", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -106,11 +106,11 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup bucket secret, %v", err)
+		r.logger.Error(err, "failed to get backup bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to ensure finalizer on bucket secret, %v", err)
+		r.logger.Error(err, "failed to ensure finalizer on bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -168,11 +168,11 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup bucket secret, %v", err)
+		r.logger.Error(err, "failed to get backup bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to remove finalizer on bucket secret, %v", err)
+		r.logger.Error(err, "failed to remove finalizer on bucket secret", "backupbucket", bb.Name)
 		return reconcile.Result{}, err
 	}
 

--- a/vendor/github.com/gardener/gardener-extensions/pkg/controller/backupentry/reconciler.go
+++ b/vendor/github.com/gardener/gardener-extensions/pkg/controller/backupentry/reconciler.go
@@ -105,11 +105,11 @@ func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.Backu
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup entry secret, %v", err)
+		r.logger.Error(err, "failed to get backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to ensure finalizer on backup entry secret, %v", err)
+		r.logger.Error(err, "failed to ensure finalizer on backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -167,11 +167,11 @@ func (r *reconciler) delete(ctx context.Context, be *extensionsv1alpha1.BackupEn
 
 	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
-		r.logger.Info("failed to get backup entry secret, %v", err)
+		r.logger.Error(err, "failed to get backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
-		r.logger.Info("failed to remove finalizer on backup entry secret, %v", err)
+		r.logger.Error(err, "failed to remove finalizer on backup entry secret", "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 

--- a/vendor/github.com/gardener/gardener-extensions/pkg/controller/cluster.go
+++ b/vendor/github.com/gardener/gardener-extensions/pkg/controller/cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,7 @@ func init() {
 
 // Cluster contains the decoded resources of Gardener's extension Cluster resource.
 type Cluster struct {
+	ObjectMeta   metav1.ObjectMeta
 	CloudProfile *gardencorev1beta1.CloudProfile
 	Seed         *gardencorev1beta1.Seed
 	Shoot        *gardencorev1beta1.Shoot
@@ -67,7 +69,7 @@ func GetCluster(ctx context.Context, c client.Client, namespace string) (*Cluste
 		return nil, err
 	}
 
-	return &Cluster{cloudProfile, seed, shoot}, nil
+	return &Cluster{cluster.ObjectMeta, cloudProfile, seed, shoot}, nil
 }
 
 // CloudProfileFromCluster returns the CloudProfile resource inside the Cluster resource.

--- a/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -147,7 +147,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 				}
 
 				if !preCheckFunc(obj, cluster) {
-					a.logger.Info("Skipping health check for condition type %q as pre check function returned false", healthConditionType)
+					a.logger.Info("Skipping health check as pre check function returned false", "conditionType", healthConditionType)
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{
 							IsHealthy: true,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -158,7 +158,7 @@ github.com/gardener/gardener-extension-networking-calico/pkg/calico
 github.com/gardener/gardener-extension-networking-calico/pkg/charts
 github.com/gardener/gardener-extension-networking-calico/pkg/controller
 github.com/gardener/gardener-extension-networking-calico/pkg/imagevector
-# github.com/gardener/gardener-extensions v1.5.1-0.20200330101454-c65957bd80b5
+# github.com/gardener/gardener-extensions v1.5.1-0.20200402091828-df061f8dae06
 github.com/gardener/gardener-extensions/hack
 github.com/gardener/gardener-extensions/hack/.ci
 github.com/gardener/gardener-extensions/hack/api-reference/template


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt terraformer Pod spec to the latest image.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener-extensions/issues/597

**Special notes for your reviewer**:
This PR requires:
- [x] terrafomer release - g/terraformer@v1.0.0 released https://github.com/gardener/terraformer/releases/tag/v1.0.0
- [x] gardener/gardener-extensions#624 - merged


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/terraformer #38 @ialidzhikov
`nsxt` and `random` providers are now removed from the terraform bundle.
```

``` action operator github.com/gardener/terraformer #37 @rfranzke
The Terraformer does now lookup the relevant data stored in `ConfigMap`s or `Secret`s live from the system instead of relying on mounted volumes. This is a breaking change as the volume mount approach does no longer work, please adapt your manifests [according to the examples](https://github.com/gardener/terraformer/tree/master/example). The rationale behind it is to not rely on potentially stale kubelet cache while it mounts the volume which may, in rare cases, cause state loss.
```

``` improvement operator github.com/gardener/terraformer #36 @ialidzhikov
`terraformer` does no longer ignore the termination signals sent to PID 1. It does now send a termination signal to the terraform process itself and waits for its completion. This should prevent rare cases in which the `terraformer` was not storing the state of created infrastructure resources.
```

```improvement operator
`g/gardener-extensions` does now require the `g/terraformer@v1.0.0`.
```