### PR TITLE
[release-v1.20] Automated cherry pick of #307: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.3.3->v0.4.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -40,7 +40,7 @@ images:
 - name: machine-controller-manager-provider-azure
   sourceRepository: github.com/gardener/machine-controller-manager-provider-azure
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-azure
-  tag: "v0.3.3"
+  tag: "v0.4.0"
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver
   repository: mcr.microsoft.com/k8s/csi/azuredisk-csi


### PR DESCRIPTION
Cherry pick of #307 on release-v1.20.

#307: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.3.3->v0.4.0]

**Release Notes:**
``` other dependency github.com/gardener/machine-controller-manager-provider-azure #30 @prashanth26
Revendors MCM dependent libraries for `v0.39.0` version.
```
``` improvement operator github.com/gardener/machine-controller-manager-provider-azure #28 @AxiomSamarth
Regression: Clean up wanted test logs
```
``` bugfix operator github.com/gardener/machine-controller-manager-provider-azure #26 @AxiomSamarth
Checks for NICs and Disks while listing VMs for orphan resource collection.
```
``` bugfix user github.com/gardener/machine-controller-manager-provider-azure #24 @kon-angelo
Fix an issue where the availability set information was not transported properly on the driver. It also added support for VMO machines.
```