### PR TITLE
[UPDATE] use offical image from ms

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -29,14 +29,14 @@ images:
   tag: "v1.20.10"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
-  sourceRepository: github.com/gardener/cloud-provider-azure
-  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.21.4"
+  sourceRepository: https://github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  tag: "v1.1.1"
   targetVersion: "1.21.x"
 - name: cloud-controller-manager
-  sourceRepository: github.com/gardener/cloud-provider-azure
-  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.22.0"
+  sourceRepository: https://github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  tag: "v1.1.1"
   targetVersion: ">= 1.22"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -31,7 +31,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: https://github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.1.1"
+  tag: "v1.0.5"
   targetVersion: "1.21.x"
 - name: cloud-controller-manager
   sourceRepository: https://github.com/kubernetes-sigs/cloud-provider-azure

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -40,7 +40,7 @@ spec:
         {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
         - cloud-controller-manager
-        {{- else if semverCompare ">=1.21" .Values.kubernetesVersion }}
+        {{- else if semverCompare ">= 1.21" .Values.kubernetesVersion }}
         - /usr/local/bin/cloud-controller-manager
         {{- else }}
         - /azure-cloud-controller-manager

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -40,6 +40,8 @@ spec:
         {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
         - cloud-controller-manager
+        {{- else if semverCompare ">=1.21" .Values.kubernetesVersion }}
+        - /usr/local/bin/cloud-controller-manager
         {{- else }}
         - /azure-cloud-controller-manager
         {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Because the official "new" way how the implementation will be updated was moved from the "inner-tree" to the k8s-sigs repos, so it would be easier to fetch the implementation direct from there.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/gardener/gardener-extension-provider-azure/issues/373
Multiple issues of shoots that was deployed on vmo / vmss-flex.
(we see some issues in the latest 4-6 months that was already fixed at the k8s-sigs repo)

**Special notes for your reviewer**:
What kind of way to you prefer to run the binary of the container.
Just move the args to the "args" key of the container spec or changing / adding the new entrypoint.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
category: feature
target_group: dependency
```
