### PR TITLE
Upgrade github.com/gardener/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,17 +26,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.20.10"
+  tag: "v1.20.12"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.21.4"
+  tag: "v1.21.6"
   targetVersion: "1.21.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.22.0"
+  tag: "v1.22.3"
   targetVersion: ">= 1.22"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
/area control-plane
/kind bug
/platform azure

Fixes #374

**Release Notes**:

``` other operator github.com/gardener/cloud-provider-azure $c36b6edcc10fbd4692799ec035f0d33eb2107189
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.12`.
```

``` other operator github.com/gardener/cloud-provider-azure $03ebe674718690b7cd389ef1f1a9094ef8ae7a53
`k8s.io/legacy-cloud-providers` is now updated to `v0.21.6`.
```

``` other operator github.com/gardener/cloud-provider-azure $e083e3b710910cc1658a2893586f1cc16e6274a5
`k8s.io/legacy-cloud-providers` is now updated to `v0.22.3`.
```
