### PR TITLE
Postpone switch to CSI drivers to 1.20

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -235,10 +235,10 @@ spec:
 
 ## CSI volume provisioners
 
-Every Azure shoot cluster that has at least Kubernetes v1.19 will be deployed with the Azure Disk CSI driver and the Azure File CSI driver.
+Every Azure shoot cluster that has at least Kubernetes v1.20 will be deployed with the Azure Disk CSI driver and the Azure File CSI driver.
 Both are compatible with the legacy in-tree volume provisioners that were deprecated by the Kubernetes community and will be removed in future versions of Kubernetes.
 End-users might want to update their custom `StorageClass`es to the new `disk.csi.azure.com` or `file.csi.azure.com` provisioner, respectively.
-Shoot clusters with Kubernetes v1.18 or less will use the in-tree `kubernetes.io/azure-disk` and `kubernetes.io/azure-file` volume provisioners in the kube-controller-manager and the kubelet.
+Shoot clusters with Kubernetes v1.19 or less will use the in-tree `kubernetes.io/azure-disk` and `kubernetes.io/azure-file` volume provisioners in the kube-controller-manager and the kubelet.
 
 ## Miscellaneous
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -464,7 +464,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		return nil, errors.Wrapf(err, "could not decode infrastructureProviderStatus of controlplane '%s'", util.ObjectName(cp))
 	}
 
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan120, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +474,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		cloudProviderDiskConfigChecksum string
 	)
 
-	if !k8sVersionLessThan119 {
+	if !k8sVersionLessThan120 {
 		secret := &corev1.Secret{}
 		if err := vp.Client().Get(ctx, kutil.Key(cp.Namespace, azure.CloudProviderDiskConfigName), secret); err != nil {
 			return nil, err
@@ -486,7 +486,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 
 	enableRemedyController := cluster.Shoot.Annotations[enableRemedyControllerAnnotation] == "true"
 
-	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan119, enableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
+	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan120, enableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
 }
 
 // GetStorageClassesChartValues returns the values for the storage classes chart applied by the generic actuator.
@@ -495,13 +495,13 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan120, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
 	if err != nil {
 		return nil, err
 	}
 
 	return map[string]interface{}{
-		"useLegacyProvisioner": k8sVersionLessThan119,
+		"useLegacyProvisioner": k8sVersionLessThan120,
 	}, nil
 }
 
@@ -651,12 +651,12 @@ func getCSIControllerChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan120, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
 	if err != nil {
 		return nil, err
 	}
 
-	if k8sVersionLessThan119 {
+	if k8sVersionLessThan120 {
 		return map[string]interface{}{"enabled": false}, nil
 	}
 
@@ -705,7 +705,7 @@ func getRemedyControllerChartValues(
 func getControlPlaneShootChartValues(
 	cluster *extensionscontroller.Cluster,
 	infraStatus *apisazure.InfrastructureStatus,
-	k8sVersionLessThan119 bool,
+	k8sVersionLessThan120 bool,
 	enableRemedyController bool,
 	cloudProviderDiskConfig string,
 	cloudProviderDiskConfigChecksum string,
@@ -714,7 +714,7 @@ func getControlPlaneShootChartValues(
 		azure.AllowUDPEgressName:         map[string]interface{}{"enabled": infraStatus.Zoned},
 		azure.CloudControllerManagerName: map[string]interface{}{"enabled": true},
 		azure.CSINodeName: map[string]interface{}{
-			"enabled":    !k8sVersionLessThan119,
+			"enabled":    !k8sVersionLessThan120,
 			"vpaEnabled": gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 			"podAnnotations": map[string]interface{}{
 				"checksum/configmap-" + azure.CloudProviderDiskConfigName: cloudProviderDiskConfigChecksum,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -127,7 +127,7 @@ var _ = Describe("ValuesProvider", func() {
 		}
 
 		cidr                  = "10.250.0.0/19"
-		clusterK8sLessThan119 = &extensionscontroller.Cluster{
+		clusterK8sLessThan120 = &extensionscontroller.Cluster{
 			Shoot: &gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Networking: gardencorev1beta1.Networking{
@@ -139,14 +139,14 @@ var _ = Describe("ValuesProvider", func() {
 				},
 			},
 		}
-		clusterK8sAtLeast119 = &extensionscontroller.Cluster{
+		clusterK8sAtLeast120 = &extensionscontroller.Cluster{
 			Shoot: &gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Networking: gardencorev1beta1.Networking{
 						Pods: &cidr,
 					},
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.19.4",
+						Version: "1.20.4",
 						VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
 							Enabled: true,
 						},
@@ -278,7 +278,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			c.EXPECT().Delete(ctx, acrConfigMap).Return(errorAcrConfigMapNotFound)
 
-			_, err := vp.GetConfigChartValues(ctx, cpNoSubnet, clusterK8sLessThan119)
+			_, err := vp.GetConfigChartValues(ctx, cpNoSubnet, clusterK8sLessThan120)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("could not determine subnet for purpose 'nodes'"))
 		})
@@ -287,7 +287,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			c.EXPECT().Delete(ctx, acrConfigMap).Return(errorAcrConfigMapNotFound)
 
-			_, err := vp.GetConfigChartValues(ctx, cpNoAvailabilitySet, clusterK8sLessThan119)
+			_, err := vp.GetConfigChartValues(ctx, cpNoAvailabilitySet, clusterK8sLessThan120)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("could not determine availability set for purpose 'nodes'"))
 		})
@@ -296,7 +296,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			c.EXPECT().Delete(ctx, acrConfigMap).Return(errorAcrConfigMapNotFound)
 
-			_, err := vp.GetConfigChartValues(ctx, cpNoRouteTables, clusterK8sLessThan119)
+			_, err := vp.GetConfigChartValues(ctx, cpNoRouteTables, clusterK8sLessThan120)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("could not determine route table for purpose 'nodes'"))
 		})
@@ -305,7 +305,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			c.EXPECT().Delete(ctx, acrConfigMap).Return(errorAcrConfigMapNotFound)
 
-			_, err := vp.GetConfigChartValues(ctx, cpNoSecurityGroups, clusterK8sLessThan119)
+			_, err := vp.GetConfigChartValues(ctx, cpNoSecurityGroups, clusterK8sLessThan120)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("could not determine security group for purpose 'nodes'"))
 		})
