### PR TITLE
Ensure the StorageAccount has MinimumTLSVersion set to TLS12

### DIFF
--- a/pkg/azure/client/storageaccount.go
+++ b/pkg/azure/client/storageaccount.go
@@ -34,6 +34,7 @@ func (c StorageAccountClient) CreateStorageAccount(ctx context.Context, resource
 			AccessTier:             storage.Cool,
 			EnableHTTPSTrafficOnly: pointer.BoolPtr(true),
 			AllowBlobPublicAccess:  pointer.BoolPtr(false),
+			MinimumTLSVersion:      storage.TLS12,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup security
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
Ensure the StorageAccount has MinimumTLSVersion set to TLS12

**Which issue(s) this PR fixes**:
Fixes #237 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The storage accounts created for the backups of the ETCDs are now ensured to have `MinimumTLSVersion` of TLS1.2.
```
