### PR TITLE
update mcm to use worker secret ref. for the machine class credentialsSecretRef

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -12,10 +12,6 @@ metadata:
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}
-  azureClientId: {{ $machineClass.secret.clientID | b64enc }}
-  azureClientSecret: {{ $machineClass.secret.clientSecret | b64enc }}
-  azureSubscriptionId: {{ $machineClass.secret.subscriptionID | b64enc }}
-  azureTenantId: {{ $machineClass.secret.tenantID | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: AzureMachineClass
@@ -72,6 +68,9 @@ spec:
   secretRef:
     name: {{ $machineClass.name }}
     namespace: {{ $.Release.Namespace }}
+  credentialsSecretRef:
+    name: {{ $machineClass.credentialsSecretRef.name }}
+    namespace: {{ $machineClass.credentialsSecretRef.namespace }}
   subnetInfo:
     vnetName: {{ $machineClass.network.vnet }}
     {{- if hasKey $machineClass.network "vnetResourceGroup" }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -16,11 +16,10 @@ machineClasses:
     kubernetes.io-cluster-shoot-crazy-botany: "1"
     kubernetes.io-role-node: "1"
   secret:
-    clientID: ABCD
-    clientSecret: ABCD
-    subscriptionID: abc
-    tenantID: abc
     cloudConfig: abc
+  credentialsSecretRef:
+    name: cloudprovider
+    namespace: shoot-namespace
   machineType: Standard_DS1_V2
   image:
     urn: "CoreOS:CoreOS:Stable:1576.5.0"
@@ -41,11 +40,10 @@ machineClasses:
     kubernetes.io-cluster-shoot-crazy-botany: "1"
     kubernetes.io-role-node: "1"
   secret:
-    clientID: ABCD
-    clientSecret: ABCD
-    subscriptionID: abc
-    tenantID: abc
     cloudConfig: abc
+  credentialsSecretRef:
+    name: cloudprovider
+    namespace: shoot-namespace
   machineType: Standard_DS1_V2
   image:
     #urn: "CoreOS:CoreOS:Stable:1576.5.0"

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -76,10 +76,4 @@ func (w *workerDelegate) GetMachineControllerManagerShootChartValues(ctx context
 	return map[string]interface{}{
 		"providerName": azure.Name,
 	}, nil
-}
-
-// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
-// with the secret keys used by the machine-controller-manager.
-func (w *workerDelegate) GetMachineControllerManagerCloudCredentials(ctx context.Context) (map[string][]byte, error) {
-	return w.generateMachineClassSecretData(ctx)
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Machines", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
Uses the machine classes  .{spec.}credentialsSecretRef field. It is a reference to a secret containing only the credentials, while today's .{spec.}secretRef still contains the user-data. See [here for more details](https://github.com/gardener/machine-controller-manager/pull/578).

Uses the worker's secret reference as the credentialsSecretRef.
This means all worker pools use the same "cloudprovider" secret containing only the cloud provider credentials.
The existing MachineClass SecretReference then only contains the user data that is different for each pool. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reducing credential update complexity by all the machine classes using the new .{spec.}credentialsSecretRef field.
This means all worker pools use the same "cloudprovider" secret containing only the cloud provider credentials.
The existing MachineClass SecretReference only contains the user data that is different for each pool.
```
