### PR TITLE
Switch from cm to secret for cloud provider config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -1,4 +1,4 @@
-{{- define "cloud-provider-config" -}}
+{{- define "cloud-provider-config-base" -}}
 cloud: AZUREPUBLICCLOUD
 location: "{{ .Values.region }}"
 resourceGroup: "{{ .Values.resourceGroup }}"
@@ -27,5 +27,23 @@ cloudProviderRateLimitQPSWrite: {{ ( max .Values.maxNodes 10 ) }}
 cloudProviderRateLimitBucketWrite: 100
 {{- if and (semverCompare ">= 1.14" .Values.kubernetesVersion) (semverCompare "< 1.18" .Values.kubernetesVersion) }}
 cloudProviderBackoffMode: v2
+{{- end }}
+{{- end -}}
+
+{{- define "cloud-provider-config" -}}
+{{ include "azure-credentials" . }}
+{{ include "azure-subscription-info" . }}
+{{ include "cloud-provider-config-base" . }}
+{{- end -}}
+
+{{- define "cloud-provider-disk-config" -}}
+{{ include "cloud-provider-config-base" . }}
+{{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
+{{ include "azure-credentials" . }}
+{{- else }}
+{{- if semverCompare ">= 1.18" .Values.kubernetesVersion }}
+{{ include "azure-subscription-info" . }}
+{{- end }}
+useInstanceMetadata: true
 {{- end }}
 {{- end -}}

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -1,10 +1,8 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: cloud-provider-config
   namespace: {{ .Release.Namespace }}
+type: Opaque
 data:
-  cloudprovider.conf: |
-{{ include "azure-credentials" . | indent 4 }}
-{{ include "azure-subscription-info" . | indent 4 }}
-{{ include "cloud-provider-config" . | indent 4 }}
+  cloudprovider.conf: {{ include "cloud-provider-config" . | b64enc }}

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config.yaml
@@ -1,16 +1,8 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: cloud-provider-disk-config
   namespace: {{ .Release.Namespace }}
+type: Opaque
 data:
-  cloudprovider.conf: |
-{{ include "cloud-provider-config" . | indent 4 }}
-{{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
-{{ include "azure-credentials" . | indent 4 }}
-{{- else }}
-{{- if semverCompare ">= 1.18" .Values.kubernetesVersion }}
-{{ include "azure-subscription-info" . | indent 4 }}
-{{- end }}
-    useInstanceMetadata: true
-{{- end }}
+  cloudprovider.conf: {{ include "cloud-provider-disk-config" . | b64enc }}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -115,8 +115,8 @@ spec:
         secret:
           secretName: cloud-controller-manager-server
       - name: cloud-provider-config
-        configMap:
-          name: cloud-provider-config
+        secret:
+          secretName: cloud-provider-config
       - name: etc-ssl
         hostPath:
           path: /etc/ssl

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
@@ -186,8 +186,8 @@ spec:
       - name: socket-dir
         emptyDir: {}
       - name: cloud-provider-config
-        configMap:
-          name: cloud-provider-config
+        secret:
+          secretName: cloud-provider-config
       {{- if eq .role "file" }}
       - name: csi-driver-controller-file
         secret:

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -68,7 +68,7 @@ const (
 
 	// AllowUDPEgressName is the name of the service for allowing UDP egress traffic.
 	AllowUDPEgressName = "allow-udp-egress"
-	// CloudProviderConfigName is the name of the configmap containing the cloud provider config.
+	// CloudProviderConfigName is the name of the secret containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
 	// CloudProviderDiskConfigName is the name of the configmap containing the cloud provider config for disk/volume handling.
 	CloudProviderDiskConfigName = "cloud-provider-disk-config"

--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -48,7 +48,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
 		Actuator: genericactuator.NewActuator(azure.Name, controlPlaneSecrets, nil, configChart, controlPlaneChart, controlPlaneShootChart,
 			storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
-			imagevector.ImageVector(), azure.CloudProviderConfigName, nil, mgr.GetWebhookServer().Port, logger),
+			imagevector.ImageVector(), "", nil, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
 		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              azure.Type,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
This PR let's the extension create/use Secrets instead of ConfigMaps for `cloud-provider-config` and `cloud-provider-disk-config`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Kubernetes Kind for `cloud-provider-config` and `cloud-provider-disk-config` in a shoot's control plane has been changed from ConfigMap to Secret.
```
