### PR TITLE
[release-v1.21] Automated cherry pick of #355: Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -21,12 +21,12 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.19.11"
+  tag: "v1.19.14"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.20.7"
+  tag: "v1.20.10"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure


### PR DESCRIPTION
/kind/enhancement

Cherry pick of #355 on release-v1.21.

#355: Upgrade github.com/gardener/cloud-provider-azure

**Release Notes:**
``` other operator github.com/gardener/cloud-provider-azure #7 @vpnachev
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.14`.
```
``` other operator github.com/gardener/cloud-provider-azure #6 @vpnachev
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.10`.
```