### PR TITLE
Diable accelerated network for AvSet clusters

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -223,5 +223,6 @@ Shoot clusters with Kubernetes v1.18 or less will use the in-tree `kubernetes.io
 ### Azure Accelerated Networking
 
 All worker machines of the cluster will be automatically configured to use [Azure Accelerated Networking](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli) if the prerequisites are fulfilled.
-The prerequisites are that the used machine type and operating system image version are compatible for Accelerated Networking.
+The prerequisites are that the cluster must be zoned, and the used machine type and operating system image version are compatible for Accelerated Networking.
+`Availability Set` based shoot clusters will not be enabled for accelerated networking even if the machine type and operating system support it, this is necessary because all machines from the availability set must be scheduled on special hardware, more daitls can be found [here](https://github.com/MicrosoftDocs/azure-docs/issues/10536).
 Supported machine types are listed in the CloudProfile in `.spec.providerConfig.machineTypes[].acceleratedNetworking` and the supported operating system image versions are defined in `.spec.providerConfig.machineImages[].versions[].acceleratedNetworking`.

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -344,10 +344,9 @@ var _ = Describe("Machines", func() {
 						"region":        region,
 						"resourceGroup": resourceGroupName,
 						"network": map[string]interface{}{
-							"vnet":                  vnetName,
-							"subnet":                subnetName,
-							"vnetResourceGroup":     vnetResourceGroupName,
-							"acceleratedNetworking": true,
+							"vnet":              vnetName,
+							"subnet":            subnetName,
+							"vnetResourceGroup": vnetResourceGroupName,
 						},
 						"availabilitySetID": availabilitySetID,
 						"tags":              vmTags,
@@ -367,11 +366,6 @@ var _ = Describe("Machines", func() {
 						"urn": machineImageURN,
 					}
 
-					defaultMachineClass["network"] = map[string]interface{}{
-						"vnet":              vnetName,
-						"subnet":            subnetName,
-						"vnetResourceGroup": vnetResourceGroupName,
-					}
 					imageIdMachineClass = copyMachineClass(defaultMachineClass)
 					imageIdMachineClass["image"] = map[string]interface{}{
 						"id": machineImageID,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area networking
/kind bug
/priority critical
/platform azure

**What this PR does / why we need it**:
Disable accelerated networking for AvSet clusters. This is necessary because for legacy clusters it is not possible to create new VMs. The creation calls are failing with 
```text
ExistingAvailabilitySetWasNotDeployedOnAcceleratedNetworkingEnabledCluster" Message="Cannot add a virtual machine (/subscriptions/...) with accelerated-networking-enabled network interface(s) on an existing availability set (/subscriptions/...) with VM(s) without accelerated-networking-enabled network interfaces.
``` 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See https://github.com/MicrosoftDocs/azure-docs/issues/10536 for more details.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Accelerated Networking feature has been disabled for AvSet clusters. It is still available for zoned clusters. 
```
