### PR TITLE
Remove hardcoded os disk type check in the worker controller.

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -418,14 +418,7 @@ func computeDisks(pool extensionsv1alpha1.WorkerPool, dataVolumesConfig []azurea
 	osDisk := map[string]interface{}{
 		"size": volumeSize,
 	}
-	// In the past the volume type information was not passed to the machineclass.
-	// In consequence the Machine controller manager has created machines always
-	// with the default volume type of the requested machine type. Existing clusters
-	// respectively their worker pools could have an invalid volume configuration
-	// which was not applied. To do not damage existing cluster we will set for
-	// now the volume type only if it's a valid Azure volume type.
-	// Otherwise, we will still use the default volume of the machine type.
-	if pool.Volume.Type != nil && (*pool.Volume.Type == "Standard_LRS" || *pool.Volume.Type == "StandardSSD_LRS" || *pool.Volume.Type == "Premium_LRS") {
+	if pool.Volume != nil && pool.Volume.Type != nil {
 		osDisk["type"] = *pool.Volume.Type
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform azure

**What this PR does / why we need it**:
Clean up a hardcoded os disk type check in the worker controller.


**Which issue(s) this PR fixes**:
Fixes #190

**Special notes for your reviewer**:
I will keep this in draft until we have migrated all cluster to use a valid os disk type.
For all other who are using the `provider-azure` extension I added a `breaking` release note to make them aware of this change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```operator breaking
An explizit check for the os disk type in the worker controller has been removed. Please ensure that existing Azure Shoots which specify a type for the os disk use a valid one. The os disk type is configured per worker pool via `.spec.provider.workers[].volume.types`. The available volume types can be looked up in the `CloudProfile` via `spec.volumeTypes[]`. If the Shoot does not specify an os disk type then the default disk type for the corresponding machine type will be used. Please check the Azure machine documentation for more detail.
```

/invite @ialidzhikov @kon-angelo 
