### PR TITLE
Explicitly set EnableHTTPSTrafficOnly to true for storage accounts

### DIFF
--- a/example/30-backupbucket.yaml
+++ b/example/30-backupbucket.yaml
@@ -17,7 +17,7 @@ metadata:
   name: cloud--azure--fg2d6
 spec:
   type: azure
-  region: eu-west-1
+  region: northeurope
   secretRef:
     name: backupprovider
     namespace: garden

--- a/pkg/azure/client/storage.go
+++ b/pkg/azure/client/storage.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -61,7 +62,8 @@ func NewStorageClientAuthFromSubscriptionSecretRef(ctx context.Context, c client
 		Kind:     storage.BlobStorage,
 		Location: &region,
 		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
-			AccessTier: storage.Cool,
+			AccessTier:             storage.Cool,
+			EnableHTTPSTrafficOnly: pointer.BoolPtr(true),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area security
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
This PR sets the `EnableHTTPSTrafficOnly` flag to `true` when created storage accounts. The field is defaulted to `true` since `2019-04-01`, though, to be sure we make it explicit.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
