### PR TITLE
Fix: Allow remedy-controller to create,read,list,watch leases

### DIFF
--- a/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/role.yaml
+++ b/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/role.yaml
@@ -16,3 +16,19 @@ rules:
   - configmaps
   verbs:
   - "*"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - remedy-controller-azure-leader-election
+  verbs:
+  - get
+  - watch
+  - update


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform azure

**What this PR does / why we need it**:
Fix: Allow remedy-controller to create,read,list,watch leases.

Shoot deletion can't be completed due to missing permission for the remedy controller with following error:
```
E0726 13:17:19.775574       1 leaderelection.go:325] error retrieving resource lock shoot--xxx--xxx/remedy-controller-azure-leader-election: leases.coordination.k8s.io "remedy-controller-azure-leader-election" is forbidden: User "system:serviceaccount:shoot--xxx--xxx:remedy-controller-azure" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "shoot--xxx--xxx"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @stoyanr @kon-angelo 
