### PR TITLE
Postpone CSI migration to Kubernetes v1.21

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -244,10 +244,10 @@ spec:
 
 ## CSI volume provisioners
 
-Every Azure shoot cluster that has at least Kubernetes v1.20 will be deployed with the Azure Disk CSI driver and the Azure File CSI driver.
+Every Azure shoot cluster that has at least Kubernetes v1.21 will be deployed with the Azure Disk CSI driver and the Azure File CSI driver.
 Both are compatible with the legacy in-tree volume provisioners that were deprecated by the Kubernetes community and will be removed in future versions of Kubernetes.
 End-users might want to update their custom `StorageClass`es to the new `disk.csi.azure.com` or `file.csi.azure.com` provisioner, respectively.
-Shoot clusters with Kubernetes v1.19 or less will use the in-tree `kubernetes.io/azure-disk` and `kubernetes.io/azure-file` volume provisioners in the kube-controller-manager and the kubelet.
+Shoot clusters with Kubernetes v1.20 or less will use the in-tree `kubernetes.io/azure-disk` and `kubernetes.io/azure-file` volume provisioners in the kube-controller-manager and the kubelet.
 
 ## Miscellaneous
 

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -48,7 +48,7 @@ const (
 	MachineControllerManagerImageName = "machine-controller-manager"
 	// TerraformerImageName is the name of the Terraformer image.
 	TerraformerImageName = "terraformer"
-	// RemedyControllerName is the name of the remedy-controller image.
+	// RemedyControllerImageName is the name of the remedy-controller image.
 	RemedyControllerImageName = "remedy-controller-azure"
 
 	// SubscriptionIDKey is the key for the subscription ID.

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -418,7 +418,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		return nil, errors.Wrapf(err, "could not decode infrastructureProviderStatus of controlplane '%s'", kutil.ObjectName(cp))
 	}
 
-	k8sVersionLessThan120, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		cloudProviderDiskConfigChecksum string
 	)
 
-	if !k8sVersionLessThan120 {
+	if !k8sVersionLessThan121 {
 		secret := &corev1.Secret{}
 		if err := vp.Client().Get(ctx, kutil.Key(cp.Namespace, azure.CloudProviderDiskConfigName), secret); err != nil {
 			return nil, err
@@ -440,7 +440,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 
 	disableRemedyController := cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] == "true"
 
-	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan120, disableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
+	return getControlPlaneShootChartValues(cluster, infraStatus, k8sVersionLessThan121, disableRemedyController, cloudProviderDiskConfig, cloudProviderDiskConfigChecksum), nil
 }
 
 // GetStorageClassesChartValues returns the values for the storage classes chart applied by the generic actuator.
@@ -449,13 +449,13 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan120, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
 	if err != nil {
 		return nil, err
 	}
 
 	return map[string]interface{}{
-		"useLegacyProvisioner": k8sVersionLessThan120,
+		"useLegacyProvisioner": k8sVersionLessThan121,
 	}, nil
 }
 
@@ -605,12 +605,12 @@ func getCSIControllerChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan120, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
 	if err != nil {
 		return nil, err
 	}
 
