### PR TITLE
Bumped MCM version from 0.34.3 to 0.34.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,7 +26,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.34.3"
+  tag: "v0.34.4"
 
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression
/priority critical
/platform aws

**What this PR does / why we need it**:
This MCM hotfix fixes issues with drain where machines were being force drained due to a race condition.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/issues/563

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Fixes issues where machines were force deleted during normal deletion due to a race condition.
```

``` improvement operator github.com/gardener/machine-controller-manager #564 @prashanth26
Set Machine Phase to Terminating before draining.
```

``` noteworthy operator github.com/gardener/machine-controller-manager #564 @prashanth26
Machine force deletion computation is based on deletionTimestamp instead of LastUpdatedTimestamp.
```