### PR TITLE
Vendor gardener/gardener@58593d8, gardener/gardener-extensions@v1.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/gardener/etcd-druid v0.1.3
-	github.com/gardener/gardener v1.1.1-0.20200311075931-7f7e52b986e7
+	github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a
 	github.com/gardener/gardener-extension-networking-calico v1.3.0
-	github.com/gardener/gardener-extensions v1.4.1-0.20200322183545-5329339c95e9
+	github.com/gardener/gardener-extensions v1.5.0
 	github.com/gardener/machine-controller-manager v0.26.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -143,11 +143,13 @@ github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcH
 github.com/gardener/gardener v0.35.1-0.20200128130120-5b69a02f511a/go.mod h1:cu4WkHhpM9JLvqx76qSViagsPO4UH9Qx5i0h3AEIdiE=
 github.com/gardener/gardener v1.1.1-0.20200311075931-7f7e52b986e7 h1:UD25lsw3fYBK7pUlXkGwUXmlpnksG9JbdwC75XZTBOQ=
 github.com/gardener/gardener v1.1.1-0.20200311075931-7f7e52b986e7/go.mod h1:lGAx5NkFDWoC4hPIL+lHJamafBxmOt5MrHq9hGtp5VI=
+github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a h1:TkMIvx1xRmd3xLuORXEqsQhpni49+wfuT4keC6d3Tsc=
+github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a/go.mod h1:lGAx5NkFDWoC4hPIL+lHJamafBxmOt5MrHq9hGtp5VI=
 github.com/gardener/gardener-extension-networking-calico v1.3.0 h1:pxztFZRvWR0ZOpifaJYVFPqE06RFMwZNe+tpz+KDSLs=
 github.com/gardener/gardener-extension-networking-calico v1.3.0/go.mod h1:7SpCZoWGAV1EDCicfMI7NDwDY7cwmlZ69jTDDLSevKU=
 github.com/gardener/gardener-extensions v1.3.0/go.mod h1:FoPT/v8gUT8BdufAAzGSMzJiiQvqr7+DMmippm1Mc9w=
-github.com/gardener/gardener-extensions v1.4.1-0.20200322183545-5329339c95e9 h1:v1BPB5ZhUrjhBDBzyV5ItM04gNeor+vO6MDWwLRfJIw=
-github.com/gardener/gardener-extensions v1.4.1-0.20200322183545-5329339c95e9/go.mod h1:yCdFgMAz++ex3d1fmhN3Yti9MR9HN9iKTUjz5eI0uIQ=
+github.com/gardener/gardener-extensions v1.5.0 h1:6JkU0/DV2bJvwkuPoP7/nPlyCrzPGKfw5j4f+wtXBeI=
+github.com/gardener/gardener-extensions v1.5.0/go.mod h1:yCdFgMAz++ex3d1fmhN3Yti9MR9HN9iKTUjz5eI0uIQ=
 github.com/gardener/gardener-resource-manager v0.9.1-0.20200124091350-6ea41bbae81f/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+
 	genericcontrolplaneactuator "github.com/gardener/gardener-extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener-extensions/pkg/controller/healthcheck"
 	healthcheckconfig "github.com/gardener/gardener-extensions/pkg/controller/healthcheck/config"
@@ -25,7 +26,6 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/controller/healthcheck/worker"
 	genericworkeractuator "github.com/gardener/gardener-extensions/pkg/controller/worker/genericactuator"
 	extensionspredicate "github.com/gardener/gardener-extensions/pkg/predicate"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,19 +45,28 @@ var (
 // RegisterHealthChecks registers health checks for each extension resource
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g azure) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
-	normalPredicates := []predicate.Predicate{extensionspredicate.HasPurpose(extensionsv1alpha1.Normal)}
 	if err := healthcheck.DefaultRegistration(
 		azure.Type,
 		extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ControlPlaneResource),
 		func() runtime.Object { return &extensionsv1alpha1.ControlPlane{} },
 		mgr,
 		opts,
