### PR TITLE
Prepare upgrade to Terraform azurerm v2.x.x

### DIFF
--- a/charts/internal/azure-infra/templates/main.tf
+++ b/charts/internal/azure-infra/templates/main.tf
@@ -63,6 +63,11 @@ resource "azurerm_route_table" "workers" {
   {{- end}}
 }
 
+resource "azurerm_subnet_route_table_association" "workers-rt-subnet-association" {
+  subnet_id      = azurerm_subnet.workers.id
+  route_table_id = azurerm_route_table.workers.id
+}
+
 resource "azurerm_network_security_group" "workers" {
   name                = "{{ required "clusterName is required" .Values.clusterName }}-workers"
   location            = "{{ required "azure.region is required" .Values.azure.region }}"
@@ -71,6 +76,11 @@ resource "azurerm_network_security_group" "workers" {
   {{- else -}}
   resource_group_name = data.azurerm_resource_group.rg.name
   {{- end}}
+}
+
+resource "azurerm_subnet_network_security_group_association" "workers-nsg-subnet-association" {
+  subnet_id                 = azurerm_subnet.workers.id
+  network_security_group_id = azurerm_network_security_group.workers.id
 }
 
 {{ if .Values.create.natGateway -}}


### PR DESCRIPTION
Add association resources for `routetable-to-subnet` and `nsg-to-subnet` in parallel to internal associations on the subnet resource.

**How to categorize this PR?**
/kind impediment
/priority normal
/platform azure

**What this PR does / why we need it**:
We need to upgrade the `azurerm` Terraform provider to at least version v2.12.0 as this is required for the NatGateway bring your own IP scenario (https://github.com/gardener/gardener-extension-provider-azure/pull/54#issuecomment-635788184, https://github.com/terraform-providers/terraform-provider-azurerm/pull/6450, https://github.com/terraform-providers/terraform-provider-azurerm/issues/6052). 

As preparation for the upgrade we need to add the `routetable-to-subnet` and `nsg-to-subnet` external association resources in parallel to the internal associations on the subnet resource. Otherwise we won't be able to upgrade to `azurerm` v2, see here: 
 https://github.com/terraform-providers/terraform-provider-azurerm/issues/2358#issuecomment-440168871

**Special notes for your reviewer**:
Create a `Infrastructure` without this change. Then checkout this PR and reconcile the `Infrastructure` once more. The route table/nsg to subnet association on Azure should not change. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```NONE

```
