### PR TITLE
StorageClasses now allow volume expansion

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -11,7 +11,7 @@ parameters:
   skuName: Standard_LRS
   kind: managed
 volumeBindingMode: WaitForFirstConsumer
-
+allowVolumeExpansion: true
 ---
 apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass

--- a/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
@@ -6,6 +6,7 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+allowVolumeExpansion: true
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: Standard_LRS
@@ -16,6 +17,7 @@ apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
 metadata:
   name: managed-standard-hdd
+allowVolumeExpansion: true
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: Standard_LRS
@@ -27,6 +29,7 @@ apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
 metadata:
   name: managed-standard-ssd
+allowVolumeExpansion: true
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: StandardSSD_LRS
@@ -38,6 +41,7 @@ apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
 metadata:
   name: managed-premium-ssd
+allowVolumeExpansion: true
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: Premium_LRS
@@ -48,6 +52,7 @@ apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
 metadata:
   name: files
+allowVolumeExpansion: true
 provisioner: kubernetes.io/azure-file
 parameters:
   skuName: Standard_LRS


### PR DESCRIPTION
**How to categorize this PR?**

/area storage
/kind enhancement
/priority normal
/platform azure
**What this PR does / why we need it**:

Allows claims for Azure Disk and Azure File to be resized.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

`AllowVolumeExpansion` is [not immutable](https://github.com/kubernetes/kubernetes/blob/6c6fd9c575457885dfbd07fe5df43df9a4e08a22/pkg/apis/storage/validation/validation.go#L59-L76).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`StorageClasses` now allow for expansion of PVCs.
```
