### PR TITLE
Improve the error message when a required part of webhookConfig is missing

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml
@@ -31,7 +31,7 @@ webhooks:
       name: {{ include "name" . }}
       path: /webhooks/validate
     {{- end }}
-    caBundle: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.global.webhookConfig.caBundle) }}
+    caBundle: {{ required ".Values.global.webhookConfig.caBundle is required" .Values.global.webhookConfig.caBundle | b64enc }}
 - name: secrets.validation.azure.provider.extensions.gardener.cloud
   rules:
   - apiGroups:
@@ -58,4 +58,4 @@ webhooks:
       name: {{ include "name" . }}
       path: /webhooks/validate/secrets
     {{- end }}
-    caBundle: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.global.webhookConfig.caBundle) }}
+    caBundle: {{ required ".Values.global.webhookConfig.caBundle is required" .Values.global.webhookConfig.caBundle | b64enc }}

--- a/charts/gardener-extension-admission-azure/charts/runtime/templates/secret-cert.yaml
+++ b/charts/gardener-extension-admission-azure/charts/runtime/templates/secret-cert.yaml
@@ -11,5 +11,5 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  tls.crt: {{ required ".Values.global.webhookConfig.tls.crt is required" (b64enc .Values.global.webhookConfig.tls.crt) }}
-  tls.key: {{ required ".Values.global.webhookConfig.tls.key is required" (b64enc .Values.global.webhookConfig.tls.key) }}
+  tls.crt: {{ required ".Values.global.webhookConfig.tls.crt is required" .Values.global.webhookConfig.tls.crt | b64enc }}
+  tls.key: {{ required ".Values.global.webhookConfig.tls.key is required" .Values.global.webhookConfig.tls.key | b64enc }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

**What this PR does / why we need it**:
Previously when trying to install the admission helm chart without providing `.global.webhookConfig.caBundle` (for example) the helm deployment was failing with an error similar to this one:
```
... at <.Values.global.webhookConfig.caBundle>: wrong type for value; expected string; got interface {}

```

After the change the same installation will fail with a message that is actually desired.
```
... execution error at (gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml:35:17): .Values.global.webhookConfig.caBundle is required
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
