### PR TITLE
Updated MCM RBACs to support VolumeAttachments

### DIFF
--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -67,3 +67,11 @@ rules:
   - watch
   resources:
   - poddisruptionbudgets
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind api-change
/platform azure

**What this PR does / why we need it**:
Update RBACs to allow GET/LIST/WATCH of `VolumeAttachments` with the new MCM provider versions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- Related to https://github.com/gardener/machine-controller-manager/pull/608
- Will make MCM provider azure release next 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
