### PR TITLE
Fix worker vmo deletion if resource group is gone

### DIFF
--- a/pkg/azure/client/vmss.go
+++ b/pkg/azure/client/vmss.go
@@ -72,6 +72,9 @@ func (c VmssClient) Create(ctx context.Context, resourceGroupName, name string, 
 func (c VmssClient) Delete(ctx context.Context, resourceGroupName, name string) error {
 	future, err := c.client.Delete(ctx, resourceGroupName, name)
 	if err != nil {
+		if IsAzureAPINotFoundError(err) {
+			return nil
+		}
 		return err
 	}
 	if err := future.WaitForCompletionRef(ctx, c.client.Client); err != nil {

--- a/pkg/controller/worker/machineset_vmo.go
+++ b/pkg/controller/worker/machineset_vmo.go
@@ -147,7 +147,7 @@ func (w *workerDelegate) cleanupVmoDependencies(ctx context.Context, infrastruct
 
 func cleanupOrphanVMODependencies(ctx context.Context, client azureclient.Vmss, dependencies []azureapi.VmoDependency, resourceGroupName string) error {
 	vmoListAll, err := client.List(ctx, resourceGroupName)
-	if err != nil {
+	if err != nil && !azureclient.IsAzureAPINotFoundError(err) {
 		return err
 	}
 	vmoList := filterGardenerManagedVmos(vmoListAll)


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/platform azure

**What this PR does / why we need it**:
Fix deletion of vmss flex/vmo dependencies managed by the worker controller in case the underlying resource group is gone.
This unblocks the deletion flow for these cases.

**Which issue(s) this PR fixes**:
Fixes #360 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @ialidzhikov @kon-angelo 
cc @stoyanr 