### PR TITLE
Add health check for remedy-controller

### DIFF
--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -118,6 +118,8 @@ const (
 	MachineControllerManagerMonitoringConfigName = "machine-controller-manager-monitoring-config"
 	// RemedyControllerName is a constant for the name of the remedy-controller.
 	RemedyControllerName = "remedy-controller-azure"
+	// DisableRemedyControllerAnnotation disables the Azure remedy controller (enabled by default)
+	DisableRemedyControllerAnnotation = "azure.provider.extensions.gardener.cloud/disable-remedy-controller"
 )
 
 var (

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -47,11 +47,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	// disableRemedyControllerAnnotation disables the Azure remedy controller (enabled by default)
-	disableRemedyControllerAnnotation = "azure.provider.extensions.gardener.cloud/disable-remedy-controller"
-)
-
 // Object names
 
 var (
@@ -437,7 +432,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		cloudProviderDiskConfigChecksum = utils.ComputeChecksum(secret.Data)
 	}
 
-	disableRemedyController := cluster.Shoot.Annotations[disableRemedyControllerAnnotation] == "true"
+	disableRemedyController := cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] == "true"
 
 	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan120, disableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
 }
@@ -639,7 +634,7 @@ func getRemedyControllerChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
-	disableRemedyController := cluster.Shoot.Annotations[disableRemedyControllerAnnotation] == "true"
+	disableRemedyController := cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] == "true"
 	if disableRemedyController {
 		return map[string]interface{}{"enabled": false}, nil
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -392,7 +392,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		It("should return correct control plane chart values when remedy controller is disabled", func() {
 			cluster = generateCluster(cidr, k8sVersionLessThan120, false, map[string]string{
-				disableRemedyControllerAnnotation: "true",
+				azure.DisableRemedyControllerAnnotation: "true",
 			})
 
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
@@ -507,7 +507,7 @@ var _ = Describe("ValuesProvider", func() {
 		Context("remedy controller is disabled", func() {
 			BeforeEach(func() {
 				cluster = generateCluster(cidr, k8sVersionLessThan120, false, map[string]string{
-					disableRemedyControllerAnnotation: "true",
+					azure.DisableRemedyControllerAnnotation: "true",
 				})
 			})
 

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -54,6 +54,9 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 		}
 		return csiEnabled
 	}
+	remedyControllerPreCheckFunc := func(_ runtime.Object, cluster *extensionscontroller.Cluster) bool {
+		return cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] != "true"
+	}
 
 	if err := healthcheck.DefaultRegistration(
 		azure.Type,
@@ -77,6 +80,11 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
 				HealthCheck:   general.NewSeedDeploymentHealthChecker(azure.CSIControllerFileName),
 				PreCheckFunc:  csiEnabledPreCheckFunc,
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(azure.RemedyControllerName),
+				PreCheckFunc:  remedyControllerPreCheckFunc,
 			},
 			{
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),


### PR DESCRIPTION
Fixes #154


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
gardener-extension-provider-azure does now have a health check for the remedy-controller Deployment.
```
