### PR TITLE
Use Terraform resource timeouts and workqueue backoff

### DIFF
--- a/charts/internal/azure-infra/templates/main.tf
+++ b/charts/internal/azure-infra/templates/main.tf
@@ -9,6 +9,12 @@ provider "azurerm" {
 resource "azurerm_resource_group" "rg" {
   name     = "{{ required "resourceGroup.name is required" .Values.resourceGroup.name }}"
   location = "{{ required "azure.region is required" .Values.azure.region }}"
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 {{- else -}}
 data "azurerm_resource_group" "rg" {
@@ -30,6 +36,12 @@ resource "azurerm_virtual_network" "vnet" {
   {{- end}}
   location            = "{{ required "azure.region is required" .Values.azure.region }}"
   address_space       = ["{{ required "resourceGroup.vnet.cidr is required" .Values.resourceGroup.vnet.cidr }}"]
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 {{- else -}}
 data "azurerm_virtual_network" "vnet" {
@@ -51,6 +63,12 @@ resource "azurerm_subnet" "workers" {
   service_endpoints         = [{{range $index, $serviceEndpoint := .Values.resourceGroup.subnet.serviceEndpoints}}{{if $index}},{{end}}"{{$serviceEndpoint}}"{{end}}]
   route_table_id            = "${azurerm_route_table.workers.id}"
   network_security_group_id = "${azurerm_network_security_group.workers.id}"
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "azurerm_route_table" "workers" {
@@ -60,7 +78,13 @@ resource "azurerm_route_table" "workers" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   {{- else -}}
   resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  {{- end}}
+  {{- end }}
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "azurerm_network_security_group" "workers" {
@@ -70,7 +94,13 @@ resource "azurerm_network_security_group" "workers" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   {{- else -}}
   resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  {{- end}}
+  {{- end }}
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 {{ if .Values.create.natGateway -}}
@@ -88,6 +118,12 @@ resource "azurerm_public_ip" "natip" {
   {{- end }}
   allocation_method   = "Static"
   sku                 = "Standard"
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "azurerm_nat_gateway" "nat" {
@@ -100,6 +136,12 @@ resource "azurerm_nat_gateway" "nat" {
   {{- end }}
   sku_name                = "Standard"
   public_ip_address_ids   = ["${azurerm_public_ip.natip.id}"]
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat-worker-subnet-association" {
@@ -135,6 +177,12 @@ resource "azurerm_availability_set" "workers" {
   platform_update_domain_count = "{{ required "azure.countUpdateDomains is required" .Values.azure.countUpdateDomains }}"
   platform_fault_domain_count  = "{{ required "azure.countFaultDomains is required" .Values.azure.countFaultDomains }}"
   managed                      = true
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 {{- end}}
 

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -16,13 +16,11 @@ package infrastructure
 
 import (
 	"context"
-	"time"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal/infrastructure"
 	"github.com/gardener/gardener/extensions/pkg/controller"
-	controllererrors "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -59,10 +57,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		Apply(); err != nil {
 
 		a.logger.Error(err, "failed to apply the terraform config", "infrastructure", infra.Name)
-		return &controllererrors.RequeueAfterError{
-			Cause:        err,
-			RequeueAfter: 30 * time.Second,
-		}
+		return err
 	}
 
 	return a.updateProviderStatus(ctx, tf, infra, config)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add some timeouts for those Terraform resources that are supporting it. Also, we will no longer requeue with the constant `30s` on errors but leverage the exponential backoff functionality of the underlying workqueue.

Part of gardener/gardener#2253

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
