### PR TITLE
Clean up the deletion of legacy cloud provider ConfigMaps

### DIFF
--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -72,7 +72,7 @@ const (
 	AllowUDPEgressName = "allow-udp-egress"
 	// CloudProviderConfigName is the name of the secret containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
-	// CloudProviderDiskConfigName is the name of the configmap containing the cloud provider config for disk/volume handling.
+	// CloudProviderDiskConfigName is the name of the secret containing the cloud provider config for disk/volume handling.
 	CloudProviderDiskConfigName = "cloud-provider-disk-config"
 	// CloudProviderConfigMapKey is the key storing the cloud provider config as value in the cloud provider configmap.
 	CloudProviderConfigMapKey = "cloudprovider.conf"

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -18,9 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	appsv1 "k8s.io/api/apps/v1"
-
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 
@@ -334,9 +331,6 @@ var _ = Describe("ValuesProvider", func() {
 
 		BeforeEach(func() {
 			c.EXPECT().Get(ctx, controlPlaneConfigSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(controlPlaneConfigSecret))
-			c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeAPIServer), &appsv1.Deployment{}).Return(nil)
-			c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: azure.CloudProviderConfigName, Namespace: namespace}}).Return(nil)
-			c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: azure.CloudProviderDiskConfigName, Namespace: namespace}}).Return(nil)
 		})
 
 		It("should return correct control plane chart values (k8s < 1.20)", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal
/platform azure

**What this PR does / why we need it**:
Follow up on https://github.com/gardener/gardener-extension-provider-azure/pull/99.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
In v1.9.0 gardener-extension-provider-azure switched the kind for `cloud-provider-config` and `cloud-provider-disk-config` in the Shoot control plane from ConfigMap to Secret (ref https://github.com/gardener/gardener-extension-provider-azure/pull/99). In this version of gardener-extension-provider-azure the corresponding cleanup and graceful migration logic related to this switch is removed. Before upgrading to this version of gardener-extension-provider-azure, make sure that you have first upgraded to v1.9.0 or newer version and the kind for `cloud-provider-config` and `cloud-provider-disk-config` is migrated to Secret.
```
