### PR TITLE
Upgrade TF azurerm v2 and NatGateway pubIP migration

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v1.4.0"
+  tag: "v1.5.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes

--- a/charts/internal/azure-infra/values.yaml
+++ b/charts/internal/azure-infra/values.yaml
@@ -15,6 +15,11 @@ create:
   # name: identity-name
   # resourceGroup: identity-resource-group
 
+natGateway:
+  idleConnectionTimeoutMinutes:
+  # TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+  migrateNatGatewayToIPAssociation: false
+
 resourceGroup:
   name: my-resource-group
   vnet:
@@ -42,7 +47,3 @@ outputKeys:
   securityGroupName: securityGroupName
   # identityID: managedIdentityID
   # identityClientID: managedIdentityClientID
-
-natGateway:
-  idleConnectionTimeoutMinutes:
-

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -645,6 +645,19 @@ bool
 <p>Zoned indicates whether the cluster uses zones</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>natGatewayPublicIpMigrated</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NatGatewayPublicIPMigrated is an indicator if the Gardener managed public ip address is already migrated.
+TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="azure.provider.extensions.gardener.cloud/v1alpha1.MachineImage">MachineImage

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -70,6 +70,9 @@ type InfrastructureStatus struct {
 	Identity *IdentityStatus
 	// Zoned indicates whether the cluster uses zones
 	Zoned bool
+	// NatGatewayPublicIPMigrated is an indicator if the Gardener managed public ip address is already migrated.
+	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+	NatGatewayPublicIPMigrated bool
 }
 
 // NetworkStatus is the current status of the infrastructure networks.

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -78,6 +78,10 @@ type InfrastructureStatus struct {
 	// Zoned indicates whether the cluster uses zones
 	// +optional
 	Zoned bool `json:"zoned,omitempty"`
+	// NatGatewayPublicIPMigrated is an indicator if the Gardener managed public ip address is already migrated.
+	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+	// +optional
+	NatGatewayPublicIPMigrated bool `json:"natGatewayPublicIpMigrated,omitempty"`
 }
 
 // NetworkStatus is the current status of the infrastructure networks.

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -474,6 +474,7 @@ func autoConvert_v1alpha1_InfrastructureStatus_To_azure_InfrastructureStatus(in 
 	out.SecurityGroups = *(*[]azure.SecurityGroup)(unsafe.Pointer(&in.SecurityGroups))
 	out.Identity = (*azure.IdentityStatus)(unsafe.Pointer(in.Identity))
 	out.Zoned = in.Zoned
+	out.NatGatewayPublicIPMigrated = in.NatGatewayPublicIPMigrated
 	return nil
 }
 
@@ -494,6 +495,7 @@ func autoConvert_azure_InfrastructureStatus_To_v1alpha1_InfrastructureStatus(in 
 	out.SecurityGroups = *(*[]SecurityGroup)(unsafe.Pointer(&in.SecurityGroups))
 	out.Identity = (*IdentityStatus)(unsafe.Pointer(in.Identity))
 	out.Zoned = in.Zoned
+	out.NatGatewayPublicIPMigrated = in.NatGatewayPublicIPMigrated
 	return nil
 }
 

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -45,12 +45,7 @@ func NewActuator() infrastructure.Actuator {
 	}
 }
 
