### PR TITLE
Deserialize custom resources with EnableStrict

### DIFF
--- a/pkg/admission/validator/cloudprofile.go
+++ b/pkg/admission/validator/cloudprofile.go
@@ -39,7 +39,7 @@ type cloudProfile struct {
 
 // InjectScheme injects the given scheme into the validator.
 func (cp *cloudProfile) InjectScheme(scheme *runtime.Scheme) error {
-	cp.decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
+	cp.decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 	return nil
 }
 

--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -43,7 +43,7 @@ func init() {
 	Scheme = runtime.NewScheme()
 	utilruntime.Must(install.AddToScheme(Scheme))
 
-	decoder = serializer.NewCodecFactory(Scheme).UniversalDecoder()
+	decoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDecoder()
 }
 
 // InfrastructureConfigFromInfrastructure extracts the InfrastructureConfig from the

--- a/pkg/controller/worker/utils_test.go
+++ b/pkg/controller/worker/utils_test.go
@@ -48,7 +48,7 @@ func wrapNewWorkerDelegate(client *mockclient.MockClient, seedChartApplier *mock
 	_ = apiazure.AddToScheme(scheme)
 	_ = v1alpha1.AddToScheme(scheme)
 
-	workerDelegate, err := NewWorkerDelegate(common.NewClientContext(client, scheme, serializer.NewCodecFactory(scheme).UniversalDecoder()), seedChartApplier, "", worker, cluster, factory)
+	workerDelegate, err := NewWorkerDelegate(common.NewClientContext(client, scheme, serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()), seedChartApplier, "", worker, cluster, factory)
 	Expect(err).NotTo(HaveOccurred())
 	return workerDelegate
 }

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Infrastructure tests", func() {
 
 		c = mgr.GetClient()
 		Expect(c).ToNot(BeNil())
-		decoder = serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder()
+		decoder = serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder()
 
 		authorizer, err := getAuthorizer(*tenantId, *clientId, *clientSecret)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority 3
/platform azure

**What this PR does / why we need it**:
Adds the `EnableStrict` option to all places where a codec factory is creation, to ensure that custom resources are always deserialized in "strict" mode. This means that resources with fields that are not allowed by the API schema will be rejected by validation and would not be processed by the controllers as well.

**Which issue(s) this PR fixes**:
Fixes #270

**Special notes for your reviewer**:

**Release note**:

```breaking user
Extension resources (`Infrastructure`, `ControlPlane`, etc.) are now deserialized in "strict" mode, including during validation by the validating webhook. This means that resources with fields that are not allowed by the API schema will be rejected by validation. Creating new shoots containing such resources will not be possible, and updating existing shoots will fail with an appropriate error until you manually update the shoot to make sure any extension resources contained in it are valid.
```
