### PR TITLE
Transform deletionTimestamp to local time during graceful deletion check

### DIFF
--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -89,7 +89,7 @@ func (a *actuator) Delete(
 			return err
 		}
 		if meta.LenList(list) != 0 {
-			if time.Since(cp.DeletionTimestamp.Time) <= a.gracefulDeletionTimeout {
+			if time.Since(cp.DeletionTimestamp.Local()) <= a.gracefulDeletionTimeout {
 				a.logger.Info("Some publicipaddresses still exist. Deletion will be retried ...")
 				return &reconcilerutils.RequeueAfterError{
 					RequeueAfter: a.gracefulDeletionWaitInterval,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
During the deletion of the `ControlPlane` resource its deletionTimestamp will now be converted to local time when checking if the period to wait for `PublicIPAddress` resources to be gracefully deleted has elapsed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dkistner @stoyanr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
