### PR TITLE
Enhance validation of cloud provider secrets

### DIFF
--- a/pkg/apis/azure/validation/secrets.go
+++ b/pkg/apis/azure/validation/secrets.go
@@ -16,9 +16,16 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+
 	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	guidRegex = regexp.MustCompile("^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$")
 )
 
 // ValidateCloudProviderSecret checks whether the given secret contains a valid Azure client credentials.
@@ -32,6 +39,21 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 		}
 		if len(val) == 0 {
 			return fmt.Errorf("field %q in secret %s cannot be empty", key, secretKey)
+		}
+		switch key {
+		case azure.SubscriptionIDKey, azure.TenantIDKey, azure.ClientIDKey:
+			// subscriptionID, tenantID, and clientID must be valid GUIDs,
+			// see https://docs.microsoft.com/en-us/rest/api/securitycenter/locations/get
+			if !guidRegex.Match(val) {
+				return fmt.Errorf("field %q in secret %s must be a valid GUID", key, secretKey)
+			}
+		case azure.ClientSecretKey:
+			// clientSecret must not contain leading or trailing new lines, as they are known to cause issues
+			// Other whitespace characters such as spaces are intentionally not checked for,
+			// since there is no documentation indicating that they would not be valid
+			if strings.Trim(string(val), "\n\r") != string(val) {
+				return fmt.Errorf("field %q in secret %s must not contain leading or traling new lines", key, secretKey)
+			}
 		}
 	}
 

--- a/pkg/apis/azure/validation/secrets_test.go
+++ b/pkg/apis/azure/validation/secrets_test.go
@@ -25,6 +25,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	subscriptionID = "b7ad693a-028a-422c-b064-d76c4586f2b3"
+	tenantID       = "ee16e592-3035-41b9-a217-958f8f75b740"
+	clientID       = "7fc4685d-3c33-40e6-b6bf-7857cab04300"
+	clientSecret   = "clientSecret"
+)
+
 var _ = Describe("Secret validation", func() {
 
 	DescribeTable("#ValidateCloudProviderSecret",
@@ -39,9 +46,9 @@ var _ = Describe("Secret validation", func() {
 
 		Entry("should return error when the subscription ID field is missing",
 			map[string][]byte{
-				azure.TenantIDKey:     []byte("tenant"),
-				azure.ClientIDKey:     []byte("cliendID"),
-				azure.ClientSecretKey: []byte("clientSecret"),
+				azure.TenantIDKey:     []byte(tenantID),
+				azure.ClientIDKey:     []byte(clientID),
+				azure.ClientSecretKey: []byte(clientSecret),
 			},
 			HaveOccurred(),
 		),
@@ -49,76 +56,116 @@ var _ = Describe("Secret validation", func() {
 		Entry("should return error when the subscription ID is empty",
 			map[string][]byte{
 				azure.SubscriptionIDKey: {},
-				azure.TenantIDKey:       []byte("tenant"),
-				azure.ClientIDKey:       []byte("cliendID"),
-				azure.ClientSecretKey:   []byte("clientSecret"),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   []byte(clientSecret),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the subscription ID is not a valid GUID",
+			map[string][]byte{
+				azure.SubscriptionIDKey: append([]byte(subscriptionID), ' '),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   []byte(clientSecret),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should return error when the tenant ID field is missing",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
-				azure.ClientIDKey:       []byte("cliendID"),
-				azure.ClientSecretKey:   []byte("clientSecret"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   []byte(clientSecret),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should return error when the tenant ID is empty",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
 				azure.TenantIDKey:       {},
-				azure.ClientIDKey:       []byte("cliendID"),
-				azure.ClientSecretKey:   []byte("clientSecret"),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   []byte(clientSecret),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the tenant ID is not a valid GUID",
+			map[string][]byte{
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       append([]byte(" "), []byte(tenantID)...),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   []byte(clientSecret),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should return error when the client ID field is missing",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
-				azure.TenantIDKey:       []byte("tenant"),
-				azure.ClientSecretKey:   []byte("clientSecret"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientSecretKey:   []byte(clientSecret),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should return error when the client ID is empty",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
-				azure.TenantIDKey:       []byte("tenant"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
 				azure.ClientIDKey:       {},
-				azure.ClientSecretKey:   []byte("clientSecret"),
+				azure.ClientSecretKey:   []byte(clientSecret),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the client ID is not a valid GUID",
+			map[string][]byte{
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte("foo"),
+				azure.ClientSecretKey:   []byte(clientSecret),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should return error when the client secret field is missing",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
-				azure.TenantIDKey:       []byte("tenant"),
-				azure.ClientIDKey:       []byte("cliendID"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte(clientID),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should return error when the client secret is empty",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
-				azure.TenantIDKey:       []byte("tenant"),
-				azure.ClientIDKey:       []byte("cliendID"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte(clientID),
 				azure.ClientSecretKey:   {},
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the client secret contains a trailing new line",
+			map[string][]byte{
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   append([]byte(clientSecret), '\n'),
 			},
 			HaveOccurred(),
 		),
 
 		Entry("should succeed when the client credentials are valid",
 			map[string][]byte{
-				azure.SubscriptionIDKey: []byte("subscription"),
-				azure.TenantIDKey:       []byte("tenant"),
-				azure.ClientIDKey:       []byte("cliendID"),
-				azure.ClientSecretKey:   []byte("clientSecret"),
+				azure.SubscriptionIDKey: []byte(subscriptionID),
+				azure.TenantIDKey:       []byte(tenantID),
+				azure.ClientIDKey:       []byte(clientID),
+				azure.ClientSecretKey:   []byte(clientSecret),
 			},
 			BeNil(),
 		),


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/area ops-productivity
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Enhances the validation of Azure cloud provider secrets:
* `subscriptionID`, `tenantID`, and `clientID` must be valid UUIDs (and therefore also can't contain leading or trailing whitespaces).
* `clientSecret` must not contain leading or trailing new lines, as they are known to cause issues. Other whitespace characters such as spaces are intentionally not checked for, since there I couldn't find any documentation indicating that they would not be valid.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
Validation of Azure cloud provider secrets is enhanced to reject `subscriptionID`, `tenantID`, and `clientID` that are not valid UUIDs, and `clientSecret` that contain leading or trailing new lines.
```
