### PR TITLE
[release-v1.15] Mitigate incorrect sigterm behaviour with Terraformer v2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v1.5.0"
+  tag: "v2.0.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -63,6 +63,8 @@ func NewTerraformer(restConfig *rest.Config, purpose string, infra *extensionsv1
 	}
 
 	return tf.
+		UseV2(true).
+		SetLogLevel("debug").
 		SetTerminationGracePeriodSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
 		SetDeadlinePod(15 * time.Minute), nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind regression
/priority critical
/platform azure

**What this PR does / why we need it**:
It seems that there are issues with sigterm handling in the upstream Terraform `azurerm` provider v2, which can lead to situations where the Terraform state is not persistent (e.g. the provider-azure pod which started the Terraformer pod lost leadership and a new provider-azure pod will then send a sigterm to the running Terraformer pod). In consequence subsequent Terraform runs will fail as resources already exists but not part of the Terraform state. 

We can mitigate the issue by introducing the Terraformer v2 which constantly write back the terraform state to the respective configmap and therefore prevent state leaks.

**Special notes for your reviewer**:
Cherry pick of #219 for `release-v1.15`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Mitigate an issue by introducing Terraformer v2 where Terraform state is leaked due to incorrect sigterm handling in the used tf `azurerm` provider.
```

/invite @ialidzhikov 
/invite @kon-angelo 
