### PR TITLE
Support multiple Azure disks when creating machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM golang:1.14.2 AS builder
+FROM golang:1.14.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-azure
 COPY . .
 RUN make install
 
 ############# base
-FROM alpine:3.11.6 AS base
+FROM alpine:3.12.0 AS base
 
 ############# gardener-extension-provider-azure
 FROM base AS gardener-extension-provider-azure

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -64,6 +64,10 @@ spec:
           storageAccountType: {{ $machineClass.osDisk.type }}
         {{- end }}
         createOption: FromImage
+{{- if $machineClass.dataDisks }}
+      dataDisks:
+{{ toYaml $machineClass.dataDisks | indent 6 }}
+{{- end }}
   resourceGroup: {{ $machineClass.resourceGroup }}
   secretRef:
     name: {{ $machineClass.name }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -53,4 +53,10 @@ machineClasses:
   osDisk:
     size: 50
     type: Standard_LRS
+# dataDisks:
+# - lun: 0
+#   caching: None
+#   diskSizeGB: 100
+#   storageAccountType: Standard_LRS
+#   name: sdb
   sshPublicKey: ssh-rsa AAAAB3...

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -100,6 +100,28 @@ The `cloudControllerManager.featureGates` contains a map of explicitly enabled o
 For production usage it's not recommend to use this field at all as you can enable alpha features or disable beta/stable features, potentially impacting the cluster stability.
 If you don't want to configure anything for the `cloudControllerManager` simply omit the key in the YAML specification.
 
+## `WorkerConfig`
+
+The Azure extension does not support a specific `WorkerConfig` yet, however, it supports encryption for volumes plus support for additional data volumes per machine.
+Please note that you cannot specify the `encrypted` flag for Azure disks as they are encrypted by default/out-of-the-box.
+For each data volume, you have to specify a name.
+The following YAML is a snippet of a `Shoot` resource:
+
+```yaml
+spec:
+  provider:
+    workers:
+    - name: cpu-worker
+      ...
+      volume:
+        type: Standard_LRS
+        size: 20Gi
+      dataVolumes:
+      - name: kubelet-dir
+        type: Standard_LRS
+        size: 25Gi
+```
+
 ## Example `Shoot` manifest (non-zoned)
 
 Please find below an example `Shoot` manifest for a non-zoned cluster:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -109,3 +109,7 @@ spec:
     volume:
       type: standard
       size: 35Gi
+  # dataVolumes:
+  # - name: kubelet-dir
+  #   type: standard
+  #   size: 36Gi

--- a/pkg/apis/azure/validation/shoot_test.go
+++ b/pkg/apis/azure/validation/shoot_test.go
@@ -129,6 +129,8 @@ var _ = Describe("Shoot validation", func() {
 				It("should forbid because volume type and size are not configured", func() {
 					workers[0].Volume.Type = nil
 					workers[0].Volume.VolumeSize = ""
+					workers[0].Volume.Encrypted = pointer.BoolPtr(false)
+					workers[0].DataVolumes = []core.Volume{{Encrypted: pointer.BoolPtr(true)}}
 
 					errorList := ValidateWorkers(workers, zoned, field.NewPath("workers"))
 
@@ -140,6 +142,41 @@ var _ = Describe("Shoot validation", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeRequired),
 							"Field": Equal("workers[0].volume.size"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeNotSupported),
+							"Field": Equal("workers[0].volume.encrypted"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeRequired),
+							"Field": Equal("workers[0].dataVolumes[0].type"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeRequired),
+							"Field": Equal("workers[0].dataVolumes[0].size"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeNotSupported),
+							"Field": Equal("workers[0].dataVolumes[0].encrypted"),
+						})),
+					))
+				})
+
+				It("should forbid because of too many data volumes", func() {
+					for i := 0; i <= 64; i++ {
+						workers[0].DataVolumes = append(workers[0].DataVolumes, core.Volume{
+							Name:       pointer.StringPtr("foo"),
+							VolumeSize: "20Gi",
+							Type:       pointer.StringPtr("foo"),
+						})
+					}
+
+					errorList := ValidateWorkers(workers, zoned, field.NewPath("workers"))
+
+					Expect(errorList).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeTooMany),
+							"Field": Equal("workers[0].dataVolumes"),
 						})),
 					))
 				})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area storage
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/1893 was merged quite some time ago, this PR now adds support for the Azure extension to handle multiple Azure disks for the worker machines.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/machine-controller-manager/issues/462

**Special notes for your reviewer**:
* Thanks @guydaichs for your work and contributions!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to configure additional data volumes for the worker machines. Please consult [this documentation](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage-as-end-user.md#workerconfig) for more information.
```