@@ -314,7 +314,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			c.EXPECT().Delete(ctx, acrConfigMap).Return(errorAcrConfigMapNotFound)
 
-			values, err := vp.GetConfigChartValues(ctx, cp, clusterK8sLessThan119)
+			values, err := vp.GetConfigChartValues(ctx, cp, clusterK8sLessThan120)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
 				"tenantId":            "TenantID",
@@ -337,7 +337,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			c.EXPECT().Delete(ctx, acrConfigMap).Return(errorAcrConfigMapNotFound)
 
-			values, err := vp.GetConfigChartValues(ctx, cpZoned, clusterK8sLessThan119)
+			values, err := vp.GetConfigChartValues(ctx, cpZoned, clusterK8sLessThan120)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
@@ -359,7 +359,7 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return correct control plane chart values with identity", func() {
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 
-			values, err := vp.GetConfigChartValues(ctx, cpIdentity, clusterK8sLessThan119)
+			values, err := vp.GetConfigChartValues(ctx, cpIdentity, clusterK8sLessThan120)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
 				"tenantId":            "TenantID",
@@ -406,25 +406,25 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: azure.CloudProviderDiskConfigName, Namespace: namespace}}).Return(nil)
 		})
 
-		It("should return correct control plane chart values (k8s < 1.19)", func() {
-			values, err := vp.GetControlPlaneChartValues(ctx, cp, clusterK8sLessThan119, checksums, false)
+		It("should return correct control plane chart values (k8s < 1.20)", func() {
+			values, err := vp.GetControlPlaneChartValues(ctx, cp, clusterK8sLessThan120, checksums, false)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
 				azure.CloudControllerManagerName: utils.MergeMaps(ccmChartValues, map[string]interface{}{
-					"kubernetesVersion": clusterK8sLessThan119.Shoot.Spec.Kubernetes.Version,
+					"kubernetesVersion": clusterK8sLessThan120.Shoot.Spec.Kubernetes.Version,
 				}),
 				azure.CSIControllerName:    enabledFalse,
 				azure.RemedyControllerName: enabledFalse,
 			}))
 		})
 
