### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure@v1.21

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -31,7 +31,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.21.1"
+  tag: "v1.21.4"
   targetVersion: ">= 1.21"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:

``` other operator github.com/gardener/cloud-provider-azure #5 @vpnachev
`k8s.io/legacy-cloud-providers` is now updated to `v0.21.4`.
```