### PR TITLE
Make the linter fail on missing or wrong doc comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,15 @@ run:
 linters:
   disable:
   - unused
+  enable:
+  - revive
+
+issues:
+  exclude-use-default: false
+  exclude:
+  # revive
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
+  - package-comments # package comment should be of the form
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// SecretsValidatorName is the name of the secrets validator.
 const SecretsValidatorName = "secrets." + extensionswebhook.ValidatorName
 
 var logger = log.Log.WithName("azure-validator-webhook")

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -27,16 +27,16 @@ import (
 )
 
 var (
-	Codec  runtime.Codec
-	Scheme *runtime.Scheme
+	codec  runtime.Codec
+	scheme *runtime.Scheme
 )
 
 func init() {
-	Scheme = runtime.NewScheme()
-	install.Install(Scheme)
-	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
-	Codec = versioning.NewDefaultingCodecForScheme(
-		Scheme,
+	scheme = runtime.NewScheme()
+	install.Install(scheme)
+	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
+	codec = versioning.NewDefaultingCodecForScheme(
+		scheme,
 		yamlSerializer,
 		yamlSerializer,
 		schema.GroupVersion{Version: "v1alpha1"},
@@ -63,7 +63,7 @@ func Load(data []byte) (*config.ControllerConfiguration, error) {
 		return cfg, nil
 	}
 
-	decoded, _, err := Codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
+	decoded, _, err := codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -94,8 +94,5 @@ func (a *actuator) Delete(ctx context.Context, backupBucket *extensionsv1alpha1.
 	}
 
 	// Delete the generated backup secret in the garden namespace.
-	if err := a.deleteBackupBucketGeneratedSecret(ctx, backupBucket); err != nil {
-		return err
-	}
-	return nil
+	return a.deleteBackupBucketGeneratedSecret(ctx, backupBucket)
 }

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -46,6 +46,7 @@ type actuator struct {
 	logger             logr.Logger
 }
 
+// NewActuator creates a new dnsrecord.Actuator.
 func NewActuator(client client.Client, azureClientFactory azureclient.Factory, logger logr.Logger) dnsrecord.Actuator {
 	return &actuator{
 		client:             client,

--- a/test/integration/infrastructure/matchers.go
+++ b/test/integration/infrastructure/matchers.go
@@ -43,6 +43,7 @@ func (a *azureNotFoundErrorMatcher) Match(actual interface{}) (success bool, err
 	return false, nil
 }
 
+// IsNotFound returns true if the given error is a autorest.DetailedError with status code http.StatusNotFound.
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -36,7 +36,7 @@ const (
 	defaultNetworkWorkerCidr = "10.250.0.0/19"
 )
 
-type GeneratorConfig struct {
+type generatorConfig struct {
 	networkWorkerCidr                string
 	networkVnetCidr                  string
 	infrastructureProviderConfigPath string
@@ -46,12 +46,12 @@ type GeneratorConfig struct {
 }
 
 var (
-	cfg    *GeneratorConfig
+	cfg    *generatorConfig
 	logger logr.Logger
 )
 
 func addFlags() {
-	cfg = &GeneratorConfig{}
+	cfg = &generatorConfig{}
 	flag.StringVar(&cfg.infrastructureProviderConfigPath, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	flag.StringVar(&cfg.controlplaneProviderConfigPath, "controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Makes the linter fail on missing or wrong doc comments and a few other common style errors, and fixes all such issues that already exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Making the linter fail on missing or wrong doc comments and a few other common style errors consists of enabling `revive` in the `golangci-lint` configuration and excluding certain `revive` errors that we are perhaps not interested in.

I have fixed the following `revive` errors (as regexes that could be included in the `golangci-lint` configuration if desired):

```
- "exported: comment on exported (var|const|type|method|function) .* should be of the form "
- "exported: exported (var|const|type|method|function) .* should have comment or be unexported"
- if-return # redundant if \.\.\.; err != nil check, just return error instead
```

I have disabled the following `revive` errors via the `golangci-lint` configuration:

```
- var-naming # ((var|const|struct field|func) .* should be .*
- dot-imports # should not use dot imports
- package-comments # package comment should be of the form
- indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
- "exported: (type|func) name will be used as .* by other packages, and that stutters;"
```

See also https://github.com/gardener/gardener/pull/4627 and https://github.com/gardener/gardener-extension-provider-aws/pull/410.

**Release note**:

```other developer
Missing or wrong doc comments and a few other common style errors will now be reported by the linter.
```
