### PR TITLE
FIX csi driver update for VMSS Flex

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -44,7 +44,7 @@ images:
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver
   repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
-  tag: "v1.2.0"
+  tag: "v1.6.0"
 - name: csi-driver-file
   sourceRepository: github.com/kubernetes-sigs/azurefile-csi-driver
   repository: mcr.microsoft.com/k8s/csi/azurefile-csi

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
@@ -44,6 +44,11 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         {{- if eq .role "disk" }}
         - --kubeconfig=/var/lib/csi-driver-controller-disk/kubeconfig
+        {{- if hasKey .Values "vmType" }}
+        {{- if eq .Values.vmType "vmss" }}
+        - --disable-avset-nodes=false
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- if eq .role "file" }}
         - --nodeid=dummy

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -436,7 +436,12 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 	checksums[azure.CloudProviderConfigName] = utils.ComputeChecksum(cpConfigSecret.Data)
 
-	return getControlPlaneChartValues(cpConfig, cp, cluster, checksums, scaledDown)
+	infraStatus := &apisazure.InfrastructureStatus{}
+	if _, _, err := vp.Decoder().Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
+		return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+	}
+
+	return getControlPlaneChartValues(cpConfig, cp, cluster, checksums, scaledDown, infraStatus)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -596,13 +601,14 @@ func getControlPlaneChartValues(
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
 	scaledDown bool,
+	infraStatus *apisazure.InfrastructureStatus,
 ) (map[string]interface{}, error) {
 	ccm, err := getCCMChartValues(cpConfig, cp, cluster, checksums, scaledDown)
 	if err != nil {
 		return nil, err
 	}
 
-	csi, err := getCSIControllerChartValues(cluster, checksums, scaledDown)
+	csi, err := getCSIControllerChartValues(cluster, checksums, scaledDown, infraStatus)
 	if err != nil {
 		return nil, err
 	}
@@ -656,6 +662,7 @@ func getCSIControllerChartValues(
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
 	scaledDown bool,
+	infraStatus *apisazure.InfrastructureStatus,
 ) (map[string]interface{}, error) {
 	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
 	if err != nil {
@@ -666,7 +673,7 @@ func getCSIControllerChartValues(
 		return map[string]interface{}{"enabled": false}, nil
 	}
 
-	return map[string]interface{}{
+	values := map[string]interface{}{
 		"enabled":  true,
 		"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"podAnnotations": map[string]interface{}{
@@ -684,7 +691,13 @@ func getCSIControllerChartValues(
 				"checksum/secret-" + azure.CSISnapshotControllerName: checksums[azure.CSISnapshotControllerName],
 			},
 		},
-	}, nil
+	}
+
+	if azureapihelper.IsVmoRequired(infraStatus) {
+		values["vmType"] = "vmss"
+	}
+
+	return values, nil
 }
 
 // getRemedyControllerChartValues collects and returns the remedy controller chart values.

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -370,7 +370,7 @@ var _ = Describe("ValuesProvider", func() {
 			}))
 		})
 
-		It("should return correct control plane chart values (k8s >= 1.21) with zoned infrastructure", func() {
+		It("should return correct control plane chart values (k8s >= 1.21) without zoned infrastructure", func() {
 			cluster = generateCluster(cidr, k8sVersionHigherEqual121, true, nil)
 			infrastructureStatus.Zoned = false
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
@@ -410,7 +410,7 @@ var _ = Describe("ValuesProvider", func() {
 			}))
 		})
 
-		It("should return correct control plane chart values (k8s >= 1.21) without zoned infrastructure", func() {
+		It("should return correct control plane chart values (k8s >= 1.21) with zoned infrastructure", func() {
 			cluster = generateCluster(cidr, k8sVersionHigherEqual121, true, nil)
 			infrastructureStatus.Zoned = true
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -412,7 +412,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		It("should return correct control plane chart values (k8s >= 1.21) without zoned infrastructure", func() {
 			cluster = generateCluster(cidr, k8sVersionHigherEqual121, true, nil)
-			infrastructureStatus.Zoned = false
+			infrastructureStatus.Zoned = true
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 
 			values, err := vp.GetControlPlaneChartValues(ctx, cp, cluster, checksums, false)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion| bug |epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area storage
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Enable usage of newer / newest csi-disk driver on VMSS Flex (VMO) clusters.

**Which issue(s) this PR fixes**:
Fixes #327

**Special notes for your reviewer**:
Can you please review  the pr?
@dkistner @kon-angelo