### PR TITLE
Fix `make install`

### DIFF
--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -26,9 +26,9 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane"
-	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	azurev1alpha1 "github.com/gardener/remedy-controller/pkg/apis/azure/v1alpha1"
 )
 
@@ -91,7 +91,7 @@ func (a *actuator) Delete(
 		if meta.LenList(list) != 0 {
 			if time.Since(cp.DeletionTimestamp.Time) <= a.gracefulDeletionTimeout {
 				a.logger.Info("Some publicipaddresses still exist. Deletion will be retried ...")
-				return &controllererror.RequeueAfterError{
+				return &reconcilerutils.RequeueAfterError{
 					RequeueAfter: a.gracefulDeletionWaitInterval,
 				}
 			} else {

--- a/pkg/controller/controlplane/actuator_test.go
+++ b/pkg/controller/controlplane/actuator_test.go
@@ -20,7 +20,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane"
-	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
+	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	azurev1alpha1 "github.com/gardener/remedy-controller/pkg/apis/azure/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -144,7 +144,7 @@ var _ = Describe("Actuator", func() {
 				})
 
 			err := actuator.Delete(ctx, cp, cluster)
-			Expect(err).To(MatchError(&controllererror.RequeueAfterError{RequeueAfter: gracefulDeletionWaitInterval}))
+			Expect(err).To(MatchError(&reconcilerutils.RequeueAfterError{RequeueAfter: gracefulDeletionWaitInterval}))
 		})
 
 		It("should forcefully remove remedy controller resources after grace period timeout has been reached", func() {


### PR DESCRIPTION
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

After the merge of https://github.com/gardener/gardener-extension-provider-azure/pull/410, `make install` fails with:
```
$ make install
> Install
pkg/controller/controlplane/actuator.go:29:2: cannot find package "." in:
	/Users/i331370/go/src/github.com/gardener/gardener-extension-provider-azure/vendor/github.com/gardener/gardener/extensions/pkg/controller/error
make: *** [install] Error 1
```

Meanwhile pkg `gardener/gardener/extensions/pkg/controller/error` was removed with the vendoring to g/g@v1.36.0 - ref https://github.com/gardener/gardener-extension-provider-azure/pull/409.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