-		normalPredicates,
-		map[healthcheck.HealthCheck]string{
-			general.NewSeedDeploymentHealthChecker(azure.CloudControllerManagerName):                     string(gardencorev1beta1.ShootControlPlaneHealthy),
-			general.CheckManagedResource(genericcontrolplaneactuator.ControlPlaneShootChartResourceName): string(gardencorev1beta1.ShootSystemComponentsHealthy),
-			general.CheckManagedResource(genericcontrolplaneactuator.StorageClassesChartResourceName):    string(gardencorev1beta1.ShootSystemComponentsHealthy),
-		}); err != nil {
+		[]predicate.Predicate{extensionspredicate.HasPurpose(extensionsv1alpha1.Normal)},
+		[]healthcheck.ConditionTypeToHealthCheck{
+			{
+				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(azure.CloudControllerManagerName),
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
+				HealthCheck:   general.CheckManagedResource(genericcontrolplaneactuator.ControlPlaneShootChartResourceName),
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
+				HealthCheck:   general.CheckManagedResource(genericcontrolplaneactuator.StorageClassesChartResourceName),
+			},
+		},
+	); err != nil {
 		return err
 	}
 
@@ -68,11 +77,21 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 		mgr,
 		opts,
 		nil,
-		map[healthcheck.HealthCheck]string{
-			general.CheckManagedResource(genericworkeractuator.McmShootResourceName):   string(gardencorev1beta1.ShootSystemComponentsHealthy),
-			general.NewSeedDeploymentHealthChecker(azure.MachineControllerManagerName): string(gardencorev1beta1.ShootControlPlaneHealthy),
-			worker.NewSufficientNodesChecker():                                         string(gardencorev1beta1.ShootEveryNodeReady),
-		})
+		[]healthcheck.ConditionTypeToHealthCheck{
+			{
+				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
+				HealthCheck:   general.CheckManagedResource(genericworkeractuator.McmShootResourceName),
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(azure.MachineControllerManagerName),
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootEveryNodeReady),
+				HealthCheck:   worker.NewSufficientNodesChecker(),
+			},
+		},
+	)
 }
 
 // AddToManager adds a controller with the default Options.

