### PR TITLE
Support for Kubernetes 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.18 | 1.18.0+     | N/A |
 | Kubernetes 1.17 | 1.17.0+     | [![Gardener v1.17 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.17%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.17%20Azure) |
 | Kubernetes 1.16 | 1.16.0+, except 1.16.2 | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20Azure) |
 | Kubernetes 1.15 | 1.15.0+, except 1.15.5 | [![Gardener v1.15 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.15%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.15%20Azure) |

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -8,10 +8,15 @@ images:
   repository: k8s.gcr.io/hyperkube
   targetVersion: "< 1.17"
 - name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v0.4.1
-  targetVersion: ">= 1.17"
+  sourceRepository: github.com/gardener/cloud-provider-aws
+  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
+  tag: "v1.17.4"
+  targetVersion: "1.17.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/gardener/cloud-provider-aws
+  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
+  tag: "v1.18.0"
+  targetVersion: ">= 1.18"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -42,8 +42,10 @@ spec:
         command:
         {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
-        {{- end }}
         - cloud-controller-manager
+        {{- else }}
+        - /azure-cloud-controller-manager
+        {{- end }}
         - --allocate-node-cidrs=true
         - --cloud-provider=azure
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -25,7 +25,7 @@ cloudProviderRateLimitQPS: {{ ( max .Values.maxNodes 10 ) }}
 cloudProviderRateLimitBucket: 100
 cloudProviderRateLimitQPSWrite: {{ ( max .Values.maxNodes 10 ) }}
 cloudProviderRateLimitBucketWrite: 100
-{{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
+{{- if and (semverCompare ">= 1.14" .Values.kubernetesVersion) (semverCompare "< 1.18" .Values.kubernetesVersion) }}
 cloudProviderBackoffMode: v2
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for 1.18 to the extension.

**Which issue(s) this PR fixes**:
* Part of gardener/gardener#2095

**Special notes for your reviewer**:
I have successfully validated the functionality as follows:
* :white_check_mark: Create new clusters with versions < 1.18
* :white_check_mark: Create new clusters with version  = 1.18
* :white_check_mark: Upgrade old clusters from version 1.17 to version 1.18
* :white_check_mark: Delete clusters with versions < 1.18
* :white_check_mark: Delete clusters with version  = 1.18

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The Azure extension does now support shoot clusters with Kubernetes version 1.18. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.18.md) before upgrading to 1.18.
```
```noteworthy operator
The cloud-controller-manager is no longer used from the out-of-tree repository. Instead, the in-tree Azure cloud-controller-manager is used for 1.17+ clusters.
```