### PR TITLE
Keep the volumesnapshotclasses CRD on ControlPlane deletion

### DIFF
--- a/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshotclasses.yaml
+++ b/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshotclasses.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: volumesnapshotclasses.snapshot.storage.k8s.io
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
 spec:
   additionalPrinterColumns:
     - JSONPath: .driver


### PR DESCRIPTION
/kind bug
/platform azure

Currently the deletion of the `extension-controlplane-shoot-crds` ManagedResource is still racy. The volumesnapshotclasses CRD can be deleted before the deletion of volumesnapshot CRs (if there are any).

In this case the `csi-snapshot-controller` Pod fails with:
```
E0516 15:08:21.745368       1 reflector.go:156] github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117: Failed to list *v1beta1.VolumeSnapshotClass: the server could not find the requested resource (get volumesnapshotclasses.snapshot.storage.k8s.io)
```

This PR keeps the volumesnapshotclasses CRD on deletion of the `extension-controlplane-shoot-crds` ManagedResource.

Part of https://github.com/gardener/gardener/issues/2227

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
