### PR TITLE
Add additional mounts to CCM

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -97,8 +97,17 @@ spec:
           mountPath: /var/lib/cloud-controller-manager-server
         - name: cloud-provider-config
           mountPath: /etc/kubernetes/cloudprovider
+        - name: fedora-rhel6-openelec-cabundle
+          mountPath: /etc/pki/tls
+          readOnly: true
+        - name: centos-rhel-cabundle
+          mountPath: /etc/pki/ca-trust
+          readOnly: true
         - name: etc-ssl
           mountPath: /etc/ssl
+          readOnly: true
+        - name: usr-share-cacerts
+          mountPath: /usr/share/ca-certificates
           readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
@@ -114,6 +123,19 @@ spec:
       - name: cloud-provider-config
         secret:
           secretName: cloud-provider-config
+      - name: fedora-rhel6-openelec-cabundle
+        hostPath:
+          path: /etc/pki/tls
+          type: "DirectoryOrCreate"
+      - name: centos-rhel-cabundle
+        hostPath:
+          path: /etc/pki/ca-trust
+          type: "DirectoryOrCreate"
       - name: etc-ssl
         hostPath:
           path: /etc/ssl
+          type: "DirectoryOrCreate"
+      - name: usr-share-cacerts
+        hostPath:
+          path: /usr/share/ca-certificates
+          type: "DirectoryOrCreate"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:

Add common certificate directory mounts to the CCM.
Otherwise the CCM might not be able to talk to the Azure API on a certain OS.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add common certificate directory mounts to the CCM.
```
