### PR TITLE
Populate worker-configuration in machine deployment

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -166,13 +166,14 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		generateMachineClassAndDeployment := func(zone *zoneInfo, availabilitySetID *string) (worker.MachineDeployment, map[string]interface{}) {
 			var (
 				machineDeployment = worker.MachineDeployment{
-					Minimum:        pool.Minimum,
-					Maximum:        pool.Maximum,
-					MaxSurge:       pool.MaxSurge,
-					MaxUnavailable: pool.MaxUnavailable,
-					Labels:         pool.Labels,
-					Annotations:    pool.Annotations,
-					Taints:         pool.Taints,
+					Minimum:              pool.Minimum,
+					Maximum:              pool.Maximum,
+					MaxSurge:             pool.MaxSurge,
+					MaxUnavailable:       pool.MaxUnavailable,
+					Labels:               pool.Labels,
+					Annotations:          pool.Annotations,
+					Taints:               pool.Taints,
+					MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
 				}
 
 				machineClassSpec = utils.MergeMaps(map[string]interface{}{

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
+	"time"
 
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
@@ -132,6 +134,8 @@ var _ = Describe("Machines", func() {
 
 				labels map[string]string
 
+				machineConfiguration *machinev1alpha1.MachineConfiguration
+
 				shootVersionMajorMinor string
 				shootVersion           string
 				scheme                 *runtime.Scheme
@@ -184,6 +188,7 @@ var _ = Describe("Machines", func() {
 				maxUnavailablePool1 = intstr.FromInt(2)
 
 				labels = map[string]string{"component": "TiDB"}
+				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
 
 				namePool2 = "pool-2"
 				minPool2 = 30
@@ -437,24 +442,26 @@ var _ = Describe("Machines", func() {
 
 					machineDeployments = worker.MachineDeployments{
 						{
-							Name:           machineClassNamePool1,
-							ClassName:      machineClassWithHashPool1,
-							SecretName:     machineClassWithHashPool1,
-							Minimum:        minPool1,
-							Maximum:        maxPool1,
-							MaxSurge:       maxSurgePool1,
-							MaxUnavailable: maxUnavailablePool1,
-							Labels:         labels,
+							Name:                 machineClassNamePool1,
+							ClassName:            machineClassWithHashPool1,
+							SecretName:           machineClassWithHashPool1,
+							Minimum:              minPool1,
+							Maximum:              maxPool1,
+							MaxSurge:             maxSurgePool1,
+							MaxUnavailable:       maxUnavailablePool1,
+							Labels:               labels,
+							MachineConfiguration: machineConfiguration,
 						},
 						{
-							Name:           machineClassNamePool2,
-							ClassName:      machineClassWithHashPool2,
-							SecretName:     machineClassWithHashPool2,
-							Minimum:        minPool2,
-							Maximum:        maxPool2,
-							MaxSurge:       maxSurgePool2,
-							MaxUnavailable: maxUnavailablePool2,
-							Labels:         labels,
+							Name:                 machineClassNamePool2,
+							ClassName:            machineClassWithHashPool2,
+							SecretName:           machineClassWithHashPool2,
+							Minimum:              minPool2,
+							Maximum:              maxPool2,
+							MaxSurge:             maxSurgePool2,
+							MaxUnavailable:       maxUnavailablePool2,
+							Labels:               labels,
+							MachineConfiguration: machineConfiguration,
 						},
 					}
 
@@ -590,6 +597,36 @@ var _ = Describe("Machines", func() {
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
+			})
+
+			It("should set expected machineControllerManager settings on machine deployment", func() {
+				expectGetSecretCallToWork(c, azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID)
+
+				testDrainTimeout := metav1.Duration{Duration: 10 * time.Minute}
+				testHealthTimeout := metav1.Duration{Duration: 20 * time.Minute}
+				testCreationTimeout := metav1.Duration{Duration: 30 * time.Minute}
+				testMaxEvictRetries := int32(30)
+				testNodeConditions := []string{"ReadonlyFilesystem", "KernelDeadlock", "DiskPressure"}
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					MachineDrainTimeout:    &testDrainTimeout,
+					MachineCreationTimeout: &testCreationTimeout,
+					MachineHealthTimeout:   &testHealthTimeout,
+					MaxEvictRetries:        &testMaxEvictRetries,
+					NodeConditions:         testNodeConditions,
+				}
+
+				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
+
+				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				resultSettings := result[0].MachineConfiguration
+				resultNodeConditions := strings.Join(testNodeConditions, ",")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resultSettings.MachineDrainTimeout).To(Equal(&testDrainTimeout))
+				Expect(resultSettings.MachineCreationTimeout).To(Equal(&testCreationTimeout))
+				Expect(resultSettings.MachineHealthTimeout).To(Equal(&testHealthTimeout))
+				Expect(resultSettings.MaxEvictRetries).To(Equal(&testMaxEvictRetries))
+				Expect(resultSettings.NodeConditions).To(Equal(&resultNodeConditions))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:  This PR populates the controller-configurations on the machine-deployment from worker-object. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/136

**Special notes for your reviewer**:
The following dependencies need to be resolved.
- [x] Vendor the MCM 0.33.0
- [x] https://github.com/gardener/gardener/pull/2563 should be merged.
- [x]  g/g with the #2563 change should be vendored. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Worker extension allows configuring following parameters on machine-deployment: drainTimeout, creationTimeout, healthTimeout, maxEvictRetries, nodeConditions.
```
