### PR TITLE
Webhook ensurer does not remove or add /etc/ssl directory for kube apiserver deployments

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+
+	"github.com/coreos/go-systemd/unit"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
@@ -28,8 +30,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-
-	"github.com/coreos/go-systemd/unit"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -81,10 +81,10 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx generi
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-apiserver"); c != nil {
 		ensureKubeAPIServerCommandLineArgs(c, csiEnabled, csiMigrationComplete)
-		ensureVolumeMounts(c, cluster.Shoot.Spec.Kubernetes.Version, csiEnabled, csiMigrationComplete)
+		ensureKubeAPIServerVolumeMounts(c, csiEnabled, csiMigrationComplete)
 	}
 
-	ensureVolumes(ps, cluster.Shoot.Spec.Kubernetes.Version, csiEnabled, csiMigrationComplete)
+	ensureKubeAPIServerVolumes(ps, csiEnabled, csiMigrationComplete)
 	return e.ensureChecksumAnnotations(ctx, &new.Spec.Template, new.Namespace, csiEnabled, csiMigrationComplete)
 }
 
@@ -105,11 +105,11 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, ect
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-controller-manager"); c != nil {
 		ensureKubeControllerManagerCommandLineArgs(c, csiEnabled, csiMigrationComplete)
-		ensureVolumeMounts(c, cluster.Shoot.Spec.Kubernetes.Version, csiEnabled, csiMigrationComplete)
+		ensureKubeControllerManagerVolumeMounts(c, cluster.Shoot.Spec.Kubernetes.Version, csiEnabled, csiMigrationComplete)
 	}
 
 	ensureKubeControllerManagerLabels(template, csiEnabled, csiMigrationComplete)
-	ensureVolumes(ps, cluster.Shoot.Spec.Kubernetes.Version, csiEnabled, csiMigrationComplete)
+	ensureKubeControllerManagerVolumes(ps, cluster.Shoot.Spec.Kubernetes.Version, csiEnabled, csiMigrationComplete)
 	return e.ensureChecksumAnnotations(ctx, &new.Spec.Template, new.Namespace, csiEnabled, csiMigrationComplete)
 }
 
@@ -239,6 +239,24 @@ var (
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/ssl",
+				Type: &directoryOrCreate,
+			},
+		},
+	}
+
+	usrShareCaCerts            = "usr-share-cacerts"
+	directoryOrCreate          = corev1.HostPathDirectoryOrCreate
+	usrShareCaCertsVolumeMount = corev1.VolumeMount{
+		Name:      usrShareCaCerts,
+		MountPath: "/usr/share/ca-certificates",
+		ReadOnly:  true,
+	}
+	usrShareCaCertsVolume = corev1.Volume{
+		Name: usrShareCaCerts,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/usr/share/ca-certificates",
+				Type: &directoryOrCreate,
 			},
 		},
 	}
@@ -257,29 +275,53 @@ var (
 	}
 )
 
-func ensureVolumeMounts(c *corev1.Container, version string, csiEnabled, csiMigrationComplete bool) {
+func ensureKubeAPIServerVolumeMounts(c *corev1.Container, csiEnabled, csiMigrationComplete bool) {
+	if csiEnabled && csiMigrationComplete {
+		c.VolumeMounts = extensionswebhook.EnsureNoVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount.Name)
+		return
+	}
+
+	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount)
+}
+
+func ensureKubeControllerManagerVolumeMounts(c *corev1.Container, version string, csiEnabled, csiMigrationComplete bool) {
 	if csiEnabled && csiMigrationComplete {
 		c.VolumeMounts = extensionswebhook.EnsureNoVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount.Name)
 		c.VolumeMounts = extensionswebhook.EnsureNoVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount.Name)
+		c.VolumeMounts = extensionswebhook.EnsureNoVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount.Name)
 		return
 	}
 
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount)
 	if mustMountEtcSSLFolder(version) {
 		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
+		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount)
 	}
 }
 
-func ensureVolumes(ps *corev1.PodSpec, version string, csiEnabled, csiMigrationComplete bool) {
+func ensureKubeAPIServerVolumes(ps *corev1.PodSpec, csiEnabled, csiMigrationComplete bool) {
+	if csiEnabled && csiMigrationComplete {
+		ps.Volumes = extensionswebhook.EnsureNoVolumeWithName(ps.Volumes, cloudProviderConfigVolume.Name)
+		return
+	}
+
+	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigVolume)
+}
+
+func ensureKubeControllerManagerVolumes(ps *corev1.PodSpec, version string, csiEnabled, csiMigrationComplete bool) {
 	if csiEnabled && csiMigrationComplete {
 		ps.Volumes = extensionswebhook.EnsureNoVolumeWithName(ps.Volumes, cloudProviderConfigVolume.Name)
 		ps.Volumes = extensionswebhook.EnsureNoVolumeWithName(ps.Volumes, etcSSLVolume.Name)
+		ps.Volumes = extensionswebhook.EnsureNoVolumeWithName(ps.Volumes, usrShareCaCertsVolume.Name)
 		return
 	}
 
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigVolume)
 	if mustMountEtcSSLFolder(version) {
 		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
+		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, usrShareCaCertsVolume)
 	}
 }
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+
+	"github.com/coreos/go-systemd/unit"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -28,8 +30,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/utils/version"
-
-	"github.com/coreos/go-systemd/unit"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -602,7 +602,6 @@ var _ = Describe("Ensurer", func() {
 })
 
 func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
-	k8sVersionLessThan117, _ := version.CompareVersions(k8sVersion, "<", "1.17")
 	k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20")
 
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
@@ -618,10 +617,6 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 		Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 		Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-		if !k8sVersionLessThan117 {
-			Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
-			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
-		}
 		if k8sVersionAtLeast120 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true"))
 		}
@@ -633,8 +628,6 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ","))
 		Expect(c.VolumeMounts).NotTo(ContainElement(cloudProviderConfigVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(cloudProviderConfigVolume))
-		Expect(c.VolumeMounts).NotTo(ContainElement(etcSSLVolumeMount))
-		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(etcSSLVolume))
 		Expect(dep.Spec.Template.Annotations).To(BeNil())
 	}
 }
@@ -660,6 +653,8 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 		if !k8sVersionLessThan117 {
 			Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+			Expect(c.VolumeMounts).To(ContainElement(usrShareCaCertsVolumeMount))
+			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(usrShareCaCertsVolume))
 		}
 		if k8sVersionAtLeast120 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true"))
@@ -674,6 +669,8 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(cloudProviderConfigVolume))
 		Expect(c.VolumeMounts).NotTo(ContainElement(etcSSLVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(etcSSLVolume))
+		Expect(c.VolumeMounts).NotTo(ContainElement(usrShareCaCertsVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(usrShareCaCertsVolume))
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
The provider extension webhook does no longer touch the `/etc/ssl/` directories on the host. 
 Mounting `/etc/ssl/` is always required for the Kube API Server for making OIDC or webhook requests.
 Gardener now always includes the aforementioned mount with [this PR](https://github.com/gardener/gardener/pull/2791).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Webhook ensurer does not remove or add the /etc/ssl directory for kube apiserver deployments any more.  This is done by the Gardenlet for version >= 1.10.0.
```
