### PR TITLE
Be pessimistic about legacy cm deletion

### DIFF
--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"encoding/json"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	appsv1 "k8s.io/api/apps/v1"
+
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 
@@ -395,6 +398,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		BeforeEach(func() {
 			c.EXPECT().Get(ctx, cpConfigSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpConfigSecret))
+			c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeAPIServer), &appsv1.Deployment{}).Return(nil)
 			c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: azure.CloudProviderConfigName, Namespace: namespace}}).Return(nil)
 			c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: azure.CloudProviderDiskConfigName, Namespace: namespace}}).Return(nil)
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane
/kind bug
/priority normal
/platform azure

**What this PR does / why we need it**:
With the introduction of #99 we observed errors during the shoot deletion because the KAS deployment still referred to the legacy cloud-provider config map. This PR adds a check if the said config map is still referenced and skips the deletion. Please note that the deletion error only happens under special circumstances, e.g. if the shoot reconciliation is aborted after the control plane deployment and immediately deleted.

**Special notes for your reviewer**:
/cc @danielfoehrKn

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issues has been fixed which caused unsuccessful shoot deletions due to the migration of the `cloud-provider-config` from a config map to a secret.
```
