### PR TITLE
Adapt to terraform v0.12 language changes

### DIFF
--- a/charts/internal/azure-infra/templates/variables.tf
+++ b/charts/internal/azure-infra/templates/variables.tf
@@ -1,9 +1,9 @@
 variable "CLIENT_ID" {
   description = "Azure client id of technical user"
-  type        = "string"
+  type        = string
 }
 
 variable "CLIENT_SECRET" {
   description = "Azure client secret of technical user"
-  type        = "string"
+  type        = string
 }

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -37,7 +37,7 @@ kind: InfrastructureConfig
 networks:
   vnet: # specify either 'name' and 'resourceGroup' or 'cidr'
     # name: my-vnet
-    # resouceGroup: my-vnet-resource-group
+    # resourceGroup: my-vnet-resource-group
     cidr: 10.250.0.0/16
   workers: 10.250.0.0/19
   # natGateway:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/kind cleanup
/priority normal
/platform azure

**What this PR does / why we need it**:
Adapt to terraform v0.12 language changes

**Which issue(s) this PR fixes**:
Fixes #110

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Until now `provider-azure` was maintaining a Terraform configuration which is both `v0.12` and `v0.11` compatible. The Terraform configuration is now adapted to the new Terraform language which makes it Terraform `v0.11` incompatible.
```
