### PR TITLE
Update kubernetes-csi/external-snapshotter

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -52,11 +52,11 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
-  tag: "v2.1.4"
+  tag: "v2.1.5"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/snapshot-controller
-  tag: "v2.1.4"
+  tag: "v2.1.5"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -43,32 +43,32 @@ images:
   tag: "v0.8.0"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
-  repository: quay.io/k8scsi/csi-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: "v1.6.0"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
-  repository: quay.io/k8scsi/csi-attacher
+  repository: k8s.gcr.io/sig-storage/csi-attacher
   tag: "v2.2.0"
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/csi-snapshotter
+  repository: k8s.gcr.io/sig-storage/csi-snapshotter
   tag: "v2.1.5"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/snapshot-controller
+  repository: k8s.gcr.io/sig-storage/snapshot-controller
   tag: "v2.1.5"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
-  repository: quay.io/k8scsi/csi-resizer
+  repository: k8s.gcr.io/sig-storage/csi-resizer
   tag: "v0.5.0"
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
-  repository: quay.io/k8scsi/csi-node-driver-registrar
+  repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
   tag: "v1.3.0"
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
-  repository: quay.io/k8scsi/livenessprobe
-  tag: "v2.0.0"
+  repository: k8s.gcr.io/sig-storage/livenessprobe
+  tag: "v2.2.0"
 
 - name: remedy-controller-azure
   sourceRepository: github.com/gardener/remedy-controller


### PR DESCRIPTION
/area storage
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following images are updated:
- k8s.gcr.io/sig-storage/csi-snapshotter: v2.1.4 -> v2.1.5
- k8s.gcr.io/sig-storage/snapshot-controller: v2.1.4 -> v2.1.5
- k8s.gcr.io/sig-storage/livenessprobe: v2.0.0 -> v2.2.0
```
