### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -16,7 +16,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.18.17"
+  tag: "v1.18.20"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure


### PR DESCRIPTION
*Release Notes*:

``` other operator github.com/gardener/cloud-provider-azure #8 @ialidzhikov
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.20`.
```

