### PR TITLE
Update remedy controller version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -68,4 +68,4 @@ images:
 - name: remedy-controller-azure
   sourceRepository: github.com/gardener/remedy-controller
   repository: eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure
-  tag: "v0.6.0"
+  tag: "v0.7.0"


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
Updates the remedy-controller version to 0.7.0. This version contains a fix for https://github.com/gardener/remedy-controller/issues/35. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user https://github.com/gardener/remedy-controller #36 @stoyanr 
Fixed a bug that caused the public IP address created by the CCM to be deleted by the remedy controller in some circumstances.
```
