### PR TITLE
[release-v1.18] Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,7 +26,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.20.0"
+  tag: "v1.20.2"
   targetVersion: ">= 1.20"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
/kind bug

Cherry pick of #248 on release-v1.18.

#248: Upgrade github.com/gardener/cloud-provider-azure

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator github.com/gardener/cloud-provider-azure $d96fb8260b4c7bb17475bf7f3c3d6fe527bc8e2b
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.2`.
```
