### PR TITLE
[release-v1.20] Automated cherry pick of #312: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.4.0->v0.4.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -40,7 +40,7 @@ images:
 - name: machine-controller-manager-provider-azure
   sourceRepository: github.com/gardener/machine-controller-manager-provider-azure
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-azure
-  tag: "v0.4.0"
+  tag: "v0.4.1"
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver
   repository: mcr.microsoft.com/k8s/csi/azuredisk-csi


### PR DESCRIPTION
Cherry pick of #312 on release-v1.20.

#312: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.4.0->v0.4.1]

**Release Notes:**
``` bugfix developer github.com/gardener/machine-controller-manager-provider-azure #32 @prashanth26
A shared data structure was causing race conditions leading to VM creation with wrong configurations.
```