### PR TITLE
Configure TCP egress for shoots

### DIFF
--- a/charts/internal/shoot-system-components/charts/allow-egress/Chart.yaml
+++ b/charts/internal/shoot-system-components/charts/allow-egress/Chart.yaml
@@ -1,5 +1,5 @@
 # TODO (dkistner): remove this subchart once we have a proper implementation for UDP egress via NAT GW
 apiVersion: v1
-description: Helm chart for allow-udp-egress
-name: allow-udp-egress
+description: Helm chart for allow-egress
+name: allow-egress
 version: 0.1.0

--- a/charts/internal/shoot-system-components/charts/allow-egress/templates/allow-tcp-egress.yaml
+++ b/charts/internal/shoot-system-components/charts/allow-egress/templates/allow-tcp-egress.yaml
@@ -1,0 +1,25 @@
+# this is a technical service created to mitigate an issue with the TCP egress traffic for Shoots using
+# Azure Standard LoadBalancers (see https://github.com/gardener/gardener-extension-provider-azure/issues/1)
+apiVersion: v1
+kind: Service
+metadata:
+  name: allow-tcp-egress
+  namespace: kube-system
+  annotations:
+    azure.remedy.gardener.cloud/ignore: "true"
+    gardener.cloud/description: |
+      This is a technical Service created to mitigate an issue with the TCP egress traffic for Shoots using
+      Azure Standard LoadBalancers (see https://github.com/gardener/gardener-extension-provider-azure/issues/1).
+      It is needed because the Standard LoadBalancers will block all outgoing TCP traffic if there is not at least
+      one open TCP Port.
+  labels:
+    app: gardener
+    role: allow-tcp-egress
+spec:
+  ports:
+  - name: dummy
+    port: 1234
+    protocol: TCP
+    targetPort: 1234
+  selector: {} # select no Pods to not expose anything by accident
+  type: LoadBalancer

--- a/charts/internal/shoot-system-components/charts/allow-egress/templates/allow-udp-egress.yaml
+++ b/charts/internal/shoot-system-components/charts/allow-egress/templates/allow-udp-egress.yaml
@@ -11,8 +11,7 @@ metadata:
       This is a technical Service created to mitigate an issue with the UDP egress traffic for Shoots using
       Azure Standard LoadBalancers (see https://github.com/gardener/gardener-extension-provider-azure/issues/1).
       It is needed because the Standard LoadBalancers will block all outgoing UDP traffic if there is not at least
-      one open UDP Port. This is a temporary workaround and will be removed in a future version, once we have a
-      proper implemenation for UDP egress via an Azure NAT Gateway in place.
+      one open UDP Port.
   labels:
     app: gardener
     role: allow-udp-egress

--- a/charts/internal/shoot-system-components/requirements.yaml
+++ b/charts/internal/shoot-system-components/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
-- name: allow-udp-egress
+- name: allow-egress
   repository: http://localhost:10191
   version: 0.1.0
-  condition: allow-udp-egress.enabled
+  condition: allow-egress.enabled
 - name: cloud-controller-manager
   repository: http://localhost:10191
   version: 0.1.0

--- a/charts/internal/shoot-system-components/values.yaml
+++ b/charts/internal/shoot-system-components/values.yaml
@@ -1,4 +1,4 @@
-allow-udp-egress:
+allow-egress:
   enabled: false
 cloud-controller-manager:
   enabled: true

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -76,8 +76,8 @@ const (
 	// MachineSetTagKey is the name of the infrastructure resource tag for machine sets.
 	MachineSetTagKey = "machineset.azure.extensions.gardener.cloud"
 
-	// AllowUDPEgressName is the name of the service for allowing UDP egress traffic.
-	AllowUDPEgressName = "allow-udp-egress"
+	// AllowEgressName is the name of the service for allowing egress traffic.
+	AllowEgressName = "allow-egress"
 	// CloudProviderConfigName is the name of the secret containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
 	// CloudProviderDiskConfigName is the name of the secret containing the cloud provider config for disk/volume handling.

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -255,9 +255,10 @@ var (
 		Path: filepath.Join(azure.InternalChartsPath, "shoot-system-components"),
 		SubCharts: []*chart.Chart{
 			{
-				Name: "allow-udp-egress",
+				Name: "allow-egress",
 				Objects: []*chart.Object{
 					{Type: &corev1.Service{}, Name: "allow-udp-egress"},
+					{Type: &corev1.Service{}, Name: "allow-tcp-egress"},
 				},
 			},
 			{
@@ -699,7 +700,7 @@ func getControlPlaneShootChartValues(
 	cloudProviderDiskConfigChecksum string,
 ) map[string]interface{} {
 	return map[string]interface{}{
-		azure.AllowUDPEgressName:         map[string]interface{}{"enabled": infraStatus.Zoned},
+		azure.AllowEgressName:            map[string]interface{}{"enabled": infraStatus.Zoned},
 		azure.CloudControllerManagerName: map[string]interface{}{"enabled": true},
 		azure.CSINodeName: map[string]interface{}{
 			"enabled":    !k8sVersionLessThan121,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -452,7 +452,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					azure.AllowUDPEgressName:         enabledTrue,
+					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
 					azure.RemedyControllerName:       enabledTrue,
@@ -467,7 +467,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					azure.AllowUDPEgressName:         enabledFalse,
+					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
 					azure.RemedyControllerName:       enabledTrue,
@@ -499,7 +499,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					azure.AllowUDPEgressName:         enabledTrue,
+					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeEnabled,
 					azure.RemedyControllerName:       enabledTrue,
@@ -514,7 +514,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					azure.AllowUDPEgressName:         enabledFalse,
+					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeEnabled,
 					azure.RemedyControllerName:       enabledTrue,
@@ -534,7 +534,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					azure.AllowUDPEgressName:         enabledTrue,
+					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
 					azure.RemedyControllerName:       enabledFalse,
@@ -549,7 +549,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					azure.AllowUDPEgressName:         enabledFalse,
+					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
 					azure.RemedyControllerName:       enabledFalse,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
When using the reverse cluster vpn model, there is no vpn-shoot service anymore created in the shoot. As a result the Azure LB is not configured to allow egress for TCP traffic when **not** using any NAT Gateway. As a result the cluster can never be created (or never stay healthy), as the kubelet cannot reach the API server. 

This PR creates a dummy TCP LB service, similar to the allow-udp-egress, to circumvent the situation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A new service `allow-tcp-egress` is created in the shoot cluster to configure TCP egress traffic when using the `reversed cluster vpn` feature.
```
