### PR TITLE
Vendor gardener/gardener@v1.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.3.0
-	github.com/gardener/gardener v1.10.0
+	github.com/gardener/gardener v1.10.2
 	github.com/gardener/gardener-extension-networking-calico v1.7.1-0.20200522070525-f9aa28d3c83a
 	github.com/gardener/machine-controller-manager v0.33.0
 	github.com/gardener/remedy-controller v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGU
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a/go.mod h1:t9oESM37bAMIuezi9I0H0I8+++8jy8BUPitcf4ERRXY=
 github.com/gardener/gardener v1.6.6/go.mod h1:w5IHIQDccvSxZJFOtBa8YConyyFgt07DBHJBWFxb6HU=
-github.com/gardener/gardener v1.10.0 h1:a5TXkjL+4DgFOgBH03R9BiH9ZPBGx4avJm912nLqKag=
-github.com/gardener/gardener v1.10.0/go.mod h1:hbpwDPyqvfcqj6383ZyddwtLiESOaVqXeFzFBpVJKBo=
+github.com/gardener/gardener v1.10.2 h1:VbBoxpz5h0QRGv9zRYjleLyCK6tz+0Dxo/1a1KIA5oE=
+github.com/gardener/gardener v1.10.2/go.mod h1:hbpwDPyqvfcqj6383ZyddwtLiESOaVqXeFzFBpVJKBo=
 github.com/gardener/gardener-extension-networking-calico v1.7.1-0.20200522070525-f9aa28d3c83a h1:jBvyEhkRzW11Nz2y9IIQAo9HUaCvCqxEko5Nf9NRYUI=
 github.com/gardener/gardener-extension-networking-calico v1.7.1-0.20200522070525-f9aa28d3c83a/go.mod h1:bmD89OLvEBbXLlznsHe90ZlgTU+OrKErwHb6NWlSTvY=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/predicate.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/predicate.go
