### PR TITLE
Fixes deletion of remedy controller resources during cp migration

### DIFF
--- a/pkg/controller/controlplane/actuator_test.go
+++ b/pkg/controller/controlplane/actuator_test.go
@@ -26,6 +26,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -60,12 +61,23 @@ var _ = Describe("Actuator", func() {
 		newPubip = func(annotations map[string]string) *azurev1alpha1.PublicIPAddress {
 			return &azurev1alpha1.PublicIPAddress{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "foo-1.2.3.4",
-					Namespace:   namespace,
-					Annotations: annotations,
+					Name:            "foo-1.2.3.4",
+					Namespace:       namespace,
+					Annotations:     annotations,
+					ResourceVersion: "1",
 				},
 				Spec: azurev1alpha1.PublicIPAddressSpec{
 					IPAddress: "1.2.3.4",
+				},
+			}
+		}
+
+		newVirtualMachine = func() *azurev1alpha1.VirtualMachine {
+			return &azurev1alpha1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "node-name",
+					Namespace:       namespace,
+					ResourceVersion: "1",
 				},
 			}
 		}
@@ -121,6 +133,58 @@ var _ = Describe("Actuator", func() {
 			a.EXPECT().Delete(ctx, cp, cluster).Return(nil)
 
 			err := actuator.Delete(ctx, cp, cluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("#Migrate", func() {
+		It("should remove finalizers from remedy controller resources and then delete them", func() {
+			cp := newControlPlane(nil)
+			a.EXPECT().Migrate(ctx, cp, cluster).Return(nil)
+
+			pubip := newPubip(nil)
+			pubipWithFinalizers := pubip.DeepCopy()
+			pubipWithFinalizers.Finalizers = append(pubipWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/publicipaddress")
+			c.EXPECT().List(ctx, &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace)).
+				DoAndReturn(func(_ context.Context, list *azurev1alpha1.PublicIPAddressList, _ ...client.ListOption) error {
+					list.Items = []azurev1alpha1.PublicIPAddress{*pubipWithFinalizers}
+					return nil
+				})
+			test.EXPECTPatchWithOptimisticLock(ctx, c, pubip, pubipWithFinalizers)
+			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.PublicIPAddress{}, client.InNamespace(namespace)).Return(nil)
+
+			vm := newVirtualMachine()
+			vmWithFinalizers := vm.DeepCopy()
+			vmWithFinalizers.Finalizers = append(vmWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/virtualmachine")
+			c.EXPECT().List(ctx, &azurev1alpha1.VirtualMachineList{}, client.InNamespace(namespace)).
+				DoAndReturn(func(_ context.Context, list *azurev1alpha1.VirtualMachineList, _ ...client.ListOption) error {
+					list.Items = []azurev1alpha1.VirtualMachine{*vmWithFinalizers}
+					return nil
+				})
+			test.EXPECTPatchWithOptimisticLock(ctx, c, vm, vmWithFinalizers)
+			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.VirtualMachine{}, client.InNamespace(namespace)).Return(nil)
+
+			c.EXPECT().List(gomock.Any(), &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace)).
+				DoAndReturn(func(_ context.Context, list *azurev1alpha1.PublicIPAddressList, _ ...client.ListOption) error {
+					list.Items = []azurev1alpha1.PublicIPAddress{}
+					return nil
+				})
+			c.EXPECT().List(gomock.Any(), &azurev1alpha1.VirtualMachineList{}, client.InNamespace(namespace)).
+				DoAndReturn(func(_ context.Context, list *azurev1alpha1.VirtualMachineList, _ ...client.ListOption) error {
+					list.Items = []azurev1alpha1.VirtualMachine{}
+					return nil
+				})
+
+			err := actuator.Migrate(ctx, cp, cluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should neither remove finalizers from remaining remedy controller resources nor delete them for controlplane with purpose exposure", func() {
+			exposure := extensionsv1alpha1.Exposure
+			cp := newControlPlane(&exposure)
+			a.EXPECT().Migrate(ctx, cp, cluster).Return(nil)
+
+			err := actuator.Migrate(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -48,7 +48,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
 		Actuator: NewActuator(genericactuator.NewActuator(azure.Name, controlPlaneSecrets, nil, configChart, controlPlaneChart, controlPlaneShootChart,
 			controlPlaneShootCRDsChart, storageClassChart, nil, NewValuesProvider(logger), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
-			imagevector.ImageVector(), "", nil, mgr.GetWebhookServer().Port, logger), logger),
+			imagevector.ImageVector(), "", nil, mgr.GetWebhookServer().Port, logger), logger, GracefulDeletionTimeout, GracefulDeletionWaitInterval),
 		ControllerOptions: opts.Controller,
 		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              azure.Type,

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/gomock.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/gomock.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HasObjectKeyOf returns a gomock.Matcher that matches if actual is a client.Object that has the same
+// ObjectKey as expected.
+func HasObjectKeyOf(expected client.Object) gomock.Matcher {
+	return &objectKeyMatcher{key: client.ObjectKeyFromObject(expected)}
+}
+
+type objectKeyMatcher struct {
+	key client.ObjectKey
+}
+
+func (o *objectKeyMatcher) Matches(actual interface{}) bool {
+	if actual == nil {
+		return false
+	}
+
+	obj, ok := actual.(client.Object)
+	if !ok {
+		return false
+	}
+
+	return o.key == client.ObjectKeyFromObject(obj)
+}
+
+func (o *objectKeyMatcher) String() string {
+	return fmt.Sprintf("has object key %q", o.key)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/options.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/options.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Flag is a flag that can be represented as a slice of strings.
+type Flag interface {
+	// Slice returns a representation of this Flag as a slice of strings.
+	Slice() []string
+}
+
+func keyToFlag(key string) string {
+	return fmt.Sprintf("--%s", key)
+}
+
+type intFlag struct {
+	key   string
+	value int
+}
+
+func (f *intFlag) Slice() []string {
+	return []string{keyToFlag(f.key), fmt.Sprintf("%d", f.value)}
+}
+
+type stringFlag struct {
+	key   string
+	value string
+}
+
+func (f *stringFlag) Slice() []string {
+	return []string{keyToFlag(f.key), f.value}
+}
+
+type boolFlag struct {
+	key   string
+	value bool
+}
+
+func (f *boolFlag) Slice() []string {
+	var value string
+	if f.value {
+		value = "true"
+	} else {
+		value = "false"
+	}
+
+	return []string{keyToFlag(f.key), value}
+}
+
+type stringSliceFlag struct {
+	key   string
+	value []string
+}
+
+func (f *stringSliceFlag) Slice() []string {
+	return []string{keyToFlag(f.key), strings.Join(f.value, ",")}
+}
+
+// IntFlag returns a Flag with the given key and integer value.
+func IntFlag(key string, value int) Flag {
+	return &intFlag{key, value}
+}
+
+// StringFlag returns a Flag with the given key and string value.
+func StringFlag(key, value string) Flag {
+	return &stringFlag{key, value}
+}
+
+// BoolFlag returns a Flag with the given key and boolean value.
+func BoolFlag(key string, value bool) Flag {
+	return &boolFlag{key, value}
+}
+
+// StringSliceFlag returns a flag with the given key and string slice value.
+func StringSliceFlag(key string, value ...string) Flag {
+	return &stringSliceFlag{key, value}
+}
+
+// Command is a command that has a name, a list of flags, and a list of arguments.
+type Command struct {
+	Name  string
+	Flags []Flag
+	Args  []string
+}
+
+// CommandBuilder is a builder for Command objects.
+type CommandBuilder struct {
+	command Command
+}
+
+// NewCommandBuilder creates and returns a new CommandBuilder with the given name.
+func NewCommandBuilder(name string) *CommandBuilder {
+	return &CommandBuilder{Command{Name: name}}
+}
+
+// Flags appends the given flags to this CommandBuilder.
+func (c *CommandBuilder) Flags(flags ...Flag) *CommandBuilder {
+	c.command.Flags = append(c.command.Flags, flags...)
+	return c
+}
+
+// Args appends the given arguments to this CommandBuilder.
+func (c *CommandBuilder) Args(args ...string) *CommandBuilder {
+	c.command.Args = append(c.command.Args, args...)
+	return c
+}
+
+// Command returns the Command that has been built by this CommandBuilder.
+func (c *CommandBuilder) Command() *Command {
+	return &c.command
+}
+
+// Slice returns a representation of this Command as a slice of strings.
+func (c *Command) Slice() []string {
+	out := []string{c.Name}
+	for _, flag := range c.Flags {
+		out = append(out, flag.Slice()...)
+	}
+	out = append(out, c.Args...)
+	return out
+}
+
+// String returns a representation of this Command as a string.
+func (c *Command) String() string {
+	return strings.Join(c.Slice(), " ")
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/test.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/test.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+)
+
+// WithVar sets the given var to the src value and returns a function to revert to the original state.
+// The type of `dst` has to be a settable pointer.
+// The value of `src` has to be assignable to the type of `dst`.
+//
+// Example usage:
+//   v := "foo"
+//   defer WithVar(&v, "bar")()
+func WithVar(dst, src interface{}) func() {
+	dstValue := reflect.ValueOf(dst)
+	if dstValue.Type().Kind() != reflect.Ptr {
+		ginkgo.Fail(fmt.Sprintf("destination value %T is not a pointer", dst))
+	}
+
+	if dstValue.CanSet() {
+		ginkgo.Fail(fmt.Sprintf("value %T cannot be set", dst))
+	}
+
+	srcValue := reflect.ValueOf(src)
+	if srcValue.Type().AssignableTo(dstValue.Type()) {
+		ginkgo.Fail(fmt.Sprintf("cannot write %T into %T", src, dst))
+	}
+
+	tmp := dstValue.Elem().Interface()
+	dstValue.Elem().Set(srcValue)
+	return func() {
+		dstValue.Elem().Set(reflect.ValueOf(tmp))
+	}
+}
+
+// WithVars sets the given vars to the given values and returns a function to revert back.
+// dstsAndSrcs have to appear in pairs of 2, otherwise there will be a runtime panic.
+//
+// Example usage:
+//  defer WithVars(&v, "foo", &x, "bar")()
+func WithVars(dstsAndSrcs ...interface{}) func() {
+	if len(dstsAndSrcs)%2 != 0 {
+		ginkgo.Fail(fmt.Sprintf("dsts and srcs are not of equal length: %v", dstsAndSrcs))
+	}
+	reverts := make([]func(), 0, len(dstsAndSrcs)/2)
+
+	for i := 0; i < len(dstsAndSrcs); i += 2 {
+		dst := dstsAndSrcs[i]
+		src := dstsAndSrcs[i+1]
+
+		reverts = append(reverts, WithVar(dst, src))
+	}
+
+	return func() {
+		for _, revert := range reverts {
+			revert()
+		}
+	}
+}
+
+// WithEnvVar sets the env variable to the given environment variable and returns a function to revert.
+// If the value is empty, the environment variable will be unset.
+func WithEnvVar(key, value string) func() {
+	tmp := os.Getenv(key)
+
+	var err error
+	if value == "" {
+		err = os.Unsetenv(key)
+	} else {
+		err = os.Setenv(key, value)
+	}
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Could not set the env variable %q to %q: %v", key, value, err))
+	}
+
+	return func() {
+		var err error
+		if tmp == "" {
+			err = os.Unsetenv(key)
+		} else {
+			err = os.Setenv(key, tmp)
+		}
+		if err != nil {
+			ginkgo.Fail(fmt.Sprintf("Could not revert the env variable %q to %q: %v", key, value, err))
+		}
+	}
+}
+
+// WithWd sets the working directory and returns a function to revert to the previous one.
+func WithWd(path string) func() {
+	oldPath, err := os.Getwd()
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Could not obtain current working diretory: %v", err))
+	}
+
+	if err := os.Chdir(path); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Could not change working diretory: %v", err))
+	}
+
+	return func() {
+		if err := os.Chdir(oldPath); err != nil {
+			ginkgo.Fail(fmt.Sprintf("Could not revert working diretory: %v", err))
+		}
+	}
+}
+
+// WithFeatureGate sets the specified gate to the specified value, and returns a function that restores the original value.
+// Failures to set or restore cause the test to fail.
+// Example use:
+//   defer WithFeatureGate(utilfeature.DefaultFeatureGate, features.<FeatureName>, true)()
+func WithFeatureGate(gate featuregate.FeatureGate, f featuregate.Feature, value bool) func() {
+	originalValue := gate.Enabled(f)
+
+	if err := gate.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", f, value)); err != nil {
+		ginkgo.Fail(fmt.Sprintf("could not set feature gate %s=%v: %v", f, value, err))
+	}
+
+	return func() {
+		if err := gate.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", f, originalValue)); err != nil {
+			ginkgo.Fail(fmt.Sprintf("could not restore feature gate %s=%v: %v", f, originalValue, err))
+		}
+	}
+}
+
+// WithTempFile creates a temporary file with the given dir and pattern, writes the given content to it,
+// and returns a function to delete it. Failures to create, open, close, or delete the file case the test to fail.
+//
+// The filename is generated by taking pattern and adding a random string to the end. If pattern includes a "*",
+// the random string replaces the last "*". If dir is the empty string, WriteTempFile uses the default directory for
+// temporary files (see ioutil.TempFile). The caller can use the value of fileName to find the pathname of the file.
+//
+// Example usage:
+//  var fileName string
+//  defer WithTempFile("", "test", []byte("test file content"), &fileName)()
+func WithTempFile(dir, pattern string, content []byte, fileName *string) func() {
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("could not create temp file in directory %s: %v", dir, err))
+	}
+
+	*fileName = file.Name()
+
+	if _, err := file.Write(content); err != nil {
+		ginkgo.Fail(fmt.Sprintf("could not write to temp file %s: %v", file.Name(), err))
+	}
+	if err := file.Close(); err != nil {
+		ginkgo.Fail(fmt.Sprintf("could not close temp file %s: %v", file.Name(), err))
+	}
+
+	return func() {
+		if err := os.Remove(file.Name()); err != nil {
+			ginkgo.Fail(fmt.Sprintf("could not delete temp file %s: %v", file.Name(), err))
+		}
+	}
+}
+
+// EXPECTPatch is a helper function for a GoMock call expecting a patch with the mock client.
+func EXPECTPatch(ctx context.Context, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
+	var expectedPatch client.Patch
+
+	switch patchType {
+	case types.MergePatchType:
+		expectedPatch = client.MergeFrom(mergeFrom)
+	case types.StrategicMergePatchType:
+		expectedPatch = client.StrategicMergeFrom(mergeFrom.DeepCopyObject().(client.Object))
+	}
+
+	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
+}
+
+// EXPECTPatchWithOptimisticLock is a helper function for a GoMock call with the mock client
+// expecting a merge patch with optimistic lock.
+func EXPECTPatchWithOptimisticLock(ctx context.Context, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, rets ...interface{}) *gomock.Call {
+	expectedPatch := client.MergeFromWithOptions(mergeFrom, client.MergeFromWithOptimisticLock{})
+	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
+}
+
+func expectPatch(ctx context.Context, c *mockclient.MockClient, expectedObj client.Object, expectedPatch client.Patch, rets ...interface{}) *gomock.Call {
+	expectedData, expectedErr := expectedPatch.Data(expectedObj)
+	Expect(expectedErr).To(BeNil())
+
+	if rets == nil {
+		rets = []interface{}{nil}
+	}
+
+	// match object key here, but verify contents only inside DoAndReturn.
+	// This is to tell gomock, for which object we expect the given patch, but to enable rich yaml diff between
+	// actual and expected via `DeepEqual`.
+	return c.
+		EXPECT().
+		Patch(ctx, HasObjectKeyOf(expectedObj), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj client.Object, patch client.Patch, _ ...client.PatchOption) error {
+			// if one of these Expects fails and Patch is called in some goroutine (e.g. via flow.Parallel)
+			// the failures will not be shown, as the ginkgo panic is not recovered, so the test is hard to fix
+			defer ginkgo.GinkgoRecover()
+
+			Expect(obj).To(DeepEqual(expectedObj))
+			data, err := patch.Data(obj)
+			Expect(err).To(BeNil())
+			Expect(patch.Type()).To(Equal(expectedPatch.Type()))
+			Expect(string(data)).To(Equal(string(expectedData)))
+			return nil
+		}).
+		Return(rets...)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/test_resources.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/test_resources.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnsureTestResources reads test resources from path, applies them using the given client and returns the created
+// objects.
+func EnsureTestResources(ctx context.Context, c client.Client, path string) ([]client.Object, error) {
+	objects, err := ReadTestResources(c.Scheme(), path)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding resources: %w", err)
+	}
+
+	for _, obj := range objects {
+		current := obj.DeepCopyObject().(client.Object)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(current), current); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+
+			// object doesn't exists, create it
+			if err := c.Create(ctx, obj); err != nil {
+				return nil, err
+			}
+		} else {
+			// object already exists, update it
+			if err := c.Patch(ctx, obj, client.MergeFromWithOptions(current, client.MergeFromWithOptimisticLock{})); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return objects, nil
+}
+
+// ReadTestResources reads test resources from path, decodes them using the given scheme and returns the parsed objects.
+// Objects are values of the proper API types, if registered in the given scheme, and *unstructured.Unstructured
+// otherwise.
+func ReadTestResources(scheme *runtime.Scheme, path string) ([]client.Object, error) {
+	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// file extensions that may contain Webhooks
+	resourceExtensions := sets.NewString(".json", ".yaml", ".yml")
+
+	var objects []client.Object
+	for _, file := range files {
+
+		if file.IsDir() {
+			continue
+		}
+		// Only parse allowlisted file types
+		if !resourceExtensions.Has(filepath.Ext(file.Name())) {
+			continue
+		}
+
+		// Unmarshal Webhooks from file into structs
+		docs, err := readDocuments(filepath.Join(path, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, doc := range docs {
+			obj, err := runtime.Decode(decoder, doc)
+			if err != nil {
+				return nil, err
+			}
+			clientObj, ok := obj.(client.Object)
+			if !ok {
+				return nil, fmt.Errorf("%T does not implement client.Object", obj)
+			}
+
+			objects = append(objects, clientObj)
+		}
+	}
+	return objects, nil
+
+}
+
+// readDocuments reads documents from file
+func readDocuments(fp string) ([][]byte, error) {
+	b, err := os.ReadFile(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs [][]byte
+	reader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(b)))
+	for {
+		// Read document
+		doc, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return nil, err
+		}
+
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -276,6 +276,7 @@ github.com/gardener/gardener/pkg/utils/kubernetes/unstructured
 github.com/gardener/gardener/pkg/utils/managedresources
 github.com/gardener/gardener/pkg/utils/retry
 github.com/gardener/gardener/pkg/utils/secrets
+github.com/gardener/gardener/pkg/utils/test
 github.com/gardener/gardener/pkg/utils/test/matchers
 github.com/gardener/gardener/pkg/utils/time
 github.com/gardener/gardener/pkg/utils/validation/cidr


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR changes the migration logic of the controlplane resource so that first the controplane CRD charts are destroyed, thus deleting the remedy controller, afterwards finalizers on `PublicIPAddresses` and `VirtualMachines` are removed and finally the resources managed by the remedy controller are deleted.

This change is necessary now due to some recent changes which make the `PublicIPAddresses` and `VirtualMachines` be immediately recreated after being deleted (since the corresponding infrastructure resources still exist in the cluster), which was blocking the migration flow from completing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @stoyanr @dkistner 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