-func (a *actuator) updateProviderStatus(
-	ctx context.Context,
-	tf terraformer.Terraformer,
-	infra *extensionsv1alpha1.Infrastructure,
-	config *api.InfrastructureConfig,
-) error {
+func (a *actuator) updateProviderStatus(ctx context.Context, tf terraformer.Terraformer, infra *extensionsv1alpha1.Infrastructure, config *api.InfrastructureConfig) error {
 	status, err := infrainternal.ComputeStatus(tf, config)
 	if err != nil {
 		return err

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -140,6 +140,14 @@ func ComputeTerraformerChartValues(infra *extensionsv1alpha1.Infrastructure, cli
 		}
 	}
 
+	// Checks if the Gardener managed NatGateway public ip needs to be migrated.
+	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+	natGatewayIPMigrationRequired, err := isNatGatewayIPMigrationRequired(infra, config)
+	if err != nil {
+		return nil, err
+	}
+	natGatewayConfig["migrateNatGatewayToIPAssociation"] = natGatewayIPMigrationRequired
+
 	if config.Identity != nil && config.Identity.Name != "" && config.Identity.ResourceGroup != "" {
 		identityConfig = map[string]interface{}{
 			"name":          config.Identity.Name,
@@ -227,6 +235,9 @@ type TerraformState struct {
 	IdentityID string
 	// IdentityClientID is the client id of the identity.
 	IdentityClientID string
+	// NatGatewayIPMigrated is the indicator if the nat gateway ip is migrated.
+	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+	NatGatewayIPMigrated string
 }
 
 // ExtractTerraformState extracts the TerraformState from the given Terraformer.
@@ -289,6 +300,10 @@ func ExtractTerraformState(tf terraformer.Terraformer, config *api.Infrastructur
 		tfState.IdentityClientID = vars[TerraformerOutputKeyIdentityClientID]
 	}
 
+	if config.Networks.NatGateway != nil && config.Networks.NatGateway.Enabled {
+		tfState.NatGatewayIPMigrated = "true"
+	}
+
 	return &tfState, nil
 }
 
@@ -342,6 +357,11 @@ func StatusFromTerraformState(state *TerraformState) *apiv1alpha1.Infrastructure
 			CountUpdateDomains: pointer.Int32Ptr(int32(state.CountUpdateDomains)),
 			Purpose:            apiv1alpha1.PurposeNodes,
 		})
+	}
+
+	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+	if state.NatGatewayIPMigrated == "true" {
+		tfState.NatGatewayPublicIPMigrated = true
 	}
 
 	return &tfState
@@ -417,4 +437,26 @@ func findDomainCounts(cluster *controller.Cluster, infra *extensionsv1alpha1.Inf
 		faultDomains:  *faultDomainCount,
 		updateDomains: *updateDomainCount,
 	}, nil
+}
+
+// isNatGatewayIPMigrationRequired checks if the Gardener managed NatGateway public ip needs to be migrated.
+// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+func isNatGatewayIPMigrationRequired(infra *extensionsv1alpha1.Infrastructure, config *api.InfrastructureConfig) (bool, error) {
+	if config.Networks.NatGateway == nil || !config.Networks.NatGateway.Enabled {
+		return false, nil
+	}
+
+	if infra.Status.ProviderStatus == nil {
+		return false, nil
+	}
+
+	infrastructureStatus, err := helper.InfrastructureStatusFromInfrastructure(infra)
+	if err != nil {
+		return false, err
+	}
+
+	if infrastructureStatus.NatGatewayPublicIPMigrated {
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -21,7 +21,6 @@ import (
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 	"github.com/gardener/gardener/extensions/pkg/controller"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -178,7 +177,9 @@ var _ = Describe("Terraform", func() {
 				"securityGroupName": TerraformerOutputKeySecurityGroupName,
 			}
 
-			expectedNatGatewayValues = map[string]interface{}{}
+			expectedNatGatewayValues = map[string]interface{}{
+				"migrateNatGatewayToIPAssociation": false,
+			}
 
 			expectedValues = map[string]interface{}{
 				"azure":         expectedAzureValues,
@@ -329,6 +330,50 @@ var _ = Describe("Terraform", func() {
 				values, err := ComputeTerraformerChartValues(infra, clientAuth, config, cluster)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(values).To(BeEquivalentTo(expectedValues))
+			})
+
+			// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
+			Context("NatGateway Gardener managed IP migration", func() {
+				BeforeEach(func() {
+					config.Networks.NatGateway = &api.NatGatewayConfig{
+						Enabled: true,
+					}
+					expectedCreateValues["natGateway"] = true
+				})
+
+				It("should migrate the NatGateway IP as it is not yet migrated", func() {
+					infrastructureStatus := api.InfrastructureStatus{
+						NatGatewayPublicIPMigrated: false,
+					}
+					infrastructureStatusMarshalled, err := json.Marshal(infrastructureStatus)
+					Expect(err).NotTo(HaveOccurred())
+
+					infra.Status.ProviderStatus = &runtime.RawExtension{
+						Raw: infrastructureStatusMarshalled,
+					}
+
+					expectedNatGatewayValues["migrateNatGatewayToIPAssociation"] = true
+					values, err := ComputeTerraformerChartValues(infra, clientAuth, config, cluster)
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(values).To(BeEquivalentTo(expectedValues))
+				})
+
+				It("should not migrate the NatGateway IP as it is already migrated", func() {
+					infrastructureStatus := api.InfrastructureStatus{
+						NatGatewayPublicIPMigrated: true,
+					}
+					infrastructureStatusMarshalled, err := json.Marshal(infrastructureStatus)
+					Expect(err).NotTo(HaveOccurred())
+
+					infra.Status.ProviderStatus = &runtime.RawExtension{
+						Raw: infrastructureStatusMarshalled,
+					}
+
+					expectedNatGatewayValues["migrateNatGatewayToIPAssociation"] = false
+					values, err := ComputeTerraformerChartValues(infra, clientAuth, config, cluster)
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(values).To(BeEquivalentTo(expectedValues))
+				})
 			})
 		})
 	})

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -56,11 +56,7 @@ func TerraformerEnvVars(secretRef corev1.SecretReference) []corev1.EnvVar {
 }
 
 // NewTerraformer initializes a new Terraformer.
