### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -15,7 +15,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.18.0"
+  tag: "v1.18.3"
   targetVersion: ">= 1.18"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
```improvement operator github.com/gardener/cloud-provider-azure #1 @ialidzhikov
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.3`.
```