### PR TITLE
Prepare PATH in prepare_release in advance

### DIFF
--- a/.ci/prepare_release
+++ b/.ci/prepare_release
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
+# update PATH in preparation for golang download by the prepare_release script
+export PATH=/usr/local/go/bin:$PATH
+
 "$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/prepare_release "$(dirname $0)"/.. github.com/gardener gardener-extension-provider-azure


### PR DESCRIPTION
The golang version installed by the vendored-in script is not found in path causing it to fall back to an older version.
As a fix/workaround, set PATH version in advance for now