--- a/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/actuator.go
+++ b/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/actuator.go
@@ -17,6 +17,8 @@ package healthcheck
 import (
 	"context"
 
+	extensionscontroller "github.com/gardener/gardener-extensions/pkg/controller"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,8 +41,20 @@ import (
 	More sophisticated checks should be implemented in the extension itself by using the HealthCheck interface.
 */
 
-// RegisterExtension returns the extension object that should be registered with the health check controller
-type RegisterExtension = func() runtime.Object
+// GetExtensionObjectFunc returns the extension object that should be registered with the health check controller
+type GetExtensionObjectFunc = func() runtime.Object
+
+// PreCheckFunc checks whether the health check shall be performed based on the given object and cluster.
+type PreCheckFunc = func(runtime.Object, *extensionscontroller.Cluster) bool
+
+// ConditionTypeToHealthCheck registers a HealthCheck for the given ConditionType. If the PreCheckFunc is not nil it will
+// be executed with the given object before the health check if performed. Otherwise, the health check will always be
+// performed.
+type ConditionTypeToHealthCheck struct {
+	ConditionType string
+	PreCheckFunc  PreCheckFunc
+	HealthCheck   HealthCheck
+}
 
 // HealthCheckActuator acts upon registered resources.
 type HealthCheckActuator interface {

--- a/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/controller.go
+++ b/vendor/github.com/gardener/gardener-extensions/pkg/controller/healthcheck/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -72,7 +73,7 @@ type DefaultAddArgs struct {
 // The field groupVersionKind stores the GroupVersionKind of the extension resource
 type RegisteredExtension struct {
 	extension           extensionsv1alpha1.Object
-	register            RegisterExtension
+	getExtensionObjFunc GetExtensionObjectFunc
 	healthConditionType []string
 	groupVersionKind    schema.GroupVersionKind
 }
@@ -87,7 +88,7 @@ type RegisteredExtension struct {
 // custom predicates allow for fine-grained control which resources to watch
 // healthChecks defines the checks to execute mapped to the healthConditionType its contributing to (e.g checkDeployment in Seed -> ControlPlaneHealthy).
 // register returns a runtime representation of the extension resource to register it with the controller-runtime
-func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, register RegisterExtension, mgr manager.Manager, opts DefaultAddArgs, customPredicates []predicate.Predicate, healthChecks map[HealthCheck]string) error {
+func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, getExtensionObjFunc GetExtensionObjectFunc, mgr manager.Manager, opts DefaultAddArgs, customPredicates []predicate.Predicate, healthChecks []ConditionTypeToHealthCheck) error {
 	predicates := DefaultPredicates()
 	predicates = append(predicates, customPredicates...)
 
@@ -98,11 +99,11 @@ func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, reg
 		SyncPeriod:        opts.HealthCheckConfig.SyncPeriod,
 	}
 
-	if err := args.RegisterExtension(register, getHealthCheckTypes(healthChecks), kind); err != nil {
+	if err := args.RegisterExtension(getExtensionObjFunc, getHealthCheckTypes(healthChecks), kind); err != nil {
 		return err
 	}
 
-	healthCheckActuator := NewActuator(args.Type, args.GetExtensionGroupVersionKind().Kind, healthChecks)
+	healthCheckActuator := NewActuator(args.Type, args.GetExtensionGroupVersionKind().Kind, getExtensionObjFunc, healthChecks)
 	return Register(mgr, args, healthCheckActuator)
 }
 
@@ -111,8 +112,8 @@ func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, reg
 // The controller writes the healthCheckTypes as a condition.type into the extension resource.
 // To contribute to the Shoot's health, the Gardener checks each extension for a Health Condition Type of SystemComponentsHealthy, EveryNodeReady, ControlPlaneHealthy.
 // However extensions are free to choose any healthCheckType
-func (a *AddArgs) RegisterExtension(register RegisterExtension, conditionTypes []string, kind schema.GroupVersionKind) error {
-	acc, err := extensions.Accessor(register())
+func (a *AddArgs) RegisterExtension(getExtensionObjFunc GetExtensionObjectFunc, conditionTypes []string, kind schema.GroupVersionKind) error {
+	acc, err := extensions.Accessor(getExtensionObjFunc())
 	if err != nil {
 		return err
 	}
@@ -121,7 +122,7 @@ func (a *AddArgs) RegisterExtension(register RegisterExtension, conditionTypes [
 		extension:           acc,
 		healthConditionType: conditionTypes,
 		groupVersionKind:    kind,
-		register:            register,
+		getExtensionObjFunc: getExtensionObjFunc,
 	}
 	return nil
 }
@@ -162,19 +163,15 @@ func add(mgr manager.Manager, args AddArgs) error {
 	}
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
-	log.Log.Info("Registered health check controller", "kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "health check type", args.registeredExtension.healthConditionType, "sync period", args.SyncPeriod.Duration.String())
+	log.Log.Info("Registered health check controller", "Kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "health check type", args.registeredExtension.healthConditionType, "sync period", args.SyncPeriod.Duration.String())
 
-	return ctrl.Watch(&source.Kind{Type: args.registeredExtension.register()}, &handler.EnqueueRequestForObject{}, predicates...)
+	return ctrl.Watch(&source.Kind{Type: args.registeredExtension.getExtensionObjFunc()}, &handler.EnqueueRequestForObject{}, predicates...)
 }
 
-func getHealthCheckTypes(healthChecks map[HealthCheck]string) []string {
-	var types []string
-	typeMap := make(map[string]struct{})
-	for _, check := range healthChecks {
-		if _, ok := typeMap[check]; !ok {
-			types = append(types, check)
-		}
-		typeMap[check] = struct{}{}
+func getHealthCheckTypes(healthChecks []ConditionTypeToHealthCheck) []string {
+	types := sets.NewString()
+	for _, healthCheck := range healthChecks {
+		types.Insert(healthCheck.ConditionType)
 	}
-	return types
+	return types.UnsortedList()
 }

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/field_constants.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/field_constants.go
@@ -17,11 +17,17 @@ package core
 // Field path constants that are specific to the internal API
 // representation.
 const (
-	// ShootSeedName is the field selector path for finding
-	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
-	ShootSeedName = "spec.seedName"
+	// BackupBucketSeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/v1beta1 BackupBucket.
+	BackupBucketSeedName = "spec.seedName"
+	// BackupEntrySeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/v1beta1 BackupEntry.
+	BackupEntrySeedName = "spec.seedName"
 
 	// ShootCloudProfileName is the field selector path for finding
 	// the CloudProfile name of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
 	ShootCloudProfileName = "spec.cloudProfileName"
+	// ShootSeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
+	ShootSeedName = "spec.seedName"
 )

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/types_shoot.go
@@ -218,12 +218,11 @@ type DNSProvider struct {
 	Primary *bool `json:"primary,omitempty"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
-	// by the Shoot and try to find respective credentials there. Specifying this field may override
+	// by the Shoot and try to find respective credentials there (primary provider only). Specifying this field may override
 	// this behavior, i.e. forcing the Gardener to only look into the given secret.
 	// +optional
 	SecretName *string `json:"secretName,omitempty"`
-	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
-	// this shoot.
+	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty"`
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/conversions.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/conversions.go
@@ -24,7 +24,36 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
-	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("BackupBucket"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", core.BackupBucketSeedName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("BackupEntry"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", core.BackupEntrySeedName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName:

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
@@ -153,13 +153,21 @@ func IsResourceSupported(resources []gardencorev1beta1.ControllerResource, resou
 // IsControllerInstallationSuccessful returns true if a ControllerInstallation has been marked as "successfully"
 // installed.
 func IsControllerInstallationSuccessful(controllerInstallation gardencorev1beta1.ControllerInstallation) bool {
+	var (
+		installed bool
+		healthy   bool
+	)
+
 	for _, condition := range controllerInstallation.Status.Conditions {
 		if condition.Type == gardencorev1beta1.ControllerInstallationInstalled && condition.Status == gardencorev1beta1.ConditionTrue {
-			return true
+			installed = true
+		}
+		if condition.Type == gardencorev1beta1.ControllerInstallationHealthy && condition.Status == gardencorev1beta1.ConditionTrue {
+			healthy = true
 		}
 	}
 
-	return false
+	return installed && healthy
 }
 
 // ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/types_shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/types_shoot.go
@@ -215,12 +215,11 @@ type DNSProvider struct {
 	Primary *bool `json:"primary,omitempty"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
-	// by the Shoot and try to find respective credentials there. Specifying this field may override
+	// by the Shoot and try to find respective credentials there (primary provider only). Specifying this field may override
 	// this behavior, i.e. forcing the Gardener to only look into the given secret.
 	// +optional
 	SecretName *string `json:"secretName,omitempty"`
-	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
-	// this shoot.
+	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty"`
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.

--- a/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -69,7 +69,7 @@ type OperatingSystemConfigList struct {
 type OperatingSystemConfigSpec struct {
 	// CRI config is a structure contains configurations of the CRI library
 	// +optional
-	CRIConfig *CRIConfig  `json:"criConfig,omitempty"`
+	CRIConfig *CRIConfig `json:"criConfig,omitempty"`
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
 	// Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/chartapplier.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/chartapplier.go
@@ -62,7 +62,9 @@ func (c *chartApplier) Apply(ctx context.Context, chartPath, namespace, name str
 	applyOpts := &ApplyOptions{}
 
 	for _, o := range opts {
-		o.MutateApplyOptions(applyOpts)
+		if o != nil {
+			o.MutateApplyOptions(applyOpts)
+		}
 	}
 
 	if len(applyOpts.MergeFuncs) == 0 {
@@ -92,7 +94,9 @@ func (c *chartApplier) Delete(ctx context.Context, chartPath, namespace, name st
 	deleteOpts := &DeleteOptions{}
 
 	for _, o := range opts {
-		o.MutateDeleteOptions(deleteOpts)
+		if o != nil {
+			o.MutateDeleteOptions(deleteOpts)
+		}
 	}
 
 	manifestReader, err := c.manifestReader(chartPath, namespace, name, deleteOpts.Values)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
@@ -136,10 +136,6 @@ func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 
 	var workerPools []map[string]interface{}
 	for _, worker := range b.Shoot.MachineDeployments {
-		// Skip worker pools for which min=0. Auto scaler cannot handle worker pools having a min count of 0.
-		if worker.Minimum == 0 {
-			continue
-		}
 
 		workerPools = append(workerPools, map[string]interface{}{
 			"name": worker.Name,
@@ -556,40 +552,56 @@ func init() {
 }
 
 // getResourcesForAPIServer returns the cpu and memory requirements for API server based on nodeCount
-func getResourcesForAPIServer(nodeCount int32) (string, string, string, string) {
+func getResourcesForAPIServer(nodeCount int32, scalingClass string) (string, string, string, string) {
 	var (
-		cpuRequest    string
-		memoryRequest string
-		cpuLimit      string
-		memoryLimit   string
+		validScalingClasses = sets.NewString("small", "medium", "large", "xlarge", "2xlarge")
+		cpuRequest          string
+		memoryRequest       string
+		cpuLimit            string
+		memoryLimit         string
 	)
 
+	if !validScalingClasses.Has(scalingClass) {
+		switch {
+		case nodeCount <= 2:
+			scalingClass = "small"
+		case nodeCount <= 10:
+			scalingClass = "medium"
+		case nodeCount <= 50:
+			scalingClass = "large"
+		case nodeCount <= 100:
+			scalingClass = "xlarge"
+		default:
+			scalingClass = "2xlarge"
+		}
+	}
+
 	switch {
-	case nodeCount <= 2:
+	case scalingClass == "small":
 		cpuRequest = "800m"
 		memoryRequest = "800Mi"
 
 		cpuLimit = "1000m"
 		memoryLimit = "1200Mi"
-	case nodeCount <= 10:
+	case scalingClass == "medium":
 		cpuRequest = "1000m"
 		memoryRequest = "1100Mi"
 
 		cpuLimit = "1200m"
 		memoryLimit = "1900Mi"
-	case nodeCount <= 50:
+	case scalingClass == "large":
 		cpuRequest = "1200m"
 		memoryRequest = "1600Mi"
 
 		cpuLimit = "1500m"
 		memoryLimit = "3900Mi"
-	case nodeCount <= 100:
+	case scalingClass == "xlarge":
 		cpuRequest = "2500m"
 		memoryRequest = "5200Mi"
 
 		cpuLimit = "3000m"
 		memoryLimit = "5900Mi"
-	default:
+	case scalingClass == "2xlarge":
 		cpuRequest = "3000m"
 		memoryRequest = "5200Mi"
 
@@ -768,9 +780,9 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 		var cpuRequest, memoryRequest, cpuLimit, memoryLimit string
 		if hvpaEnabled {
-			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMinNodeCount())
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMinNodeCount(), b.Shoot.Info.Annotations[common.ShootAlphaScalingAPIServerClass])
 		} else {
-			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMaxNodeCount())
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMaxNodeCount(), b.Shoot.Info.Annotations[common.ShootAlphaScalingAPIServerClass])
 		}
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{

--- a/vendor/github.com/gardener/gardener/pkg/operation/common/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/common/types.go
@@ -290,6 +290,13 @@ const (
 	// SecretRefChecksumAnnotation is the annotation key for checksum of referred secret in resource spec.
 	SecretRefChecksumAnnotation = "checksum/secret.data"
 
+	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
+	// It influences the size of the initial resource requests/limits.
+	// Possible values are [small, medium, large, xlarge, 2xlarge].
+	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+	// what you do.
+	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
+
 	// ShootExperimentalAddonKyma is a constant for an annotation on the shoot stating that Kyma shall be installed.
 	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
 	ShootExperimentalAddonKyma = "experimental.addons.shoot.gardener.cloud/kyma"

--- a/vendor/github.com/gardener/gardener/pkg/operation/garden/garden.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/garden/garden.go
@@ -110,7 +110,7 @@ func constructDomainFromSecret(secret *corev1.Secret) (*Domain, error) {
 // DomainIsDefaultDomain identifies whether the given domain is a default domain.
 func DomainIsDefaultDomain(domain string, defaultDomains []*Domain) *Domain {
 	for _, defaultDomain := range defaultDomains {
-		if strings.HasSuffix(domain, defaultDomain.Domain) {
+		if strings.HasSuffix(domain, "."+defaultDomain.Domain) {
 			return defaultDomain
 		}
 	}

--- a/vendor/github.com/gardener/gardener/pkg/utils/imagevector/imagevector_components.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/imagevector/imagevector_components.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagevector
+
+import (
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// ComponentOverrideEnv is the name of the environment variable for image vector overrides of components deployed
+	// by Gardener.
+	ComponentOverrideEnv = "IMAGEVECTOR_OVERWRITE_COMPONENTS"
+)
+
+// ReadComponentOverwrite reads an ComponentImageVector from the given io.Reader.
+func ReadComponentOverwrite(r io.Reader) (ComponentImageVectors, error) {
+	data := struct {
+		Components []ComponentImageVector `json:"components" yaml:"components"`
+	}{}
+
+	if err := yaml.NewDecoder(r).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	out := make(ComponentImageVectors, len(data.Components))
+	for _, component := range data.Components {
+		out[component.Name] = component.ImageVectorOverwrite
+	}
+
+	return out, nil
+}
+
+// ReadComponentOverwriteFile reads an ComponentImageVector from the file with the given name.
+func ReadComponentOverwriteFile(name string) (ComponentImageVectors, error) {
+	file, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return ReadComponentOverwrite(file)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/imagevector/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/imagevector/types.go
@@ -40,6 +40,15 @@ type Image struct {
 // ImageVector is a list of image sources.
 type ImageVector []*ImageSource
 
+// ComponentImageVector contains an image vector overwrite for a component deployed by Gardener.
+type ComponentImageVector struct {
+	Name                 string `json:"name" yaml:"name"`
+	ImageVectorOverwrite string `json:"imageVectorOverwrite" yaml:"imageVectorOverwrite"`
+}
+
+// ComponentImageVectors maps a component with a given name (key) to the image vector overwrite content (value).
+type ComponentImageVectors map[string]string
+
 // FindOptions are options that can be supplied during either `FindImage` or `FindImages`.
 type FindOptions struct {
 	RuntimeVersion *string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -83,7 +83,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v1.1.1-0.20200311075931-7f7e52b986e7
+# github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a
 github.com/gardener/gardener/pkg/api/extensions
 github.com/gardener/gardener/pkg/apis/core
 github.com/gardener/gardener/pkg/apis/core/helper
@@ -158,7 +158,7 @@ github.com/gardener/gardener-extension-networking-calico/pkg/calico
 github.com/gardener/gardener-extension-networking-calico/pkg/charts
 github.com/gardener/gardener-extension-networking-calico/pkg/controller
 github.com/gardener/gardener-extension-networking-calico/pkg/imagevector
-# github.com/gardener/gardener-extensions v1.4.1-0.20200322183545-5329339c95e9
+# github.com/gardener/gardener-extensions v1.5.0
 github.com/gardener/gardener-extensions/hack
 github.com/gardener/gardener-extensions/hack/.ci
 github.com/gardener/gardener-extensions/hack/api-reference/template


### PR DESCRIPTION
**What this PR does / why we need it**:
Vendor gardener/gardener@58593d8, [gardener/gardener-extensions@v1.5.0](https://github.com/gardener/gardener-extensions/releases/tag/v1.5.0) to get the latest fixes and features.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user github.com/gardener/gardener-extensions #626 @rfranzke
An issue in the machine reconciliation has been fixed that caused the reconciliation being stuck in some cases where a previously broken worker configuration (e.g., due to the specification of machine types that are not available in certain availability zones) has been corrected.
```
```improvement user github.com/gardener/gardener-extensions #609 @prashanth26 
Allow force deletion of machines incase of cluster hibernation
```
```improvement operator github.com/gardener/gardener-extensions #605 @ialidzhikov 
An issue causing running terraformer container to leak on the Node without associated Pod resource is now fixed. This will prevent multiple containers to execute `apply/destroy` commands simultaneously in some cases (especially for long running terraformer Pods).
```
```improvement operator github.com/gardener/gardener-extensions #606 @EmoinLanyu 
Credentials used by machine-controller-manager are now updated during worker deletion.
```