### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,17 +11,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.17.9"
+  tag: "v1.17.13"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.18.6"
+  tag: "v1.18.10"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.19.0"
+  tag: "v1.19.3"
   targetVersion: ">= 1.19"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cloud-provider-azure $9e40e1f9388dbf4ee36651c91e7f6f782d66a1dc
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.13`.
```

``` improvement operator github.com/gardener/cloud-provider-azure $e9839413ee92ac7aefc7a3d5724136623f5f7174
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.10`.
```

``` improvement operator github.com/gardener/cloud-provider-azure $4d966972ea8d5678342e4c1e064f9ad450d0f42b
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.3`.
```