### PR TITLE
Cleanup natipmigration logic

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -659,19 +659,6 @@ bool
 <p>Zoned indicates whether the cluster uses zones</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>natGatewayPublicIpMigrated</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>NatGatewayPublicIPMigrated is an indicator if the Gardener managed public ip address is already migrated.
-TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="azure.provider.extensions.gardener.cloud/v1alpha1.MachineImage">MachineImage

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -92,9 +92,6 @@ type InfrastructureStatus struct {
 	Identity *IdentityStatus
 	// Zoned indicates whether the cluster uses zones
 	Zoned bool
-	// NatGatewayPublicIPMigrated is an indicator if the Gardener managed public ip address is already migrated.
-	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
-	NatGatewayPublicIPMigrated bool
 }
 
 // NetworkStatus is the current status of the infrastructure networks.

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -103,10 +103,6 @@ type InfrastructureStatus struct {
 	// Zoned indicates whether the cluster uses zones
 	// +optional
 	Zoned bool `json:"zoned,omitempty"`
-	// NatGatewayPublicIPMigrated is an indicator if the Gardener managed public ip address is already migrated.
-	// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
-	// +optional
-	NatGatewayPublicIPMigrated bool `json:"natGatewayPublicIpMigrated,omitempty"`
 }
 
 // NetworkStatus is the current status of the infrastructure networks.

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -494,7 +494,6 @@ func autoConvert_v1alpha1_InfrastructureStatus_To_azure_InfrastructureStatus(in 
 	out.SecurityGroups = *(*[]azure.SecurityGroup)(unsafe.Pointer(&in.SecurityGroups))
 	out.Identity = (*azure.IdentityStatus)(unsafe.Pointer(in.Identity))
 	out.Zoned = in.Zoned
-	out.NatGatewayPublicIPMigrated = in.NatGatewayPublicIPMigrated
 	return nil
 }
 
@@ -515,7 +514,6 @@ func autoConvert_azure_InfrastructureStatus_To_v1alpha1_InfrastructureStatus(in 
 	out.SecurityGroups = *(*[]SecurityGroup)(unsafe.Pointer(&in.SecurityGroups))
 	out.Identity = (*IdentityStatus)(unsafe.Pointer(in.Identity))
 	out.Zoned = in.Zoned
-	out.NatGatewayPublicIPMigrated = in.NatGatewayPublicIPMigrated
 	return nil
 }
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -94,10 +94,6 @@ resource "azurerm_nat_gateway" "nat" {
   {{ if hasKey .natGateway "zone" -}}
   zones = [{{ .natGateway.zone | quote }}]
   {{- end }}
-  {{ if .natGateway.migrateNatGatewayToIPAssociation -}}
-  # TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
-  public_ip_address_ids   = []
-  {{- end }}
   {{- end }}
 }
 resource "azurerm_subnet_nat_gateway_association" "nat-worker-subnet-association" {

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -169,9 +169,7 @@ var _ = Describe("Terraform", func() {
 				"securityGroupName": TerraformerOutputKeySecurityGroupName,
 			}
 
-			expectedNatGatewayValues = map[string]interface{}{
-				"migrateNatGatewayToIPAssociation": false,
-			}
+			expectedNatGatewayValues = map[string]interface{}{}
 
 			expectedValues = map[string]interface{}{
 				"azure":         expectedAzureValues,
@@ -436,50 +434,6 @@ var _ = Describe("Terraform", func() {
 				values, err := ComputeTerraformerTemplateValues(infra, config, cluster)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(BeEquivalentTo(expectedValues))
-			})
-
-			// TODO(natipmigration) This can be removed in future versions when the ip migration has been completed.
-			Context("NatGateway Gardener managed IP migration", func() {
-				BeforeEach(func() {
-					config.Networks.NatGateway = &api.NatGatewayConfig{
-						Enabled: true,
-					}
-					expectedCreateValues["natGateway"] = true
-				})
-
-				It("should migrate the NatGateway IP as it is not yet migrated", func() {
-					infrastructureStatus := api.InfrastructureStatus{
-						NatGatewayPublicIPMigrated: false,
-					}
-					infrastructureStatusMarshalled, err := json.Marshal(infrastructureStatus)
-					Expect(err).NotTo(HaveOccurred())
-
-					infra.Status.ProviderStatus = &runtime.RawExtension{
-						Raw: infrastructureStatusMarshalled,
-					}
-
-					expectedNatGatewayValues["migrateNatGatewayToIPAssociation"] = true
-					values, err := ComputeTerraformerTemplateValues(infra, config, cluster)
-					Expect(err).To(Not(HaveOccurred()))
-					Expect(values).To(BeEquivalentTo(expectedValues))
-				})
-
-				It("should not migrate the NatGateway IP as it is already migrated", func() {
-					infrastructureStatus := api.InfrastructureStatus{
-						NatGatewayPublicIPMigrated: true,
-					}
-					infrastructureStatusMarshalled, err := json.Marshal(infrastructureStatus)
-					Expect(err).NotTo(HaveOccurred())
-
-					infra.Status.ProviderStatus = &runtime.RawExtension{
-						Raw: infrastructureStatusMarshalled,
-					}
-
-					expectedNatGatewayValues["migrateNatGatewayToIPAssociation"] = false
-					values, err := ComputeTerraformerTemplateValues(infra, config, cluster)
-					Expect(err).To(Not(HaveOccurred()))
-					Expect(values).To(BeEquivalentTo(expectedValues))
-				})
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
/kind cleanup
/platform azure

**What this PR does / why we need it**:
Remove `natgateway` ip migration (ref: `TODO(natipmigration)`) logic which was required to migrate from `azurerm` provider v1 to v2.
The logic is now in since `v1.15` and will be removed with `v1.23`.
This should be enough time to reconcile all `Infrastructure` resources. ref: https://github.com/gardener/gardener-extension-provider-azure/pull/192 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The logic to migrate the Terraform natgateway state will be removed. In case there are `Infrastructure` resources that are created with < `v1.15` and not reconciled with >= `v1.15` they need to be reconciled before a release with this change is applied.
```

/invite @kon-angelo 
/cc @ialidzhikov 
