### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,12 +11,12 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.17.4"
+  tag: "v1.17.9"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.18.3"
+  tag: "v1.18.6"
   targetVersion: ">= 1.18"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:

```improvement operator github.com/gardener/cloud-provider-azure #2 @ialidzhikov
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.9`.
```

```improvement operator github.com/gardener/cloud-provider-azure #3 @ialidzhikov
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.6`.
```