### PR TITLE
User lenient decoder for infra status

### DIFF
--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -36,6 +36,9 @@ var (
 	Scheme *runtime.Scheme
 
 	decoder runtime.Decoder
+
+	// lenientDecoder is a decoder that does not use strict mode.
+	lenientDecoder runtime.Decoder
 )
 
 func init() {
@@ -43,6 +46,7 @@ func init() {
 	utilruntime.Must(install.AddToScheme(Scheme))
 
 	decoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDecoder()
+	lenientDecoder = serializer.NewCodecFactory(Scheme).UniversalDecoder()
 }
 
 // InfrastructureConfigFromInfrastructure extracts the InfrastructureConfig from the
@@ -63,7 +67,7 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 func InfrastructureStatusFromInfrastructure(infra *extensionsv1alpha1.Infrastructure) (*api.InfrastructureStatus, error) {
 	config := &api.InfrastructureStatus{}
 	if infra.Status.ProviderStatus != nil && infra.Status.ProviderStatus.Raw != nil {
-		if _, _, err := decoder.Decode(infra.Status.ProviderStatus.Raw, nil, config); err != nil {
+		if _, _, err := lenientDecoder.Decode(infra.Status.ProviderStatus.Raw, nil, config); err != nil {
 			return nil, err
 		}
 		return config, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Due to the removal of the `natGatewayPublicIpMigrated` field in https://github.com/gardener/gardener-extension-provider-azure/pull/406 currently existing shoots may have their reconciliation blocked if they try to reconcile worker resources (e.g. scaling a worker pool) without first reconciling the Infrastructure.

The issue occurs due to the extra field in existing infrastructureStatus that is not allowed from the strict decoder. This PR uses a non-strict decoder to decode the infrastructureStatus.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Azure provider extension now uses non-strict decoder for InfrastructrureStatus resources.
```
