### PR TITLE
Forbid tenant and subscription IDs to be changed for existing shoots

### DIFF
--- a/pkg/admission/validator/secret.go
+++ b/pkg/admission/validator/secret.go
@@ -46,13 +46,14 @@ func (s *secret) InjectClient(client client.Client) error {
 // Validate checks whether the given new secret is in use by Shoot with provider.type=azure
 // and if yes, it check whether the new secret contains valid client credentials.
 func (s *secret) Validate(ctx context.Context, newObj, oldObj client.Object) error {
+	var oldSecret *corev1.Secret
 	secret, ok := newObj.(*corev1.Secret)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)
 	}
 
 	if oldObj != nil {
-		oldSecret, ok := oldObj.(*corev1.Secret)
+		oldSecret, ok = oldObj.(*corev1.Secret)
 		if !ok {
 			return fmt.Errorf("wrong object type %T for old object", oldObj)
 		}
@@ -71,5 +72,5 @@ func (s *secret) Validate(ctx context.Context, newObj, oldObj client.Object) err
 		return nil
 	}
 
-	return azurevalidation.ValidateCloudProviderSecret(secret)
+	return azurevalidation.ValidateCloudProviderSecret(secret, oldSecret)
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -193,5 +193,5 @@ func (s *shoot) validateShootSecret(ctx context.Context, shoot *core.Shoot) erro
 		return err
 	}
 
-	return azurevalidation.ValidateCloudProviderSecret(secret)
+	return azurevalidation.ValidateCloudProviderSecret(secret, nil)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Forbid tenant and subscription IDs to be changed for existing shoots.

**Which issue(s) this PR fixes**:
Fixes #42

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
It is now disallowed the tenant or subscription ID to be changed for azure cloud provider secret when it is still used by at least one shoot cluster.
```
