### PR TITLE
Update remedy-controller to v0.9.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -86,4 +86,4 @@ images:
 - name: remedy-controller-azure
   sourceRepository: github.com/gardener/remedy-controller
   repository: eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure
-  tag: "v0.8.0"
+  tag: "v0.9.0"


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Updates `remedy-controller` to v0.9.0 which introduces improvements to entropy correction in case of missed service and node events, see https://github.com/gardener/remedy-controller/pull/43. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release notes**:

```feature operator
* The node and service controllers now have a configurable sync period (defaults to 4h), so that if an event is missed, the next reconcile will happen at most after this period.
* The node and service predicates now use an expiring cache of nodes / services, so that if an event is missed, the next event is likely to cause a reconcile after comparing with the cache.
* The node and service controllers now also watch "owned" `VirtualMachine` and `PublicIPAddress` resources and would trigger a reconcile if a an unexpected situation is detected, such as creating or updating an object without an owner, deleting an object with an owner that is not being deleted, etc.
* The node and service controllers have been enhanced to ensure that any owned objects are deleted if the node or service is not found.
* The service controller has been enhanced to also delete any still existing "owned" `PublicIPAddress` resources that are not found in the service `LoadBalancer` IPs when deleting a service or ensuring that it's deleted.
```

