### PR TITLE
[release-v1.15] Fix deleting controlplane with purpose exposure

### DIFF
--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -69,9 +69,11 @@ func (a *actuator) Delete(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) error {
-	// Delete all remaining remedy controller resources
-	if err := a.deleteRemedyControllerResources(ctx, cp); err != nil {
-		return err
+	if cp.Spec.Purpose == nil || *cp.Spec.Purpose == extensionsv1alpha1.Normal {
+		// Delete all remaining remedy controller resources
+		if err := a.deleteRemedyControllerResources(ctx, cp); err != nil {
+			return err
+		}
 	}
 
 	// Call Delete on the composed Actuator
@@ -86,9 +88,11 @@ func (a *actuator) Migrate(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) error {
-	// Delete all remaining remedy controller resources
-	if err := a.deleteRemedyControllerResources(ctx, cp); err != nil {
-		return err
+	if cp.Spec.Purpose == nil || *cp.Spec.Purpose == extensionsv1alpha1.Normal {
+		// Delete all remaining remedy controller resources
+		if err := a.deleteRemedyControllerResources(ctx, cp); err != nil {
+			return err
+		}
 	}
 
 	// Call Migrate on the composed Actuator


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug
/priority critical
/platform azure

**What this PR does / why we need it**:
Changes the logic in the controlplane actuator so that remedy controller resources are deleted only for `normal` controlplanes, but not for `exposure` ones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Cherry pick of #224 for `release-v1.15`.

**Release note**:

```other operator
Fixed a bug that caused reconciling hibernated shoots to fail if the `APIServerSNI` feature gate is enabled.
```
