### PR TITLE
Fix the ./.ci/prepare_release script

### DIFF
--- a/.ci/prepare_release
+++ b/.ci/prepare_release
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-# update PATH in preparation for golang download by the prepare_release script
-export PATH=/usr/local/go/bin:$PATH
-
-"$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/prepare_release "$(dirname $0)"/.. github.com/gardener gardener-extension-provider-azure
+"$(dirname $0)"/../hack/.ci/prepare_release "$(dirname $0)"/.. github.com/gardener gardener-extension-provider-azure

--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -1,0 +1,79 @@
+#!/usr/bin/env sh
+#
+# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+repo_root_dir="$1"
+repo_base="$2"
+repo_name="$3"
+
+apk update
+apk add --no-cache \
+    ca-certificates \
+    make \
+    bash \
+    go \
+    git \
+    musl-dev \
+    curl \
+    openssl \
+    tar \
+    gzip \
+    gcc \
+    sed
+
+GOLANG_VERSION="$(sed -rn 's/FROM (eu\.gcr\.io\/gardener-project\/3rd\/golang|golang):([^ ]+).*/\2/p' < "$repo_root_dir/Dockerfile")"
+
+export \
+    GOROOT="$(go env GOROOT)" \
+    GOOS="$(go env GOOS)" \
+    GOARCH="$(go env GOARCH)" \
+    GOHOSTOS="$(go env GOHOSTOS)" \
+    GOHOSTARCH="$(go env GOHOSTARCH)"
+
+echo "Downloading go $GOLANG_VERSION"
+wget -q -O - "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz" | tar zx -C /usr/local
+cd /usr/local/go/src
+echo "Executing make on go $GOLANG_VERSION"
+./make.bash > /dev/null 2>&1
+
+# Make the newly "installed from source" go the default one
+export PATH="/usr/local/go/bin:$PATH"
+export GOROOT="/usr/local/go"
+
+export GOPATH="$(mktemp -d)"
+export GOBIN="$GOPATH/bin"
+export PATH="$GOBIN:$PATH"
+
+REPO_BASE="$GOPATH/src/$repo_base"
+mkdir -p "$REPO_BASE"
+REPO_PATH="$REPO_BASE/$repo_name"
+cp -R "$repo_root_dir" "$REPO_PATH"
+
+current_dir="$(pwd)"
+cd "$REPO_PATH"
+make install-requirements
+cd "$current_dir"
+
+echo "$EFFECTIVE_VERSION" > "$REPO_PATH/VERSION"
+cur_dir="$(pwd)"
+cd "$REPO_PATH"
+if ! make generate; then
+  cd "$cur_dir"
+  exit 1
+fi
+cd "$cur_dir"
+cp -RT "$REPO_PATH/" "$repo_root_dir/"


### PR DESCRIPTION
/kind bug

This PR introduces local `./hack/.ci/prepare_release` with the following diff compared to `vendor/github.com/gardener/gardener/hack/.ci/prepare_release`:

```
$ colordiff vendor/github.com/gardener/gardener/hack/.ci/prepare_release ./hack/.ci/prepare_release
```

```diff
52a53,56
> # Make the newly "installed from source" go the default one
> export PATH="/usr/local/go/bin:$PATH"
> export GOROOT="/usr/local/go"
>
```

Part of https://github.com/gardener/gardener/issues/4055 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
