### PR TITLE
Fix volume fsType handling for CSI volumes

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
@@ -98,6 +98,7 @@ spec:
         - --kubeconfig=/var/lib/csi-provisioner/kubeconfig
         - --timeout=120s
         - --volume-name-prefix=pv-{{ .Release.Namespace }}
+        - --default-fstype=ext4
         - --v=5
         env:
         - name: ADDRESS


### PR DESCRIPTION
/area storage
/kind bug
/platform azure

Similar to https://github.com/gardener/gardener-extension-provider-openstack/pull/142

Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/298

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing CSI PV to do not have set `spec.csi.fsType` is now fixed. The csi-provisioner is now started with `--default-fstype=ext4` which is the default fstype to be used when there is no fstype specified in the StorageClass.
```
