### PR TITLE
Revert Terraform resource timeouts

### DIFF
--- a/charts/internal/azure-infra/templates/main.tf
+++ b/charts/internal/azure-infra/templates/main.tf
@@ -9,12 +9,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "rg" {
   name     = "{{ required "resourceGroup.name is required" .Values.resourceGroup.name }}"
   location = "{{ required "azure.region is required" .Values.azure.region }}"
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
 }
 {{- else -}}
 data "azurerm_resource_group" "rg" {
@@ -36,12 +30,6 @@ resource "azurerm_virtual_network" "vnet" {
   {{- end}}
   location            = "{{ required "azure.region is required" .Values.azure.region }}"
   address_space       = ["{{ required "resourceGroup.vnet.cidr is required" .Values.resourceGroup.vnet.cidr }}"]
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
 }
 {{- else -}}
 data "azurerm_virtual_network" "vnet" {
@@ -63,12 +51,6 @@ resource "azurerm_subnet" "workers" {
   service_endpoints         = [{{range $index, $serviceEndpoint := .Values.resourceGroup.subnet.serviceEndpoints}}{{if $index}},{{end}}"{{$serviceEndpoint}}"{{end}}]
   route_table_id            = "${azurerm_route_table.workers.id}"
   network_security_group_id = "${azurerm_network_security_group.workers.id}"
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
 }
 
 resource "azurerm_route_table" "workers" {
@@ -78,13 +60,7 @@ resource "azurerm_route_table" "workers" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   {{- else -}}
   resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  {{- end }}
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
+  {{- end}}
 }
 
 resource "azurerm_network_security_group" "workers" {
@@ -94,13 +70,7 @@ resource "azurerm_network_security_group" "workers" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   {{- else -}}
   resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  {{- end }}
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
+  {{- end}}
 }
 
 {{ if .Values.create.natGateway -}}
@@ -118,12 +88,6 @@ resource "azurerm_public_ip" "natip" {
   {{- end }}
   allocation_method   = "Static"
   sku                 = "Standard"
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
 }
 
 resource "azurerm_nat_gateway" "nat" {
@@ -136,12 +100,6 @@ resource "azurerm_nat_gateway" "nat" {
   {{- end }}
   sku_name                = "Standard"
   public_ip_address_ids   = ["${azurerm_public_ip.natip.id}"]
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat-worker-subnet-association" {
@@ -177,12 +135,6 @@ resource "azurerm_availability_set" "workers" {
   platform_update_domain_count = "{{ required "azure.countUpdateDomains is required" .Values.azure.countUpdateDomains }}"
   platform_fault_domain_count  = "{{ required "azure.countFaultDomains is required" .Values.azure.countFaultDomains }}"
   managed                      = true
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-    delete = "10m"
-  }
 }
 {{- end}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert the Terraform resource timeouts introduced with #85 as the custom timeouts are still behind a beta feature gate (disabled by default) for azurerm 1.44.0.
Ref https://registry.terraform.io/providers/hashicorp/azurerm/1.43.0/docs/guides/2.0-beta

**Which issue(s) this PR fixes**:
Fixes #88

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
