### PR TITLE
Reintroduce generation of tf config on deletion

### DIFF
--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -17,11 +17,14 @@ package infrastructure
 import (
 	"context"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal/infrastructure"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -46,5 +49,23 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 		return tf.CleanupConfiguration(ctx)
 	}
 
-	return tf.SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef)...).Destroy(ctx)
+	config, err := helper.InfrastructureConfigFromInfrastructure(infra)
+	if err != nil {
+		return err
+	}
+
+	terraformFiles, err := infrastructure.RenderTerraformerTemplate(infra, config, cluster)
+	if err != nil {
+		return err
+	}
+
+	return tf.
+		InitializeWith(ctx, terraformer.DefaultInitializer(a.Client(), terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, terraformer.StateConfigMapInitializerFunc(NoOpStateInitializer))).
+		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef)...).
+		Destroy(ctx)
+}
+
+// NoOpStateInitializer is a no-op StateConfigMapInitializerFunc.
+func NoOpStateInitializer(ctx context.Context, c client.Client, namespace, name string, owner *metav1.OwnerReference) error {
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
/kind regression
/platform azure

**What this PR does / why we need it**:
Reintroduce the generation of the terraform configuration on deletion.

**Which issue(s) this PR fixes**:
Fixes #359

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @ialidzhikov 
/cc @kon-angelo 
