### PR TITLE
Stop using `github.com/pkg/errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pierrec/lz4 v2.5.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -26,7 +26,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -78,7 +77,7 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, errors.Wrapf(err, "could not decode providerConfig of cloudProfile for '%s'", kutil.ObjectName(cluster.CloudProfile))
+			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", kutil.ObjectName(cluster.CloudProfile), err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
@@ -25,7 +26,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -55,7 +55,7 @@ func (a *actuator) reconcile(ctx context.Context, logger logr.Logger, infra *ext
 		InitializeWith(ctx, terraformer.DefaultInitializer(a.Client(), terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, stateInitializer)).
 		Apply(ctx); err != nil {
 
-		return errors.Wrap(err, "failed to apply the terraform config")
+		return fmt.Errorf("failed to apply the terraform config: %w", err)
 	}
 
 	return a.updateProviderStatus(ctx, tf, infra, config, cluster)

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -18,13 +18,13 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	azureapi "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -45,7 +45,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*azureapi.WorkerStatus, e
 	}
 
 	if _, _, err := w.Decoder().Decode(w.worker.Status.ProviderStatus.Raw, nil, workerStatus); err != nil {
-		return nil, errors.Wrapf(err, "could not decode the worker provider status of worker '%s'", kutil.ObjectName(w.worker))
+		return nil, fmt.Errorf("could not decode the worker provider status of worker '%s': %w", kutil.ObjectName(w.worker), err)
 	}
 	return workerStatus, nil
 }
@@ -70,7 +70,7 @@ func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerS
 
 func (w *workerDelegate) updateWorkerProviderStatusWithError(ctx context.Context, workerStatus *azureapi.WorkerStatus, err error) error {
 	if statusUpdateErr := w.updateWorkerProviderStatus(ctx, workerStatus); statusUpdateErr != nil {
-		return errors.Wrapf(statusUpdateErr, err.Error())
+		return fmt.Errorf("%s: %w", err.Error(), statusUpdateErr)
 	}
 	return err
 }

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -16,32 +16,31 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
-	"github.com/pkg/errors"
 )
 
 // UpdateMachineImagesStatus stores the used machine images for the `Worker` resource in the worker-provider-status.
 func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
-			return errors.Wrapf(err, "unable to generate the machine config")
+			return fmt.Errorf("unable to generate the machine config: %w", err)
 		}
 	}
 
 	// Decode the current worker provider status.
 	workerStatus, err := w.decodeWorkerProviderStatus()
 	if err != nil {
-		return errors.Wrapf(err, "unable to decode the worker provider status")
+		return fmt.Errorf("unable to decode the worker provider status: %w", err)
 	}
 
 	workerStatus.MachineImages = w.machineImages
 	if err := w.updateWorkerProviderStatus(ctx, workerStatus); err != nil {
-		return errors.Wrapf(err, "unable to update worker provider status")
+		return fmt.Errorf("unable to update worker provider status: %w", err)
 	}
 
 	return nil
@@ -57,7 +56,7 @@ func (w *workerDelegate) findMachineImage(name, version string) (urn, id *string
 	if providerStatus := w.worker.Status.ProviderStatus; providerStatus != nil {
 		workerStatus := &api.WorkerStatus{}
 		if _, _, err := w.Decoder().Decode(providerStatus.Raw, nil, workerStatus); err != nil {
-			return nil, nil, nil, errors.Wrapf(err, "could not decode worker status of worker '%s'", kutil.ObjectName(w.worker))
+			return nil, nil, nil, fmt.Errorf("could not decode worker status of worker '%s': %w", kutil.ObjectName(w.worker), err)
 		}
 
 		machineImage, err := helper.FindMachineImage(workerStatus.MachineImages, name, version)

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -68,7 +67,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 	// Delete any older version of AzureMachineClass CRs.
 	// TODO: Remove this clean-up in future version.
 	if err := w.Client().DeleteAllOf(ctx, &machinev1alpha1.AzureMachineClass{}, client.InNamespace(w.worker.Namespace)); err != nil {
-		return errors.Wrapf(err, "cleaning up older version of Azure machine class CRs failed")
+		return fmt.Errorf("cleaning up older version of Azure machine class CRs failed: %w", err)
 	}
 
 	return w.seedChartApplier.Apply(ctx, filepath.Join(azure.InternalChartsPath, "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))

--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -16,6 +16,7 @@ package controlplaneexposure
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/config"
 
@@ -28,7 +29,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -88,7 +88,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: new.Namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}})
 	if err != nil {
-		return errors.Wrap(err, "could not get kube-apiserver service load balancer address")
+		return fmt.Errorf("could not get kube-apiserver service load balancer address: %w", err)
 	}
 
 	if c := extensionswebhook.ContainerWithName(new.Spec.Template.Spec.Containers, "kube-apiserver"); c != nil {

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 	"strconv"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/gardener/gardener/extensions/test/tm/generator"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -105,10 +105,10 @@ func main() {
 
 func validate() error {
 	if err := generator.ValidateString(&cfg.infrastructureProviderConfigPath); err != nil {
-		return errors.Wrap(err, "error validating infrastructure provider config path")
+		return fmt.Errorf("error validating infrastructure provider config path: %w", err)
 	}
 	if err := generator.ValidateString(&cfg.controlplaneProviderConfigPath); err != nil {
-		return errors.Wrap(err, "error validating controlplane provider config path")
+		return fmt.Errorf("error validating controlplane provider config path: %w", err)
 	}
 	//Optional Parameters
 	if err := generator.ValidateString(&cfg.networkVnetCidr); err != nil {
@@ -122,7 +122,7 @@ func validate() error {
 	if err := generator.ValidateString(&cfg.zonedFlag); err == nil {
 		parsedBool, err := strconv.ParseBool(cfg.zonedFlag)
 		if err != nil {
-			return errors.Wrap(err, "zoned is not a boolean value")
+			return fmt.Errorf("zoned is not a boolean value: %w", err)
 		}
 		cfg.zoned = parsedBool
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -495,7 +495,6 @@ github.com/pelletier/go-toml
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.11.0 => github.com/prometheus/client_golang v1.11.0
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Similar to gardener/gardener#4280 we should be using Go native error wrapping (available since GO 1.13).

**Which issue(s) this PR fixes**:
Fixes #337

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @vanjiii 
