### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,22 +11,22 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.17.15"
+  tag: "v1.17.17"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.18.13"
+  tag: "v1.18.17"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.19.5"
+  tag: "v1.19.9"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.20.2"
+  tag: "v1.20.5"
   targetVersion: ">= 1.20"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` other operator github.com/gardener/cloud-provider-azure $b35140c6e20cc9b134c7f1b67d43bd1f4ad4cfe9
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.17`.
```

``` other operator github.com/gardener/cloud-provider-azure $377c955e20e19ba5e23243969ad1b88065e05ba4
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.17`.
```

``` other operator github.com/gardener/cloud-provider-azure $4d262ccda31f86940d134c915d65036c6c01e423
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.9`.
```

``` other operator github.com/gardener/cloud-provider-azure $0bce3dfab963920cb9f0f5a45f4a045c1db4a96b
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.5`.
```