### PR TITLE
Fix flag name for gen-provider-azure TestDefinition

### DIFF
--- a/.test-defs/provider-azure.yaml
+++ b/.test-defs/provider-azure.yaml
@@ -14,5 +14,5 @@ spec:
     --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
     --network-vnet-cidr=$NETWORK_VNET_CIDR
     --network-worker-cidr=$NETWORK_WORKER_CIDR
-    --zone=$ZONE
+    --zoned=$ZONED
   image: eu.gcr.io/gardener-project/3rd/golang:1.15.5

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gardener/gardener/extensions/test/tm/generator"
 	"github.com/pkg/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	infra := v1alpha1.InfrastructureConfig{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
 		},
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	cp := v1alpha1.ControlPlaneConfig{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
 		},


### PR DESCRIPTION
/kind bug

Currently trying to run the command from the TestDefinition fails with:

```
flag provided but not defined: -zone
Usage of /var/folders/p9/6dr9snnx6ws1dxkj4b66st6r0000gn/T/go-build621034547/b001/exe/generator:
  -controlplane-provider-config-filepath string
    	filepath to the provider specific controlplane config
  -infrastructure-provider-config-filepath string
    	filepath to the provider specific infrastructure config
  -network-vnet-cidr string
    	vnet network cidr
  -network-worker-cidr string
    	worker network cidr
  -zoned string
    	shoot uses multiple zones
exit status 2
```

Ref https://github.com/gardener/gardener-extension-provider-azure/pull/189

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The gen-provider-azure TestDefinition is now passing the correct flag to the generator.
```
