### PR TITLE
Enable remedy controller by default

### DIFF
--- a/charts/internal/seed-controlplane/values.yaml
+++ b/charts/internal/seed-controlplane/values.yaml
@@ -3,4 +3,4 @@ cloud-controller-manager:
 csi-driver-controller:
   enabled: false
 remedy-controller-azure:
-  enabled: false
+  enabled: true

--- a/charts/internal/shoot-system-components/values.yaml
+++ b/charts/internal/shoot-system-components/values.yaml
@@ -5,4 +5,4 @@ cloud-controller-manager:
 csi-driver-node:
   enabled: false
 remedy-controller-azure:
-  enabled: false
+  enabled: true

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -49,10 +49,8 @@ import (
 )
 
 const (
-	// enableRemedyControllerAnnotation enables the Azure remedy controller (disabled by default)
-	// This annotation and the corresponding code should be removed once the remedy controller is considered
-	// fully enabled for production use.
-	enableRemedyControllerAnnotation = "azure.provider.extensions.gardener.cloud/enable-remedy-controller"
+	// disableRemedyControllerAnnotation disables the Azure remedy controller (enabled by default)
+	disableRemedyControllerAnnotation = "azure.provider.extensions.gardener.cloud/disable-remedy-controller"
 )
 
 // Object names
@@ -483,9 +481,9 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		cloudProviderDiskConfigChecksum = utils.ComputeChecksum(secret.Data)
 	}
 
-	enableRemedyController := cluster.Shoot.Annotations[enableRemedyControllerAnnotation] == "true"
+	disableRemedyController := cluster.Shoot.Annotations[disableRemedyControllerAnnotation] == "true"
 
-	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan120, enableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
+	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan120, disableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
 }
 
 // GetStorageClassesChartValues returns the values for the storage classes chart applied by the generic actuator.
@@ -685,8 +683,8 @@ func getRemedyControllerChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
-	enableRemedyController := cluster.Shoot.Annotations[enableRemedyControllerAnnotation] == "true"
-	if !enableRemedyController {
+	disableRemedyController := cluster.Shoot.Annotations[disableRemedyControllerAnnotation] == "true"
+	if disableRemedyController {
 		return map[string]interface{}{"enabled": false}, nil
 	}
 
@@ -705,7 +703,7 @@ func getControlPlaneShootChartValues(
 	cluster *extensionscontroller.Cluster,
 	infraStatus *apisazure.InfrastructureStatus,
 	k8sVersionLessThan120 bool,
-	enableRemedyController bool,
+	disableRemedyController bool,
 	cloudProviderDiskConfig string,
 	cloudProviderDiskConfigChecksum string,
 ) map[string]interface{} {
@@ -720,6 +718,6 @@ func getControlPlaneShootChartValues(
 			},
 			"cloudProviderConfig": cloudProviderDiskConfig,
 		},
-		azure.RemedyControllerName: map[string]interface{}{"enabled": enableRemedyController},
+		azure.RemedyControllerName: map[string]interface{}{"enabled": !disableRemedyController},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
* Enables the remedy controller on all Azure clusters. The annotation `azure.provider.extensions.gardener.cloud/enable-remedy-controller` is no longer required to enable it.
* Introduces the annotation `azure.provider.extensions.gardener.cloud/disable-remedy-controller` that can be used to disable the remedy controller on certain clusters (as a temporary workaround in case it causes issues until they are fixed).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
The remedy controller is now enabled by default on all Azure clusters. It can be disabled using the annotation `azure.provider.extensions.gardener.cloud/disable-remedy-controller: "true"`
```
