### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -21,17 +21,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.19.9"
+  tag: "v1.19.11"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.20.5"
+  tag: "v1.20.7"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.21.0"
+  tag: "v1.21.1"
   targetVersion: ">= 1.21"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
Adopt the fixes for https://github.com/kubernetes/kubernetes/issues/100855.

*Release Notes*:
``` other operator github.com/gardener/cloud-provider-azure $3fc375539244c6d4e56c814bdc274df5337dcf43
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.11`.
```

``` other operator github.com/gardener/cloud-provider-azure $0187dc87ea2a853d2b220989808bdf7e3327551d
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.7`.
```

``` other operator github.com/gardener/cloud-provider-azure $783a563a0c62bfec856610d718fb35c54a6eda24
`k8s.io/legacy-cloud-providers` is now updated to `v0.21.1`.
```
