### PR TITLE
Fix shoot deletion issue by adding the ignore annotation to allow-udp-egress

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -63,4 +63,4 @@ images:
 - name: remedy-controller-azure
   sourceRepository: github.com/gardener/remedy-controller
   repository: eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure
-  tag: "v0.3.0"
+  tag: "v0.6.0"

--- a/charts/internal/shoot-system-components/charts/allow-udp-egress/templates/allow-udp-egress.yaml
+++ b/charts/internal/shoot-system-components/charts/allow-udp-egress/templates/allow-udp-egress.yaml
@@ -6,6 +6,7 @@ metadata:
   name: allow-udp-egress
   namespace: kube-system
   annotations:
+    azure.remedy.gardener.cloud/ignore: "true"
     gardener.cloud/description: |
       This is a technical Service created to mitigate an issue with the UDP egress traffic for Shoots using
       Azure Standard LoadBalancers (see https://github.com/gardener/gardener-extension-provider-azure/issues/1).


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug
/priority normal
/platform azure

**What this PR does / why we need it**:
Fixes the shoot deletion issue described in https://github.com/gardener/remedy-controller/issues/12 by adding the ignore annotation to the `allow-udp-egress` service.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/remedy-controller/issues/12

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