-func NewTerraformer(
-	restConfig *rest.Config,
-	purpose string,
-	infra *extensionsv1alpha1.Infrastructure,
-) (terraformer.Terraformer, error) {
+func NewTerraformer(restConfig *rest.Config, purpose string, infra *extensionsv1alpha1.Infrastructure) (terraformer.Terraformer, error) {
 	tf, err := terraformer.NewForConfig(logger.NewLogger("info"), restConfig, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage())
 	if err != nil {
 		return nil, err
@@ -73,11 +69,7 @@ func NewTerraformer(
 }
 
 // NewTerraformerWithAuth initializes a new Terraformer that has the azure auth credentials.
-func NewTerraformerWithAuth(
-	restConfig *rest.Config,
-	purpose string,
-	infra *extensionsv1alpha1.Infrastructure,
-) (terraformer.Terraformer, error) {
+func NewTerraformerWithAuth(restConfig *rest.Config, purpose string, infra *extensionsv1alpha1.Infrastructure) (terraformer.Terraformer, error) {
 	tf, err := NewTerraformer(restConfig, purpose, infra)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind technical-debt
/priority normal
/platform azure

**What this PR does / why we need it**:
This PR contains migration logic to switch the `azurerm` Terraform provider version from `v1.x.x` to version `v2.x.x` (major version change).

In detail the following changes in the Terraform are required:
- Add `features` field to the Terraform manifest
- Remove the route table and network security group references from the `azurerm_subnet` resource. There are meanwhile associations resources in place, but we need to keep the resource references before we can migrate. Before this migration can be applied all Shoots `Infrastructure` need to be reconciled by a Gardener Azure extension which contains this PR: https://github.com/gardener/gardener-extension-provider-azure/pull/161 (shipped with `v1.14.0`)
- The `azurerm_subnet` resource field `address_prefix` has been moved to `address_prefixes`
- Added the migration steps for the Gardener managed NAT IP [proposed](https://github.com/gardener/gardener-extension-provider-azure/pull/54#issuecomment-664593585) by @ialidzhikov. The `TODO(natipmigration)` changes can be removed in future release when all Shoot `Infrastructure` are reconciled with this change. These changes are required to unblock also https://github.com/gardener/gardener-extension-provider-azure/pull/54

This PR can only be merged when a new Terraformer with this PR https://github.com/gardener/terraformer/pull/54 is in.

**Special notes for your reviewer**:
Create an `Infrastructure` with NatGateway (with an Azure extension not including this PR and an `azurerm` tf provider of version `v1.x.x`). Then reconcile the existing `Infrastructure` an Azure extension which contains these changes.

This Terraformer image can be used for testing: `dominickistner/terraformer:azurerm-2360`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Gardener Azure provider extension is now using the `azurerm` Terraform provider in version `v2.x.x`
```

```action operator
Operators need to ensure that all Azure Shoot `Infrastructure` resource are reconciled with the Gardener Azure provider extension `v1.14.0` (contains a PR which is a prerequisite for this Terraform migration https://github.com/gardener/gardener-extension-provider-azure/pull/161) before applying this version. Please have a special look on hibernated clusters as their `Infrastructure` is might not reconciled for a while.
```

``` improvement operator github.com/gardener/terraformer #54 @dkistner
Terraformer uses now the azurerm provider in version v2.36.0
```

/invite @ialidzhikov 
/invite @kon-angelo 
