### PR TITLE
Introduce Azure client factory and refactor backup controllers

### DIFF
--- a/pkg/azure/client/factory.go
+++ b/pkg/azure/client/factory.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
+
+	azureresources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	azurestorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewAzureClientFactory returns a new factory to produce clients for various Azure services.
+func NewAzureClientFactory(client client.Client) Factory {
+	return AzureFactory{
+		client: client,
+	}
+}
+
+// Group reads the secret from the passed reference and return an Azure resource group client.
+func (f AzureFactory) Group(ctx context.Context, secretRef corev1.SecretReference) (Group, error) {
+	authorizer, subscriptionID, err := internal.GetAuthorizerAndSubscriptionID(ctx, f.client, secretRef)
+	if err != nil {
+		return nil, err
+	}
+	groupClient := azureresources.NewGroupsClient(subscriptionID)
+	groupClient.Authorizer = authorizer
+
+	return GroupClient{
+		client: groupClient,
+	}, nil
+}
+
+// Storage reads the secret from the passed reference and return an Azure (blob) storage client.
+func (f AzureFactory) Storage(ctx context.Context, secretRef corev1.SecretReference) (Storage, error) {
+	serviceURL, err := newStorageClient(ctx, f.client, &secretRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return StorageClient{
+		serviceURL: serviceURL,
+	}, nil
+}
+
+// StorageAccount reads the secret from the passed reference and return an Azure storage account client.
+func (f AzureFactory) StorageAccount(ctx context.Context, secretRef corev1.SecretReference) (StorageAccount, error) {
+	authorizer, subscriptionID, err := internal.GetAuthorizerAndSubscriptionID(ctx, f.client, secretRef)
+	if err != nil {
+		return nil, err
+	}
+	storageAccountClient := azurestorage.NewAccountsClient(subscriptionID)
+	storageAccountClient.Authorizer = authorizer
+
+	return StorageAccountClient{
+		client: storageAccountClient,
+	}, nil
+}

--- a/pkg/azure/client/group.go
+++ b/pkg/azure/client/group.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+)
+
+// CreateOrUpdate creates a resource group or update an existing resource group.
+func (c GroupClient) CreateOrUpdate(ctx context.Context, resourceGroupName, region string) error {
+	if _, err := c.client.CreateOrUpdate(ctx, resourceGroupName, resources.Group{
+		Location: &region,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteIfExits deletes a resource group if it exits.
+func (c GroupClient) DeleteIfExits(ctx context.Context, resourceGroupName string) error {
+	_, err := c.client.Delete(ctx, resourceGroupName)
+	if err != nil && internal.AzureAPIErrorNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/azure/client/storage.go
+++ b/pkg/azure/client/storage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,161 +20,24 @@ import (
 	"net/url"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
-	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NewStorageClientAuthFromSubscriptionSecretRef retrieves the azure storage client auth from specified by the secret reference.
-func NewStorageClientAuthFromSubscriptionSecretRef(ctx context.Context, c client.Client, secretRef *corev1.SecretReference, resourceGroupName, accountName, region string) (*StorageAuth, error) {
-	// Reference : https://github.com/Azure-Samples/azure-sdk-for-go-samples/blob/master/storage/account.go
-	clientAuth, err := internal.GetClientAuthData(ctx, c, *secretRef)
-	if err != nil {
-		return nil, err
-	}
-
-	groupsClient := resources.NewGroupsClient(clientAuth.SubscriptionID)
-	clientCredConfig := auth.NewClientCredentialsConfig(clientAuth.ClientID, clientAuth.ClientSecret, clientAuth.TenantID)
-	authorizer, err := clientCredConfig.Authorizer()
-	if err != nil {
-		return nil, err
-	}
-	groupsClient.Authorizer = authorizer
-	if _, err := groupsClient.CreateOrUpdate(ctx, resourceGroupName, resources.Group{
-		Location: &region,
-	}); err != nil {
-		return nil, err
-	}
-
-	storageAccountClient := storage.NewAccountsClient(clientAuth.SubscriptionID)
-	storageAccountClient.Authorizer = authorizer
-	future, err := storageAccountClient.Create(ctx, resourceGroupName, accountName, storage.AccountCreateParameters{
-		Sku: &storage.Sku{
-			Name: storage.StandardLRS,
-		},
-		Kind:     storage.BlobStorage,
-		Location: &region,
-		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
-			AccessTier:             storage.Cool,
-			EnableHTTPSTrafficOnly: pointer.BoolPtr(true),
-			AllowBlobPublicAccess:  pointer.BoolPtr(false),
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if err := future.WaitForCompletionRef(ctx, storageAccountClient.Client); err != nil {
-		return nil, err
-	}
-
-	keysResponse, err := storageAccountClient.ListKeys(ctx, resourceGroupName, accountName, storage.Kerb)
-	if err != nil {
-		return nil, err
-	}
-
-	key := (*keysResponse.Keys)[0]
-
-	return &StorageAuth{
-		StorageAccount: []byte(accountName),
-		StorageKey:     []byte(*key.Value),
-	}, nil
-}
-
-// DeleteResourceGroupFromSubscriptionSecretRef deletes the resource group using subscription details from secretRef .
-func DeleteResourceGroupFromSubscriptionSecretRef(ctx context.Context, c client.Client, secretRef *corev1.SecretReference, resourceGroupName string) error {
-	clientAuth, err := internal.GetClientAuthData(ctx, c, *secretRef)
-	if err != nil {
-		return err
-	}
-
-	groupsClient := resources.NewGroupsClient(clientAuth.SubscriptionID)
-	clientCredConfig := auth.NewClientCredentialsConfig(clientAuth.ClientID, clientAuth.ClientSecret, clientAuth.TenantID)
-	authorizer, err := clientCredConfig.Authorizer()
-	if err != nil {
-		return err
-	}
-	groupsClient.Authorizer = authorizer
-
-	_, err = groupsClient.Delete(ctx, resourceGroupName)
-	return err
-}
-
-// NewStorageClientFromSecretRef retrieves the azure client from specified by the secret reference.
-func NewStorageClientFromSecretRef(ctx context.Context, c client.Client, secretRef *corev1.SecretReference) (*StorageClient, error) {
-	secret, err := extensionscontroller.GetSecretByReference(ctx, c, secretRef)
-	if err != nil {
-		return nil, err
-	}
-
-	storageAuth, err := ReadStorageClientAuthDataFromSecret(secret)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewStorageClientFromStorageAuth(storageAuth)
-}
-
-// ReadStorageClientAuthDataFromSecret reads the storage client auth details from the given secret.
-func ReadStorageClientAuthDataFromSecret(secret *corev1.Secret) (*StorageAuth, error) {
-	storageAccount, ok := secret.Data[azure.StorageAccount]
-	if !ok {
-		return nil, fmt.Errorf("secret %s/%s doesn't have a storage account", secret.Namespace, secret.Name)
-	}
-
-	storageKey, ok := secret.Data[azure.StorageKey]
-	if !ok {
-		return nil, fmt.Errorf("secret %s/%s doesn't have a storage key", secret.Namespace, secret.Name)
-	}
-
-	return &StorageAuth{
-		StorageAccount: storageAccount,
-		StorageKey:     storageKey,
-	}, nil
-}
-
-// NewStorageClientFromStorageAuth create the storage client from storage auth.
-func NewStorageClientFromStorageAuth(storageAuth *StorageAuth) (*StorageClient, error) {
-	credentials, err := azblob.NewSharedKeyCredential(string(storageAuth.StorageAccount), string(storageAuth.StorageKey))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create shared key credentials: %v", err)
-	}
-
-	p := azblob.NewPipeline(credentials, azblob.PipelineOptions{
-		Retry: azblob.RetryOptions{
-			Policy: azblob.RetryPolicyExponential,
-		},
-	})
-
-	u, err := url.Parse(fmt.Sprintf("https://%s.%s", storageAuth.StorageAccount, azure.AzureBlobStorageHostName))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse service url: %v", err)
-	}
-
-	serviceURL := azblob.NewServiceURL(*u, p)
-
-	return &StorageClient{
-		serviceURL: serviceURL,
-	}, nil
-}
-
-// DeleteObjectsWithPrefix deletes the blob objects with the specific <prefix> from <container>. If it does not exist,
-// no error is returned.
-func (c *StorageClient) DeleteObjectsWithPrefix(ctx context.Context, container, prefix string) error {
-	containerURL := c.serviceURL.NewContainerURL(container)
+// DeleteObjectsWithPrefix deletes the blob objects with the specific <prefix> from <container>.
+// If it does not exist, no error is returned.
+func (c StorageClient) DeleteObjectsWithPrefix(ctx context.Context, container, prefix string) error {
+	var containerURL = c.serviceURL.NewContainerURL(container)
 	opts := azblob.ListBlobsSegmentOptions{
 		Details: azblob.BlobListingDetails{
 			Deleted: true,
 		},
 		Prefix: prefix,
 	}
+
 	for marker := (azblob.Marker{}); marker.NotDone(); {
 		// Get a result segment starting with the blob indicated by the current Marker.
 		listBlob, err := containerURL.ListBlobsFlatSegment(ctx, marker, opts)
@@ -193,9 +56,9 @@ func (c *StorageClient) DeleteObjectsWithPrefix(ctx context.Context, container, 
 	return nil
 }
 
-// deleteBlobIfExists deletes the azure blob with name <blobName> from <container>. If it does not exist,
-// no error is returned.
-func (c *StorageClient) deleteBlobIfExists(ctx context.Context, container, blobName string) error {
+// deleteBlobIfExists deletes the azure blob with name <blobName> from <container>.
+// If it does not exist,no error is returned.
+func (c StorageClient) deleteBlobIfExists(ctx context.Context, container, blobName string) error {
 	blockBlobURL := c.serviceURL.NewContainerURL(container).NewBlockBlobURL(blobName)
 	if _, err := blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{}); err != nil {
 		if stgErr, ok := err.(azblob.StorageError); ok {
@@ -209,9 +72,9 @@ func (c *StorageClient) deleteBlobIfExists(ctx context.Context, container, blobN
 	return nil
 }
 
-// CreateContainerIfNotExists creates the azure blob container with name <container>. If it already exist,
-// no error is returned.
-func (c *StorageClient) CreateContainerIfNotExists(ctx context.Context, container string) error {
+// CreateContainerIfNotExists creates the azure blob container with name <container>.
+// If it already exist,no error is returned.
+func (c StorageClient) CreateContainerIfNotExists(ctx context.Context, container string) error {
 	containerURL := c.serviceURL.NewContainerURL(container)
 	if _, err := containerURL.Create(ctx, nil, azblob.PublicAccessNone); err != nil {
 		if stgErr, ok := err.(azblob.StorageError); ok {
@@ -225,9 +88,9 @@ func (c *StorageClient) CreateContainerIfNotExists(ctx context.Context, containe
 	return nil
 }
 
-// DeleteContainerIfExists deletes the azure blob container with name <container>. If it does not exist,
-// no error is returned.
-func (c *StorageClient) DeleteContainerIfExists(ctx context.Context, container string) error {
+// DeleteContainerIfExists deletes the azure blob container with name <container>.
+// If it does not exist, no error is returned.
+func (c StorageClient) DeleteContainerIfExists(ctx context.Context, container string) error {
 	containerURL := c.serviceURL.NewContainerURL(container)
 	if _, err := containerURL.Delete(ctx, azblob.ContainerAccessConditions{}); err != nil {
 		if stgErr, ok := err.(azblob.StorageError); ok {
@@ -241,4 +104,41 @@ func (c *StorageClient) DeleteContainerIfExists(ctx context.Context, container s
 		return err
 	}
 	return nil
+}
+
+// newStorageClient creates a client for an Azure Blob storage by reading auth information from secret reference.
+func newStorageClient(ctx context.Context, client client.Client, secretRef *corev1.SecretReference) (*azblob.ServiceURL, error) {
+	secret, err := extensionscontroller.GetSecretByReference(ctx, client, secretRef)
+	if err != nil {
+		return nil, err
+	}
+
+	storageAccountName, ok := secret.Data[azure.StorageAccount]
+	if !ok {
+		return nil, fmt.Errorf("secret %s/%s doesn't have a storage account", secret.Namespace, secret.Name)
+	}
+
+	storageAccountKey, ok := secret.Data[azure.StorageKey]
+	if !ok {
+		return nil, fmt.Errorf("secret %s/%s doesn't have a storage key", secret.Namespace, secret.Name)
+	}
+
+	credentials, err := azblob.NewSharedKeyCredential(string(storageAccountName), string(storageAccountKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create shared key credentials: %v", err)
+	}
+
+	pipeline := azblob.NewPipeline(credentials, azblob.PipelineOptions{
+		Retry: azblob.RetryOptions{
+			Policy: azblob.RetryPolicyExponential,
+		},
+	})
+
+	storageAccountURL, err := url.Parse(fmt.Sprintf("https://%s.%s", storageAccountName, azure.AzureBlobStorageHostName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse service url: %v", err)
+	}
+
+	serviceURL := azblob.NewServiceURL(*storageAccountURL, pipeline)
+	return &serviceURL, nil
 }

--- a/pkg/azure/client/storageaccount.go
+++ b/pkg/azure/client/storageaccount.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	"k8s.io/utils/pointer"
+)
+
+// CreateStorageAccount creates a storage account.
+func (c StorageAccountClient) CreateStorageAccount(ctx context.Context, resourceGroupName, storageAccountName, region string) error {
+	future, err := c.client.Create(ctx, resourceGroupName, storageAccountName, storage.AccountCreateParameters{
+		Kind:     storage.BlobStorage,
+		Location: &region,
+		Sku: &storage.Sku{
+			Name: storage.StandardLRS,
+		},
+		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
+			AccessTier:             storage.Cool,
+			EnableHTTPSTrafficOnly: pointer.BoolPtr(true),
+			AllowBlobPublicAccess:  pointer.BoolPtr(false),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.client.Client)
+}
+
+// ListStorageAccountKey lists the first key of a storage account.
+func (c StorageAccountClient) ListStorageAccountKey(ctx context.Context, resourceGroupName, storageAccountName string) (string, error) {
+	response, err := c.client.ListKeys(ctx, resourceGroupName, storageAccountName, storage.Kerb)
+	if err != nil {
+		return "", err
+	}
+
+	if len(*response.Keys) < 1 {
+		return "", fmt.Errorf("could not list keys as less then one key exists for storage account %s", storageAccountName)
+	}
+
+	firstKey := (*response.Keys)[0]
+	return *firstKey.Value, nil
+}

--- a/pkg/controller/backupbucket/backupbucket.go
+++ b/pkg/controller/backupbucket/backupbucket.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket
+
+import (
+	"context"
+	"fmt"
+
+	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ensureBackupBucket(ctx context.Context, client client.Client, factory azureclient.Factory, backupBucket *extensionsv1alpha1.BackupBucket) (string, string, error) {
+	var (
+		backupBucketNameSha = utils.ComputeSHA1Hex([]byte(backupBucket.Name))
+		storageAccountName  = fmt.Sprintf("bkp%s", backupBucketNameSha[:15])
+	)
+
+	// Get resource group client to ensure resource group to host backup storage account exists.
+	groupClient, err := factory.Group(ctx, backupBucket.Spec.SecretRef)
+	if err != nil {
+		return "", "", err
+	}
+	if err := groupClient.CreateOrUpdate(ctx, backupBucket.Name, backupBucket.Spec.Region); err != nil {
+		return "", "", err
+	}
+
+	// Get storage account client to create the backup storage account.
+	storageAccountClient, err := factory.StorageAccount(ctx, backupBucket.Spec.SecretRef)
+	if err != nil {
+		return "", "", err
+	}
+	if err := storageAccountClient.CreateStorageAccount(ctx, backupBucket.Name, storageAccountName, backupBucket.Spec.Region); err != nil {
+		return "", "", err
+	}
+
+	// Get the key of the storage account.
+	storageAccountKey, err := storageAccountClient.ListStorageAccountKey(ctx, backupBucket.Name, storageAccountName)
+	if err != nil {
+		return "", "", err
+	}
+
+	return storageAccountName, storageAccountKey, nil
+}

--- a/pkg/controller/backupbucket/secret.go
+++ b/pkg/controller/backupbucket/secret.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+
+	extensioncontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (a *actuator) createBackupBucketGeneratedSecret(ctx context.Context, backupBucket *extensionsv1alpha1.BackupBucket, storageAccountName, storageKey string) error {
+	var generatedSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("generated-bucket-%s", backupBucket.Name),
+			Namespace: "garden",
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, a.client, generatedSecret, func() error {
+		generatedSecret.Data = map[string][]byte{
+			azure.StorageAccount: []byte(storageAccountName),
+			azure.StorageKey:     []byte(storageKey),
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return extensioncontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, backupBucket, func() error {
+		backupBucket.Status.GeneratedSecretRef = &corev1.SecretReference{
+			Name:      generatedSecret.Name,
+			Namespace: generatedSecret.Namespace,
+		}
+		return nil
+	})
+}
+
+// deleteBackupBucketGeneratedSecret deletes generated secret referred by core BackupBucket resource in garden.
+func (a *actuator) deleteBackupBucketGeneratedSecret(ctx context.Context, backupBucket *extensionsv1alpha1.BackupBucket) error {
+	if backupBucket.Status.GeneratedSecretRef == nil {
+		return nil
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backupBucket.Status.GeneratedSecretRef.Name,
+			Namespace: backupBucket.Status.GeneratedSecretRef.Namespace,
+		},
+	}
+	return k8sclient.IgnoreNotFound(a.client.Delete(ctx, secret))
+}

--- a/pkg/controller/backupentry/actuator.go
+++ b/pkg/controller/backupentry/actuator.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
-	"github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator"
 
+	"github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,11 +46,12 @@ func (a *actuator) GetETCDSecretData(ctx context.Context, be *extensionsv1alpha1
 	return backupSecretData, nil
 }
 
-func (a *actuator) Delete(ctx context.Context, be *extensionsv1alpha1.BackupEntry) error {
-	azureClient, err := azureclient.NewStorageClientFromSecretRef(ctx, a.client, &be.Spec.SecretRef)
+func (a *actuator) Delete(ctx context.Context, backupEntry *extensionsv1alpha1.BackupEntry) error {
+	factory := azureclient.NewAzureClientFactory(a.client)
+	storageClient, err := factory.Storage(ctx, backupEntry.Spec.SecretRef)
 	if err != nil {
 		return err
 	}
 
-	return azureClient.DeleteObjectsWithPrefix(ctx, be.Spec.BucketName, fmt.Sprintf("%s/", be.Name))
+	return storageClient.DeleteObjectsWithPrefix(ctx, backupEntry.Spec.BucketName, fmt.Sprintf("%s/", backupEntry.Name))
 }

--- a/pkg/internal/utils.go
+++ b/pkg/internal/utils.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// AzureAPIErrorNotFound tries to determine if an error is a resource not found error.
+func AzureAPIErrorNotFound(err error) bool {
+	switch e := err.(type) {
+	case autorest.DetailedError:
+		if e.Response != nil && e.Response.StatusCode == http.StatusNotFound {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/internal/utils_test.go
+++ b/pkg/internal/utils_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal_test
+
+import (
+	"errors"
+	"net/http"
+
+	. "github.com/gardener/gardener-extension-provider-azure/pkg/internal"
+
+	"github.com/Azure/go-autorest/autorest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", func() {
+	Describe("#AzureAPIErrorNotFound", func() {
+		var err error
+		BeforeEach(func() {
+			err = errors.New("error")
+		})
+
+		It("should return false as error is no detailed azure error", func() {
+			Expect(AzureAPIErrorNotFound(err)).To(BeFalse())
+		})
+
+		It("should return false as error is not a NotFound", func() {
+			detailedErr := autorest.DetailedError{
+				Original:   err,
+				StatusCode: http.StatusInternalServerError,
+			}
+			Expect(AzureAPIErrorNotFound(detailedErr)).To(BeFalse())
+		})
+
+		It("should return true as error is a NotFound", func() {
+			detailedErr := autorest.DetailedError{
+				Original: err,
+				Response: &http.Response{
+					StatusCode: http.StatusNotFound,
+				},
+				StatusCode: http.StatusNotFound,
+			}
+			Expect(AzureAPIErrorNotFound(detailedErr)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/priority normal
/platform azure

**What this PR does / why we need it**:
Introduce Azure client factory and refactor backup controllers
- Add a factory to produce clients for various Azure services
- Rafactor backup controller (BackupBucket and BackupEntry) to make use of the factory
- Apply some boy scout (restructuring, moving functionally to packages which use it only) on the backup controller (BackupBucket and BackupEntry) implementations
- Add util function to check if an Azure error is a NotFound 404
- Add auth function to return Azure authorizer and to return subscription id

Also preparation for an incoming vmo pr as it needs the factory.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The client management for various Azure services within the Azure provider extension has been harmonised by adding a factory to produce those clients.
```

/invite @kon-angelo 