### PR TITLE
depend on publish-trait, rather on injected step(s)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -35,7 +35,7 @@ gardener-extension-provider-azure:
         test-integration:
           execute:
           - test-integration.sh
-          depends:
+          trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
prepare for switch to kaniko-builder