-	if k8sVersionLessThan120 {
+	if k8sVersionLessThan121 {
 		return map[string]interface{}{"enabled": false}, nil
 	}
 
@@ -659,7 +659,7 @@ func getRemedyControllerChartValues(
 func getControlPlaneShootChartValues(
 	cluster *extensionscontroller.Cluster,
 	infraStatus *apisazure.InfrastructureStatus,
-	k8sVersionLessThan120 bool,
+	k8sVersionLessThan121 bool,
 	disableRemedyController bool,
 	cloudProviderDiskConfig string,
 	cloudProviderDiskConfigChecksum string,
@@ -668,7 +668,7 @@ func getControlPlaneShootChartValues(
 		azure.AllowUDPEgressName:         map[string]interface{}{"enabled": infraStatus.Zoned},
 		azure.CloudControllerManagerName: map[string]interface{}{"enabled": true},
 		azure.CSINodeName: map[string]interface{}{
-			"enabled":    !k8sVersionLessThan120,
+			"enabled":    !k8sVersionLessThan121,
 			"vpaEnabled": gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 			"podAnnotations": map[string]interface{}{
 				"checksum/configmap-" + azure.CloudProviderDiskConfigName: cloudProviderDiskConfigChecksum,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -103,8 +103,8 @@ var _ = Describe("ValuesProvider", func() {
 		cidr                    = "10.250.0.0/19"
 		cloudProviderConfigData = "foo"
 
-		k8sVersionLessThan120    = "1.13.4"
-		k8sVersionHigherEqual120 = "1.20.4"
+		k8sVersionLessThan121    = "1.13.4"
+		k8sVersionHigherEqual121 = "1.21.4"
 
 		enabledTrue  = map[string]interface{}{"enabled": true}
 		enabledFalse = map[string]interface{}{"enabled": false}
@@ -159,7 +159,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		infrastructureStatus = defaultInfrastructureStatus.DeepCopy()
 		controlPlaneConfig = defaultControlPlaneConfig.DeepCopy()
-		cluster = generateCluster(cidr, k8sVersionLessThan120, false, nil)
+		cluster = generateCluster(cidr, k8sVersionLessThan121, false, nil)
 	})
 
 	AfterEach(func() {
@@ -253,7 +253,7 @@ var _ = Describe("ValuesProvider", func() {
 					"availabilitySetName": primaryAvailabilitySetName,
 					"routeTableName":      "route-table-name",
 					"securityGroupName":   "security-group-name-workers",
-					"kubernetesVersion":   k8sVersionLessThan120,
+					"kubernetesVersion":   k8sVersionLessThan121,
 					"maxNodes":            maxNodes,
 				}))
 			})
@@ -275,7 +275,7 @@ var _ = Describe("ValuesProvider", func() {
 					"region":            "eu-west-1a",
 					"routeTableName":    "route-table-name",
 					"securityGroupName": "security-group-name-workers",
-					"kubernetesVersion": k8sVersionLessThan120,
+					"kubernetesVersion": k8sVersionLessThan121,
 					"maxNodes":          maxNodes,
 				}))
 			})
@@ -302,7 +302,7 @@ var _ = Describe("ValuesProvider", func() {
 					"region":              "eu-west-1a",
 					"routeTableName":      "route-table-name",
 					"securityGroupName":   "security-group-name-workers",
-					"kubernetesVersion":   k8sVersionLessThan120,
+					"kubernetesVersion":   k8sVersionLessThan121,
 					"acrIdentityClientId": identityName,
 					"maxNodes":            maxNodes,
 				}))
@@ -320,7 +320,7 @@ var _ = Describe("ValuesProvider", func() {
 			ccmChartValues = utils.MergeMaps(enabledTrue, map[string]interface{}{
 				"replicas":          1,
 				"clusterName":       namespace,
-				"kubernetesVersion": k8sVersionLessThan120,
+				"kubernetesVersion": k8sVersionLessThan121,
 				"podNetwork":        cidr,
 				"podAnnotations": map[string]interface{}{
 					"checksum/secret-cloud-controller-manager":        "3d791b164a808638da9a8df03924be2a41e34cd664e42231c00fe369e3588272",
@@ -342,7 +342,7 @@ var _ = Describe("ValuesProvider", func() {
 			c.EXPECT().Delete(context.TODO(), ccmMonitoringConfigmap).DoAndReturn(clientDeleteSuccess())
 		})
 
-		It("should return correct control plane chart values (k8s < 1.20)", func() {
+		It("should return correct control plane chart values (k8s < 1.21)", func() {
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 			values, err := vp.GetControlPlaneChartValues(ctx, cp, cluster, checksums, false)
 
@@ -362,8 +362,8 @@ var _ = Describe("ValuesProvider", func() {
 			}))
 		})
 
-		It("should return correct control plane chart values (k8s >= 1.20)", func() {
-			cluster = generateCluster(cidr, k8sVersionHigherEqual120, true, nil)
+		It("should return correct control plane chart values (k8s >= 1.21)", func() {
+			cluster = generateCluster(cidr, k8sVersionHigherEqual121, true, nil)
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 
 			values, err := vp.GetControlPlaneChartValues(ctx, cp, cluster, checksums, false)
@@ -400,7 +400,7 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should return correct control plane chart values when remedy controller is disabled", func() {
-			cluster = generateCluster(cidr, k8sVersionLessThan120, false, map[string]string{
+			cluster = generateCluster(cidr, k8sVersionLessThan121, false, map[string]string{
 				azure.DisableRemedyControllerAnnotation: "true",
 			})
 
@@ -436,7 +436,7 @@ var _ = Describe("ValuesProvider", func() {
 			})
 		)
 
-		Context("k8s < 1.20", func() {
+		Context("k8s < 1.21", func() {
 			It("should return correct control plane shoot chart values for zoned cluster", func() {
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 
@@ -466,7 +466,7 @@ var _ = Describe("ValuesProvider", func() {
 			})
 		})
 
-		Context("k8s >= 1.20", func() {
+		Context("k8s >= 1.21", func() {
 			var (
 				cpDiskConfigKey = client.ObjectKey{Namespace: namespace, Name: azure.CloudProviderDiskConfigName}
 				cpDiskConfig    = &corev1.Secret{
@@ -482,7 +482,7 @@ var _ = Describe("ValuesProvider", func() {
 
 			BeforeEach(func() {
 				c.EXPECT().Get(ctx, cpDiskConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpDiskConfig))
-				cluster = generateCluster(cidr, k8sVersionHigherEqual120, true, nil)
+				cluster = generateCluster(cidr, k8sVersionHigherEqual121, true, nil)
 			})
 
 			It("should return correct control plane shoot chart values for zoned cluster", func() {
@@ -515,7 +515,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		Context("remedy controller is disabled", func() {
 			BeforeEach(func() {
-				cluster = generateCluster(cidr, k8sVersionLessThan120, false, map[string]string{
+				cluster = generateCluster(cidr, k8sVersionLessThan121, false, map[string]string{
 					azure.DisableRemedyControllerAnnotation: "true",
 				})
 			})
@@ -550,15 +550,15 @@ var _ = Describe("ValuesProvider", func() {
 	})
 
 	Describe("#GetStorageClassesChartValues()", func() {
-		It("should return correct storage class chart values (k8s < 1.20)", func() {
+		It("should return correct storage class chart values (k8s < 1.21)", func() {
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 			values, err := vp.GetStorageClassesChartValues(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{"useLegacyProvisioner": true}))
 		})
 
-		It("should return correct storage class chart values (k8s >= 1.20)", func() {
-			cluster = generateCluster(cidr, k8sVersionHigherEqual120, true, nil)
+		It("should return correct storage class chart values (k8s >= 1.21)", func() {
+			cluster = generateCluster(cidr, k8sVersionHigherEqual121, true, nil)
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 			values, err := vp.GetStorageClassesChartValues(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/csimigration/add.go
+++ b/pkg/controller/csimigration/add.go
@@ -36,7 +36,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return csimigration.Add(mgr, csimigration.AddArgs{
 		ControllerOptions:             opts.Controller,
-		CSIMigrationKubernetesVersion: "1.20",
+		CSIMigrationKubernetesVersion: "1.21",
 		Type:                          azure.Type,
 		StorageClassNameToLegacyProvisioner: map[string]string{
 			"default":              "kubernetes.io/azure-disk",

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -48,7 +48,7 @@ var (
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g azure) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
 	csiEnabledPreCheckFunc := func(_ runtime.Object, cluster *extensionscontroller.Cluster) bool {
-		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.20")
+		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.21")
 		if err != nil {
 			return false
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	acrConfigPath       = "/var/lib/kubelet/acr.conf"
-	csiMigrationVersion = "1.20"
+	csiMigrationVersion = "1.21"
 )
 
 // NewEnsurer creates a new controlplane ensurer.

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -92,12 +92,12 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		eContextK8s120 = genericmutator.NewInternalEnsurerContext(
+		eContextK8s121 = genericmutator.NewInternalEnsurerContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.20.0",
+							Version: "1.21.0",
 						},
 					},
 					Status: gardencorev1beta1.ShootStatus{
@@ -106,7 +106,7 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		eContextK8s120WithCSIAnnotation = genericmutator.NewInternalEnsurerContext(
+		eContextK8s121WithCSIAnnotation = genericmutator.NewInternalEnsurerContext(
 			&extensionscontroller.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -116,7 +116,7 @@ var _ = Describe("Ensurer", func() {
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.20.0",
+							Version: "1.21.0",
 						},
 					},
 					Status: gardencorev1beta1.ShootStatus{
@@ -185,7 +185,7 @@ var _ = Describe("Ensurer", func() {
 			checkKubeAPIServerDeployment(dep, annotations, "1.16.0", false)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17, < 1.20)", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.17, < 1.21)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s117, dep, nil)
@@ -194,20 +194,20 @@ var _ = Describe("Ensurer", func() {
 			checkKubeAPIServerDeployment(dep, annotations, "1.17.4", false)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.20)", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.21)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s120, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s121, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, annotations, "1.20.0", false)
+			checkKubeAPIServerDeployment(dep, annotations, "1.21.0", false)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.20 w/ CSI annotation)", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.21 w/ CSI annotation)", func() {
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s121WithCSIAnnotation, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, nil, "1.20.0", true)
+			checkKubeAPIServerDeployment(dep, nil, "1.21.0", true)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -274,7 +274,7 @@ var _ = Describe("Ensurer", func() {
 			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.16.4", false)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17, k8s < 1.20)", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.17, k8s < 1.21)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s117, dep, nil)
@@ -283,17 +283,17 @@ var _ = Describe("Ensurer", func() {
 			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.17.8", false)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.20 w/o CSI annotation)", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.21 w/o CSI annotation)", func() {
 			c.EXPECT().Get(ctx, key, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s120, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s121, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.20.0", false)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.21.0", false)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.20 w/ CSI annotation)", func() {
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.21 w/ CSI annotation)", func() {
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s121WithCSIAnnotation, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkKubeControllerManagerDeployment(dep, nil, nil, "1.18.0", true)
@@ -356,25 +356,25 @@ var _ = Describe("Ensurer", func() {
 			ensurer = NewEnsurer(logger)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s < 1.20)", func() {
+		It("should add missing elements to kube-scheduler deployment (k8s < 1.21)", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s117, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkKubeSchedulerDeployment(dep, "1.17.0", false)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s >= 1.20 w/o CSI annotation)", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s120, dep, nil)
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.21 w/o CSI annotation)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s121, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.20.0", false)
+			checkKubeSchedulerDeployment(dep, "1.21.0", false)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s >= 1.20 w/ CSI annotation)", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.21 w/ CSI annotation)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s121WithCSIAnnotation, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.20.0", true)
+			checkKubeSchedulerDeployment(dep, "1.21.0", true)
 		})
 	})
 
@@ -396,7 +396,7 @@ var _ = Describe("Ensurer", func() {
 			}
 		})
 
-		It("should modify existing elements of kubelet.service unit options (k8s < 1.20)", func() {
+		It("should modify existing elements of kubelet.service unit options (k8s < 1.21)", func() {
 			newUnitOptions := []*unit.UnitOption{
 				{
 					Section: "Service",
@@ -415,7 +415,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(opts).To(Equal(newUnitOptions))
 		})
 
-		It("should modify existing elements of kubelet.service unit options and add acr config (k8s < 1.20)", func() {
+		It("should modify existing elements of kubelet.service unit options and add acr config (k8s < 1.21)", func() {
 			var (
 				acrCM = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderAcrConfigName},
@@ -441,7 +441,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(opts).To(Equal(newUnitOptions))
 		})
 
-		It("should modify existing elements of kubelet.service unit options (k8s >= 1.20)", func() {
+		It("should modify existing elements of kubelet.service unit options (k8s >= 1.21)", func() {
 			newUnitOptions := []*unit.UnitOption{
 				{
 					Section: "Service",
@@ -455,12 +455,12 @@ var _ = Describe("Ensurer", func() {
 
 			c.EXPECT().Get(ctx, acrCmKey, &corev1.ConfigMap{}).Return(apierrors.NewNotFound(schema.GroupResource{}, azure.CloudProviderAcrConfigName))
 
-			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s120, oldUnitOptions, nil)
+			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s121, oldUnitOptions, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(opts).To(Equal(newUnitOptions))
 		})
 
-		It("should modify existing elements of kubelet.service unit options and add acr config (k8s >= 1.20)", func() {
+		It("should modify existing elements of kubelet.service unit options and add acr config (k8s >= 1.21)", func() {
 			var (
 				acrCM = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderAcrConfigName},
@@ -481,7 +481,7 @@ var _ = Describe("Ensurer", func() {
 
 			c.EXPECT().Get(ctx, acrCmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(acrCM))
 
-			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s120, oldUnitOptions, nil)
+			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s121, oldUnitOptions, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(opts).To(Equal(newUnitOptions))
 		})
@@ -498,7 +498,7 @@ var _ = Describe("Ensurer", func() {
 			}
 		})
 
-		It("should modify existing elements of kubelet configuration (k8s < 1.20)", func() {
+		It("should modify existing elements of kubelet configuration (k8s < 1.21)", func() {
 			newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 				FeatureGates: map[string]bool{
 					"Foo": true,
@@ -511,7 +511,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 		})
 
-		It("should modify existing elements of kubelet configuration (k8s >= 1.20)", func() {
+		It("should modify existing elements of kubelet configuration (k8s >= 1.21)", func() {
 			newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 				FeatureGates: map[string]bool{
 					"Foo":                           true,
@@ -524,19 +524,19 @@ var _ = Describe("Ensurer", func() {
 			}
 			kubeletConfig := *oldKubeletConfig
 
-			err := ensurer.EnsureKubeletConfiguration(ctx, eContextK8s120, &kubeletConfig, nil)
+			err := ensurer.EnsureKubeletConfiguration(ctx, eContextK8s121, &kubeletConfig, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 		})
 	})
 
 	Describe("#ShouldProvisionKubeletCloudProviderConfig", func() {
-		It("should return true (k8s < 1.20)", func() {
+		It("should return true (k8s < 1.21)", func() {
 			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s117)).To(BeTrue())
 		})
 
-		It("should return false (k8s >= 1.20)", func() {
-			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s120)).To(BeFalse())
+		It("should return false (k8s >= 1.21)", func() {
+			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s121)).To(BeFalse())
 		})
 	})
 
@@ -579,7 +579,7 @@ var _ = Describe("Ensurer", func() {
 })
 
 func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
-	k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20")
+	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
 
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -594,7 +594,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 		Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 		Expect(c.VolumeMounts).To(ContainElement(cloudProviderConfigVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-		if k8sVersionAtLeast120 {
+		if k8sVersionAtLeast121 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true"))
 		}
 	} else {
@@ -611,7 +611,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 
 func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
 	k8sVersionLessThan117, _ := version.CompareVersions(k8sVersion, "<", "1.17")
-	k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20")
+	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
 
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -633,7 +633,7 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 			Expect(c.VolumeMounts).To(ContainElement(usrShareCaCertsVolumeMount))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(usrShareCaCertsVolume))
 		}
-		if k8sVersionAtLeast120 {
+		if k8sVersionAtLeast121 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true"))
 		}
 	} else {
@@ -652,7 +652,7 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 }
 
 func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
-	if k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20"); !k8sVersionAtLeast120 {
+	if k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21"); !k8sVersionAtLeast121 {
 		return
 	}
 


### PR DESCRIPTION

/kind enhancement
/priority normal
/platform azure

Ref https://github.com/gardener/gardener-extension-provider-azure/issues/3#issuecomment-737330926


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
CSI controllers / drivers are now deployed by default if the Kubernetes version is v1.21 or greater (not v1.20 as before). The reason for postponement is that the corresponding upstream feature `CSIMigrationAzureFile` is still alpha in Kubernetes v1.20 and its promotion to beta is pushed back to v1.21.
```
