### PR TITLE
Update remedy controller version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -81,4 +81,4 @@ images:
 - name: remedy-controller-azure
   sourceRepository: github.com/gardener/remedy-controller
   repository: eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure
-  tag: "v0.7.0"
+  tag: "v0.8.0"

--- a/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/configmap.yaml
+++ b/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/configmap.yaml
@@ -17,11 +17,13 @@ data:
     azure:
       orphanedPublicIPRemedy:
         requeueInterval: {{ required ".Values.config.azure.orphanedPublicIPRemedy.requeueInterval is required" .Values.config.azure.orphanedPublicIPRemedy.requeueInterval }}
+        syncPeriod: {{ required ".Values.config.azure.orphanedPublicIPRemedy.syncPeriod is required" .Values.config.azure.orphanedPublicIPRemedy.syncPeriod }}
         deletionGracePeriod: {{ required ".Values.config.azure.orphanedPublicIPRemedy.deletionGracePeriod is required" .Values.config.azure.orphanedPublicIPRemedy.deletionGracePeriod }}
         maxGetAttempts: {{ required ".Values.config.azure.orphanedPublicIPRemedy.maxGetAttempts is required" .Values.config.azure.orphanedPublicIPRemedy.maxGetAttempts }}
         maxCleanAttempts: {{ required ".Values.config.azure.orphanedPublicIPRemedy.maxReapplyAttempts is required" .Values.config.azure.orphanedPublicIPRemedy.maxCleanAttempts }}
       failedVMRemedy:
         requeueInterval: {{ required ".Values.config.azure.failedVMRemedy.requeueInterval is required" .Values.config.azure.failedVMRemedy.requeueInterval }}
+        syncPeriod: {{ required ".Values.config.azure.failedVMRemedy.syncPeriod is required" .Values.config.azure.failedVMRemedy.syncPeriod }}
         maxGetAttempts: {{ required ".Values.config.azure.failedVMRemedy.maxGetAttempts is required" .Values.config.azure.failedVMRemedy.maxGetAttempts }}
         maxReapplyAttempts: {{ required ".Values.config.azure.failedVMRemedy.maxReapplyAttempts is required" .Values.config.azure.failedVMRemedy.maxReapplyAttempts }}
 {{- end }}

--- a/charts/internal/seed-controlplane/charts/remedy-controller-azure/values.yaml
+++ b/charts/internal/seed-controlplane/charts/remedy-controller-azure/values.yaml
@@ -37,10 +37,12 @@ config:
   azure:
     orphanedPublicIPRemedy:
       requeueInterval: 1m
+      syncPeriod: 10h
       deletionGracePeriod: 5m
       maxGetAttempts: 5
       maxCleanAttempts: 5
     failedVMRemedy:
       requeueInterval: 1m
+      syncPeriod: 2h
       maxGetAttempts: 5
       maxReapplyAttempts: 5


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Updates the remedy-controller version to 0.8.0. This version contains https://github.com/gardener/remedy-controller/pull/39, which adds a `SyncPeriod` configuration option for both remedies to to specify the minimum frequency at which `PublicIPAddress` and `VirtualMachine` resources are to be reconciled. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user github.com/gardener/remedy-controller #39 @stoyanr 
It is now possible to specify the minimum frequency at which `PublicIPAddress` and `VirtualMachine` resources will be reconciled via the `SyncPeriod` options. By default, these are set to 10 hours and 2 hours respectively.
```
