### PR TITLE
Update the admission-azure RBAC after cloud provider Secrets validation feature

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
@@ -9,12 +9,19 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
-  - cloudprofiles
   - shoots
+  - cloudprofiles
+  - secretbindings
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
/kind bug
/platform azure

Similar to gardener/gardener-extension-provider-aws#346
Follow-up after #301

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
