### PR TITLE
Increased PV reattachment timeout to 150s

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - --machine-creation-timeout=20m
         - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
+        - --machine-pv-reattach-timeout=150s
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPortAzure }}
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform azure

**What this PR does / why we need it**:
The PR increases the default max `pv-reattachment-timeout` for azure to `150s` from existing `90s`. This is to allow azure larger timeouts due to slower reattachments. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to https://github.com/gardener/machine-controller-manager/pull/608#issue-645730826. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