@@ -21,21 +21,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// MachineStatusHasChanged is a predicate deciding wether the status of a MCM's Machine has been changed.
+// MachineStatusHasChanged is a predicate deciding whether the status of a Machine has been changed.
 func MachineStatusHasChanged() predicate.Predicate {
 	statusHasChanged := func(oldObj runtime.Object, newObj runtime.Object) bool {
 		oldMachine, ok := oldObj.(*machinev1alpha1.Machine)
 		if !ok {
 			return false
 		}
+
 		newMachine, ok := newObj.(*machinev1alpha1.Machine)
 		if !ok {
 			return false
 		}
-		oldStatus := oldMachine.Status
-		newStatus := newMachine.Status
 
-		return oldStatus.Node != newStatus.Node
+		return oldMachine.Spec.ProviderID != newMachine.Spec.ProviderID ||
+			oldMachine.Status.Node != newMachine.Status.Node
 	}
 
 	return predicate.Funcs{
@@ -43,8 +43,7 @@ func MachineStatusHasChanged() predicate.Predicate {
 			return true
 		},
 		UpdateFunc: func(event event.UpdateEvent) bool {
-			result := statusHasChanged(event.ObjectOld, event.ObjectNew)
-			return result
+			return statusHasChanged(event.ObjectOld, event.ObjectNew)
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
 			return false

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/admissionplugins.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/admissionplugins.go
@@ -55,6 +55,10 @@ var (
 // If the given Kubernetes version does not explicitly define admission plugins the set of names for the next
 // available version will be returned (e.g., for version X not defined the set of version X-1 will be returned).
 func GetAdmissionPluginsForVersion(v string) []gardencorev1beta1.AdmissionPlugin {
+	return copyPlugins(getAdmissionPluginsForVersionInternal(v))
+}
+
+func getAdmissionPluginsForVersionInternal(v string) []gardencorev1beta1.AdmissionPlugin {
 	version, err := semver.NewVersion(v)
 	if err != nil {
 		return admissionPlugins[lowestSupportedKubernetesVersionMajorMinor]
@@ -78,4 +82,13 @@ func GetAdmissionPluginsForVersion(v string) []gardencorev1beta1.AdmissionPlugin
 
 func formatMajorMinor(major, minor int64) string {
 	return fmt.Sprintf("%d.%d", major, minor)
+}
+
+func copyPlugins(admissionPlugins []gardencorev1beta1.AdmissionPlugin) []gardencorev1beta1.AdmissionPlugin {
+	dst := make([]gardencorev1beta1.AdmissionPlugin, 0)
+	for _, plugin := range admissionPlugins {
+		pluginPointer := &plugin
+		dst = append(dst, *pluginPointer.DeepCopy())
+	}
+	return dst
 }

--- a/vendor/github.com/gardener/gardener/pkg/controllerutils/miscellaneous.go
+++ b/vendor/github.com/gardener/gardener/pkg/controllerutils/miscellaneous.go
@@ -16,9 +16,13 @@ package controllerutils
 
 import (
 	"strings"
+	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const separator = ","
@@ -82,4 +86,40 @@ func setTaskAnnotations(annotations map[string]string, tasks []string) {
 	}
 
 	annotations[common.ShootTasks] = strings.Join(tasks, separator)
+}
+
+var (
+	// Now is a function for returning the current time.
+	Now = time.Now
+	// RandomDuration is a function for returning a random duration.
+	RandomDuration = utils.RandomDuration
+)
+
+// ReconcileOncePer24hDuration returns the duration until the next reconciliation should happen while respecting that
+// only one reconciliation should happen per 24h. If the deletion timestamp is set or the generation has changed or the
+// last operation does not indicate success or indicates that the last reconciliation happened more than 24h ago then 0
+// will be returned.
+func ReconcileOncePer24hDuration(objectMeta metav1.ObjectMeta, observedGeneration int64, lastOperation *gardencorev1beta1.LastOperation) time.Duration {
+	if objectMeta.DeletionTimestamp != nil {
+		return 0
+	}
+
+	if objectMeta.Generation != observedGeneration {
+		return 0
+	}
+
+	if lastOperation == nil ||
+		lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded ||
+		(lastOperation.Type != gardencorev1beta1.LastOperationTypeCreate && lastOperation.Type != gardencorev1beta1.LastOperationTypeReconcile) {
+		return 0
+	}
+
+	// If last reconciliation happened more than 24h ago then we want to reconcile immediately, so let's only compute
+	// a delay if the last reconciliation was within the last 24h.
+	if lastReconciliation := lastOperation.LastUpdateTime.Time; Now().UTC().Before(lastReconciliation.UTC().Add(24 * time.Hour)) {
+		durationUntilLastReconciliationWas24hAgo := lastReconciliation.UTC().Add(24 * time.Hour).Sub(Now().UTC())
+		return RandomDuration(durationUntilLastReconciliationWas24hAgo)
+	}
+
+	return 0
 }

--- a/vendor/github.com/gardener/gardener/pkg/gardenlet/apis/config/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/gardenlet/apis/config/types.go
@@ -176,6 +176,11 @@ type ShootControllerConfiguration struct {
 	// ConcurrentSyncs is the number of workers used for the controller to work on
 	// events.
 	ConcurrentSyncs *int
+	// ProgressReportPeriod is the period how often the progress of a shoot operation will be reported in the
+	// Shoot's `.status.lastOperation` field. By default, the progress will be reported immediately after a task of the
+	// respective flow has been completed. If you set this to a value > 0 (e.g., 5s) then it will be only reported every
+	// 5 seconds. Any tasks that were completed in the meantime will not be reported.
+	ProgressReportPeriod *metav1.Duration
 	// ReconcileInMaintenanceOnly determines whether Shoot reconciliations happen only
 	// during its maintenance time window.
 	ReconcileInMaintenanceOnly *bool

--- a/vendor/github.com/gardener/gardener/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/gardener/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -574,6 +574,11 @@ func (in *ShootControllerConfiguration) DeepCopyInto(out *ShootControllerConfigu
 		*out = new(int)
 		**out = **in
 	}
+	if in.ProgressReportPeriod != nil {
+		in, out := &in.ProgressReportPeriod, &out.ProgressReportPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ReconcileInMaintenanceOnly != nil {
 		in, out := &in.ReconcileInMaintenanceOnly, &out.ReconcileInMaintenanceOnly
 		*out = new(bool)

--- a/vendor/github.com/gardener/gardener/pkg/operation/operation.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/operation.go
@@ -73,7 +73,7 @@ func NewBuilder() *Builder {
 		secretsFunc: func() (map[string]*corev1.Secret, error) {
 			return nil, fmt.Errorf("secrets map is required but not set")
 		},
-		seedFunc: func(context.Context, client.Client) (*seed.Seed, error) {
+		seedFunc: func(context.Context) (*seed.Seed, error) {
 			return nil, fmt.Errorf("seed object is required but not set")
 		},
 		shootFunc: func(context.Context, client.Client, *garden.Garden, *seed.Seed) (*shoot.Shoot, error) {
@@ -142,17 +142,16 @@ func (b *Builder) WithSecrets(secrets map[string]*corev1.Secret) *Builder {
 
 // WithSeed sets the seedFunc attribute at the Builder.
 func (b *Builder) WithSeed(s *seed.Seed) *Builder {
-	b.seedFunc = func(_ context.Context, _ client.Client) (*seed.Seed, error) { return s, nil }
+	b.seedFunc = func(_ context.Context) (*seed.Seed, error) { return s, nil }
 	return b
 }
 
 // WithSeedFrom sets the seedFunc attribute at the Builder which will build a new Seed object.
 func (b *Builder) WithSeedFrom(k8sGardenCoreInformers gardencoreinformers.Interface, seedName string) *Builder {
-	b.seedFunc = func(ctx context.Context, c client.Client) (*seed.Seed, error) {
+	b.seedFunc = func(ctx context.Context) (*seed.Seed, error) {
 		return seed.
 			NewBuilder().
 			WithSeedObjectFromLister(k8sGardenCoreInformers.Seeds().Lister(), seedName).
-			WithSeedSecretFromClient(ctx, c).
 			Build()
 	}
 	return b
@@ -249,7 +248,7 @@ func (b *Builder) Build(ctx context.Context, clientMap clientmap.ClientMap) (*Op
 	}
 	operation.Logger = logger
 
-	seed, err := b.seedFunc(ctx, gardenClient.Client())
+	seed, err := b.seedFunc(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -347,8 +346,11 @@ func (o *Operation) GetSecretKeysOfRole(kind string) []string {
 }
 
 func makeDescription(stats *flow.Stats) string {
+	if stats.ProgressPercent() == 0 {
+		return "Starting " + stats.FlowName
+	}
 	if stats.ProgressPercent() == 100 {
-		return "Execution finished"
+		return stats.FlowName + " finished"
 	}
 	return strings.Join(stats.Running.StringList(), ", ")
 }
@@ -370,7 +372,9 @@ func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) 
 			if shoot.Status.LastOperation.LastUpdateTime.After(lastUpdateTime.Time) {
 				return nil, fmt.Errorf("last operation of Shoot %s/%s was updated mid-air", shoot.Namespace, shoot.Name)
 			}
-			shoot.Status.LastOperation.Description = description
+			if description != "" {
+				shoot.Status.LastOperation.Description = description
+			}
 			shoot.Status.LastOperation.Progress = progress
 			shoot.Status.LastOperation.LastUpdateTime = lastUpdateTime
 			return shoot, nil

--- a/vendor/github.com/gardener/gardener/pkg/operation/seed/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/seed/types.go
@@ -16,19 +16,15 @@ package seed
 
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Builder is an object that builds Seed objects.
 type Builder struct {
 	seedObjectFunc func() (*gardencorev1beta1.Seed, error)
-	seedSecretFunc func(*corev1.SecretReference) (*corev1.Secret, error)
 }
 
 // Seed is an object containing information about a Seed cluster.
 type Seed struct {
 	Info                           *gardencorev1beta1.Seed
-	Secret                         *corev1.Secret
 	LoadBalancerServiceAnnotations map[string]string
 }

--- a/vendor/github.com/gardener/gardener/pkg/operation/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/types.go
@@ -47,7 +47,7 @@ type Builder struct {
 	imageVectorFunc           func() (imagevector.ImageVector, error)
 	loggerFunc                func() (*logrus.Entry, error)
 	secretsFunc               func() (map[string]*corev1.Secret, error)
-	seedFunc                  func(context.Context, client.Client) (*seed.Seed, error)
+	seedFunc                  func(context.Context) (*seed.Seed, error)
 	shootFunc                 func(context.Context, client.Client, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
 	chartsRootPathFunc        func() string
 }

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/flow.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/flow.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/logger"
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -32,9 +33,6 @@ const (
 	logKeyFlow = "flow"
 	logKeyTask = "task"
 )
-
-// ProgressReporter is continuously called on progress in a flow.
-type ProgressReporter func(context.Context, *Stats)
 
 // ErrorCleaner is called when a task which errored during the previous reconciliation phase completes with success
 type ErrorCleaner func(context.Context, string)
@@ -101,7 +99,7 @@ func (n *node) addTargets(taskIDs ...TaskID) {
 // are left blank and don't affect the Flow.
 type Opts struct {
 	Logger           logrus.FieldLogger
-	ProgressReporter func(ctx context.Context, stats *Stats)
+	ProgressReporter ProgressReporter
 	ErrorCleaner     func(ctx context.Context, taskID string)
 	ErrorContext     *utilerrors.ErrorContext
 	Context          context.Context
@@ -124,6 +122,7 @@ type nodeResult struct {
 
 // Stats are the statistics of a Flow execution.
 type Stats struct {
+	FlowName  string
 	All       TaskIDs
 	Succeeded TaskIDs
 	Failed    TaskIDs
@@ -140,6 +139,7 @@ func (s *Stats) ProgressPercent() int32 {
 // Copy deeply copies a Stats object.
 func (s *Stats) Copy() *Stats {
 	return &Stats{
+		s.FlowName,
 		s.All.Copy(),
 		s.Succeeded.Copy(),
 		s.Failed.Copy(),
@@ -150,8 +150,9 @@ func (s *Stats) Copy() *Stats {
 
 // InitialStats creates a new Stats object with the given set of initial TaskIDs.
 // The initial TaskIDs are added to all TaskIDs as well as to the pending ones.
-func InitialStats(all TaskIDs) *Stats {
+func InitialStats(flowName string, all TaskIDs) *Stats {
 	return &Stats{
+		flowName,
 		all,
 		NewTaskIDs(),
 		NewTaskIDs(),
@@ -160,7 +161,7 @@ func InitialStats(all TaskIDs) *Stats {
 	}
 }
 
-func newExecution(flow *Flow, log logrus.FieldLogger, reporter ProgressReporter, errorCleaner ErrorCleaner, errorContext *utilerrors.ErrorContext) *execution {
+func newExecution(flow *Flow, log logrus.FieldLogger, progressReporter ProgressReporter, errorCleaner ErrorCleaner, errorContext *utilerrors.ErrorContext) *execution {
 	all := NewTaskIDs()
 
 	for name := range flow.nodes {
@@ -174,10 +175,10 @@ func newExecution(flow *Flow, log logrus.FieldLogger, reporter ProgressReporter,
 
 	return &execution{
 		flow,
-		InitialStats(all),
+		InitialStats(flow.name, all),
 		nil,
 		log,
-		reporter,
+		progressReporter,
 		errorCleaner,
 		errorContext,
 		make(chan *nodeResult),
@@ -258,12 +259,20 @@ func (e *execution) cleanErrors(ctx context.Context, taskID TaskID) {
 
 func (e *execution) reportProgress(ctx context.Context) {
 	if e.progressReporter != nil {
-		e.progressReporter(ctx, e.stats.Copy())
+		e.progressReporter.Report(ctx, e.stats.Copy())
 	}
 }
 
 func (e *execution) run(ctx context.Context) error {
 	defer close(e.done)
+
+	if e.progressReporter != nil {
+		if err := e.progressReporter.Start(ctx); err != nil {
+			return err
+		}
+		defer e.progressReporter.Stop()
+	}
+
 	e.log.Info("Starting")
 	e.reportProgress(ctx)
 
@@ -274,9 +283,9 @@ func (e *execution) run(ctx context.Context) error {
 	for name := range roots {
 		if cancelErr = ctx.Err(); cancelErr == nil {
 			e.runNode(ctx, name)
-			e.reportProgress(ctx)
 		}
 	}
+	e.reportProgress(ctx)
 
 	for e.stats.Running.Len() > 0 {
 		result := <-e.done

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+)
+
+// ProgressReporterFn is continuously called on progress in a flow.
+type ProgressReporterFn func(context.Context, *Stats)
+
+// ProgressReporter is used to report the current progress of a flow.
+type ProgressReporter interface {
+	// Start starts the progress reporter.
+	Start(context.Context) error
+	// Stop stops the progress reporter.
+	Stop()
+	// Report reports the progress using the current statistics.
+	Report(context.Context, *Stats)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_delaying.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_delaying.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type progressReporterDelaying struct {
+	lock                sync.Mutex
+	ctx                 context.Context
+	ctxCancel           context.CancelFunc
+	reporterFn          ProgressReporterFn
+	period              time.Duration
+	timer               *time.Timer
+	pendingProgress     *Stats
+	delayProgressReport bool
+}
+
+// NewDelayingProgressReporter returns a new progress reporter with the given function and the configured period. A
+// period of `0` will lead to immediate reports as soon as flow tasks are completed.
+func NewDelayingProgressReporter(reporterFn ProgressReporterFn, period time.Duration) ProgressReporter {
+	return &progressReporterDelaying{
+		reporterFn: reporterFn,
+		period:     period,
+	}
+}
+
+func (p *progressReporterDelaying) Start(ctx context.Context) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.timer != nil {
+		return fmt.Errorf("progress reporter has already been started")
+	}
+
+	// We store the context on the progressReporterDelaying object so that we can call the reporterFn with the original
+	// context - otherwise, the final state cannot be reported because the cancel context will already be canceled
+	p.ctx = ctx
+
+	if p.period > 0 {
+		p.timer = time.NewTimer(p.period)
+
+		ctx, cancel := context.WithCancel(ctx)
+		p.ctxCancel = cancel
+
+		go p.run(ctx)
+	}
+
+	return nil
+}
+
+func (p *progressReporterDelaying) Stop() {
+	p.lock.Lock()
+
+	if p.ctxCancel != nil {
+		p.ctxCancel()
+	}
+
+	p.ctxCancel = nil
+	p.timer = nil
+	p.lock.Unlock()
+	p.report()
+}
+
+func (p *progressReporterDelaying) Report(_ context.Context, pendingProgress *Stats) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.timer != nil && p.delayProgressReport {
+		p.pendingProgress = pendingProgress
+		return
+	}
+
+	p.reporterFn(p.ctx, pendingProgress)
+	p.delayProgressReport = true
+}
+
+func (p *progressReporterDelaying) run(ctx context.Context) {
+	timer := p.timer
+	for timer != nil {
+		select {
+		case <-timer.C:
+			timer.Reset(p.period)
+			p.report()
+
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func (p *progressReporterDelaying) report() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.pendingProgress != nil {
+		p.reporterFn(p.ctx, p.pendingProgress)
+		p.pendingProgress = nil
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_immediate.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_immediate.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+)
+
+type progressReporterImmediate struct {
+	reporterFn ProgressReporterFn
+}
+
+// NewImmediateProgressReporter returns a new progress reporter with the given function.
+func NewImmediateProgressReporter(reporterFn ProgressReporterFn) ProgressReporter {
+	return progressReporterImmediate{
+		reporterFn: reporterFn,
+	}
+}
+
+func (p progressReporterImmediate) Start(context.Context) error { return nil }
+func (p progressReporterImmediate) Stop()                       {}
+func (p progressReporterImmediate) Report(ctx context.Context, stats *Stats) {
+	p.reporterFn(ctx, stats)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
@@ -341,10 +341,10 @@ func CheckAPIServerAvailability(condition gardencorev1beta1.Condition, restClien
 		} else {
 			body = string(bodyRaw)
 		}
-		message := fmt.Sprintf("API server /healthz endpoint endpoint check returned a non ok status code %d. %s (%s)", statusCode, responseDurationText, body)
+		message := fmt.Sprintf("API server /healthz endpoint check returned a non ok status code %d. (%s)", statusCode, body)
 		return conditioner("HealthzRequestError", message)
 	}
 
-	message := fmt.Sprintf("API server /healthz endpoint responded with success status code. %s", responseDurationText)
+	message := "API server /healthz endpoint responded with success status code."
 	return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, "HealthzRequestSucceeded", message)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v1.10.0
+# github.com/gardener/gardener v1.10.2
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
Vendor gardener/gardener@v1.10.2

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator github.com/gardener/gardener #2909 @rfranzke
Machines without `.spec.providerID` or `.status.node` will no longer be persisted in the `Worker`' `.status.state` field. This is to prevent unnecessary updates to the `ShootState` resources.
```