-		It("should return correct control plane chart values (k8s >= 1.19)", func() {
-			values, err := vp.GetControlPlaneChartValues(ctx, cp, clusterK8sAtLeast119, checksums, false)
+		It("should return correct control plane chart values (k8s >= 1.20)", func() {
+			values, err := vp.GetControlPlaneChartValues(ctx, cp, clusterK8sAtLeast120, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
 				azure.CloudControllerManagerName: utils.MergeMaps(ccmChartValues, map[string]interface{}{
-					"kubernetesVersion": clusterK8sAtLeast119.Shoot.Spec.Kubernetes.Version,
+					"kubernetesVersion": clusterK8sAtLeast120.Shoot.Spec.Kubernetes.Version,
 				}),
 				azure.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
 					"replicas": 1,
@@ -453,7 +453,7 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
 				azure.CloudControllerManagerName: utils.MergeMaps(ccmChartValues, map[string]interface{}{
-					"kubernetesVersion": clusterK8sLessThan119.Shoot.Spec.Kubernetes.Version,
+					"kubernetesVersion": clusterK8sLessThan120.Shoot.Spec.Kubernetes.Version,
 				}),
 				azure.CSIControllerName: enabledFalse,
 				azure.RemedyControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
@@ -485,9 +485,9 @@ var _ = Describe("ValuesProvider", func() {
 			})
 		)
 
-		Context("k8s < 1.19", func() {
+		Context("k8s < 1.20", func() {
 			It("should return correct control plane shoot chart values for non zoned cluster", func() {
-				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sLessThan119, checksums)
+				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sLessThan120, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
 					azure.AllowUDPEgressName:         enabledFalse,
@@ -498,7 +498,7 @@ var _ = Describe("ValuesProvider", func() {
 			})
 
 			It("should return correct control plane shoot chart values for zoned cluster", func() {
-				values, err := vp.GetControlPlaneShootChartValues(ctx, cpZoned, clusterK8sLessThan119, checksums)
+				values, err := vp.GetControlPlaneShootChartValues(ctx, cpZoned, clusterK8sLessThan120, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
 					azure.AllowUDPEgressName:         enabledTrue,
@@ -509,13 +509,13 @@ var _ = Describe("ValuesProvider", func() {
 			})
 		})
 
-		Context("k8s >= 1.19", func() {
+		Context("k8s >= 1.20", func() {
 			BeforeEach(func() {
 				c.EXPECT().Get(ctx, cpDiskConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpDiskConfig))
 			})
 
 			It("should return correct control plane shoot chart values for non zoned cluster", func() {
-				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sAtLeast119, checksums)
+				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sAtLeast120, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
 					azure.AllowUDPEgressName:         enabledFalse,
@@ -526,7 +526,7 @@ var _ = Describe("ValuesProvider", func() {
 			})
 
 			It("should return correct control plane shoot chart values for zoned cluster", func() {
-				values, err := vp.GetControlPlaneShootChartValues(ctx, cpZoned, clusterK8sAtLeast119, checksums)
+				values, err := vp.GetControlPlaneShootChartValues(ctx, cpZoned, clusterK8sAtLeast120, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
 					azure.AllowUDPEgressName:         enabledTrue,
@@ -563,14 +563,14 @@ var _ = Describe("ValuesProvider", func() {
 	})
 
 	Describe("#GetStorageClassesChartValues()", func() {
-		It("should return correct storage class chart values (k8s < 1.19)", func() {
-			values, err := vp.GetStorageClassesChartValues(ctx, cp, clusterK8sLessThan119)
+		It("should return correct storage class chart values (k8s < 1.20)", func() {
+			values, err := vp.GetStorageClassesChartValues(ctx, cp, clusterK8sLessThan120)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{"useLegacyProvisioner": true}))
 		})
 
-		It("should return correct storage class chart values (k8s >= 1.19)", func() {
-			values, err := vp.GetStorageClassesChartValues(ctx, cp, clusterK8sAtLeast119)
+		It("should return correct storage class chart values (k8s >= 1.20)", func() {
+			values, err := vp.GetStorageClassesChartValues(ctx, cp, clusterK8sAtLeast120)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{"useLegacyProvisioner": false}))
 		})

--- a/pkg/controller/csimigration/add.go
+++ b/pkg/controller/csimigration/add.go
@@ -36,7 +36,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return csimigration.Add(mgr, csimigration.AddArgs{
 		ControllerOptions:             opts.Controller,
-		CSIMigrationKubernetesVersion: "1.19",
+		CSIMigrationKubernetesVersion: "1.20",
 		Type:                          azure.Type,
 		StorageClassNameToLegacyProvisioner: map[string]string{
 			"default":              "kubernetes.io/azure-disk",

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -48,7 +48,7 @@ var (
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g azure) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
 	csiEnabledPreCheckFunc := func(_ runtime.Object, cluster *extensionscontroller.Cluster) bool {
-		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.19")
+		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.20")
 		if err != nil {
 			return false
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	acrConfigPath       = "/var/lib/kubelet/acr.conf"
-	csiMigrationVersion = "1.19"
+	csiMigrationVersion = "1.20"
 )
 
 // NewEnsurer creates a new controlplane ensurer.

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -92,12 +92,12 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		eContextK8s119 = genericmutator.NewInternalEnsurerContext(
+		eContextK8s120 = genericmutator.NewInternalEnsurerContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.19.0",
+							Version: "1.20.0",
 						},
 					},
 					Status: gardencorev1beta1.ShootStatus{
@@ -106,7 +106,7 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		eContextK8s119WithCSIAnnotation = genericmutator.NewInternalEnsurerContext(
+		eContextK8s120WithCSIAnnotation = genericmutator.NewInternalEnsurerContext(
 			&extensionscontroller.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -116,7 +116,7 @@ var _ = Describe("Ensurer", func() {
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.19.0",
+							Version: "1.20.0",
 						},
 					},
 					Status: gardencorev1beta1.ShootStatus{
@@ -193,7 +193,7 @@ var _ = Describe("Ensurer", func() {
 			checkKubeAPIServerDeployment(dep, annotations, "1.16.0", false)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17, < 1.19)", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17, < 1.20)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s117, dep, nil)
@@ -202,20 +202,20 @@ var _ = Describe("Ensurer", func() {
 			checkKubeAPIServerDeployment(dep, annotations, "1.17.4", false)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.19)", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.20)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s119, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s120, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, annotations, "1.19.0", false)
+			checkKubeAPIServerDeployment(dep, annotations, "1.20.0", false)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.19 w/ CSI annotation)", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s119WithCSIAnnotation, dep, nil)
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.20 w/ CSI annotation)", func() {
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, nil, "1.19.0", true)
+			checkKubeAPIServerDeployment(dep, nil, "1.20.0", true)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -283,7 +283,7 @@ var _ = Describe("Ensurer", func() {
 			checkKubeControllerManagerDeployment(dep, annotationsConfigMap, kubeControllerManagerLabels, "1.16.4", false)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17, k8s < 1.19)", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17, k8s < 1.20)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s117, dep, nil)
@@ -292,17 +292,17 @@ var _ = Describe("Ensurer", func() {
 			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.17.8", false)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.19 w/o CSI annotation)", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.20 w/o CSI annotation)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s119, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s120, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.19.0", false)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.20.0", false)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.19 w/ CSI annotation)", func() {
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s119WithCSIAnnotation, dep, nil)
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.20 w/ CSI annotation)", func() {
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkKubeControllerManagerDeployment(dep, nil, nil, "1.18.0", true)
@@ -365,25 +365,25 @@ var _ = Describe("Ensurer", func() {
 			ensurer = NewEnsurer(logger)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s < 1.19)", func() {
+		It("should add missing elements to kube-scheduler deployment (k8s < 1.20)", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s117, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkKubeSchedulerDeployment(dep, "1.17.0", false)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s >= 1.19 w/o CSI annotation)", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s119, dep, nil)
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.20 w/o CSI annotation)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s120, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.19.0", false)
+			checkKubeSchedulerDeployment(dep, "1.20.0", false)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s >= 1.19 w/ CSI annotation)", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s119WithCSIAnnotation, dep, nil)
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.20 w/ CSI annotation)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.19.0", true)
+			checkKubeSchedulerDeployment(dep, "1.20.0", true)
 		})
 	})
 
@@ -405,7 +405,7 @@ var _ = Describe("Ensurer", func() {
 			}
 		})
 
-		It("should modify existing elements of kubelet.service unit options (k8s < 1.19)", func() {
+		It("should modify existing elements of kubelet.service unit options (k8s < 1.20)", func() {
 			newUnitOptions := []*unit.UnitOption{
 				{
 					Section: "Service",
@@ -424,7 +424,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(opts).To(Equal(newUnitOptions))
 		})
 
-		It("should modify existing elements of kubelet.service unit options and add acr config (k8s < 1.19)", func() {
+		It("should modify existing elements of kubelet.service unit options and add acr config (k8s < 1.20)", func() {
 			var (
 				acrCM = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderAcrConfigName},
@@ -450,7 +450,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(opts).To(Equal(newUnitOptions))
 		})
 
-		It("should modify existing elements of kubelet.service unit options (k8s >= 1.19)", func() {
+		It("should modify existing elements of kubelet.service unit options (k8s >= 1.20)", func() {
 			newUnitOptions := []*unit.UnitOption{
 				{
 					Section: "Service",
@@ -464,12 +464,12 @@ var _ = Describe("Ensurer", func() {
 
 			c.EXPECT().Get(ctx, acrCmKey, &corev1.ConfigMap{}).Return(apierrors.NewNotFound(schema.GroupResource{}, azure.CloudProviderAcrConfigName))
 
-			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s119, oldUnitOptions, nil)
+			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s120, oldUnitOptions, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(opts).To(Equal(newUnitOptions))
 		})
 
-		It("should modify existing elements of kubelet.service unit options and add acr config (k8s >= 1.19)", func() {
+		It("should modify existing elements of kubelet.service unit options and add acr config (k8s >= 1.20)", func() {
 			var (
 				acrCM = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderAcrConfigName},
@@ -490,7 +490,7 @@ var _ = Describe("Ensurer", func() {
 
 			c.EXPECT().Get(ctx, acrCmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(acrCM))
 
-			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s119, oldUnitOptions, nil)
+			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s120, oldUnitOptions, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(opts).To(Equal(newUnitOptions))
 		})
@@ -507,7 +507,7 @@ var _ = Describe("Ensurer", func() {
 			}
 		})
 
-		It("should modify existing elements of kubelet configuration (k8s < 1.19)", func() {
+		It("should modify existing elements of kubelet configuration (k8s < 1.20)", func() {
 			newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 				FeatureGates: map[string]bool{
 					"Foo": true,
@@ -520,7 +520,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 		})
 
-		It("should modify existing elements of kubelet configuration (k8s >= 1.19)", func() {
+		It("should modify existing elements of kubelet configuration (k8s >= 1.20)", func() {
 			newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 				FeatureGates: map[string]bool{
 					"Foo":                           true,
@@ -533,19 +533,19 @@ var _ = Describe("Ensurer", func() {
 			}
 			kubeletConfig := *oldKubeletConfig
 
-			err := ensurer.EnsureKubeletConfiguration(ctx, eContextK8s119, &kubeletConfig, nil)
+			err := ensurer.EnsureKubeletConfiguration(ctx, eContextK8s120, &kubeletConfig, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 		})
 	})
 
 	Describe("#ShouldProvisionKubeletCloudProviderConfig", func() {
-		It("should return true (k8s < 1.19)", func() {
+		It("should return true (k8s < 1.20)", func() {
 			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s117)).To(BeTrue())
 		})
 
-		It("should return false (k8s >= 1.19)", func() {
-			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s119)).To(BeFalse())
+		It("should return false (k8s >= 1.20)", func() {
+			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s120)).To(BeFalse())
 		})
 	})
 
@@ -603,7 +603,7 @@ var _ = Describe("Ensurer", func() {
 
 func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
 	k8sVersionLessThan117, _ := version.CompareVersions(k8sVersion, "<", "1.17")
-	k8sVersionAtLeast119, _ := version.CompareVersions(k8sVersion, ">=", "1.19")
+	k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20")
 
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -622,7 +622,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 			Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
 		}
-		if k8sVersionAtLeast119 {
+		if k8sVersionAtLeast120 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true"))
 		}
 	} else {
@@ -641,7 +641,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 
 func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
 	k8sVersionLessThan117, _ := version.CompareVersions(k8sVersion, "<", "1.17")
-	k8sVersionAtLeast119, _ := version.CompareVersions(k8sVersion, ">=", "1.19")
+	k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20")
 
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -661,7 +661,7 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 			Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
 		}
-		if k8sVersionAtLeast119 {
+		if k8sVersionAtLeast120 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true"))
 		}
 	} else {
@@ -678,7 +678,7 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 }
 
 func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
-	if k8sVersionAtLeast119, _ := version.CompareVersions(k8sVersion, ">=", "1.19"); !k8sVersionAtLeast119 {
+	if k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20"); !k8sVersionAtLeast120 {
 		return
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
Changes the Kubernetes version requirement to deploy CSI controllers / drivers by default from 1.19 to 1.20. See https://github.com/gardener/remedy-controller/issues/1 for the motivation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
CSI controllers / drivers are now deployed by default if the Kubernetes version is 1.20 or later (not 1.19 as before)
```
