### PR TITLE
Fix CP InfrastructureStatus decoder usage

### DIFF
--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -62,12 +62,12 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 	return nil, fmt.Errorf("provider config is not set on the infrastructure resource")
 }
 
-// InfrastructureStatusFromInfrastructure extracts the InfrastructureStatus from the
+// InfrastructureStatusFromRaw extracts the InfrastructureStatus from the
 // ProviderStatus section of the given Infrastructure.
-func InfrastructureStatusFromInfrastructure(infra *extensionsv1alpha1.Infrastructure) (*api.InfrastructureStatus, error) {
+func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.InfrastructureStatus, error) {
 	config := &api.InfrastructureStatus{}
-	if infra.Status.ProviderStatus != nil && infra.Status.ProviderStatus.Raw != nil {
-		if _, _, err := lenientDecoder.Decode(infra.Status.ProviderStatus.Raw, nil, config); err != nil {
+	if raw != nil && raw.Raw != nil {
+		if _, _, err := lenientDecoder.Decode(raw.Raw, nil, config); err != nil {
 			return nil, err
 		}
 		return config, nil

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -393,9 +393,14 @@ func (vp *valuesProvider) GetConfigChartValues(ctx context.Context, cp *extensio
 	}
 
 	// Decode infrastructureProviderStatus
-	infraStatus := &apisazure.InfrastructureStatus{}
-	if _, _, err := vp.Decoder().Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
-		return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+	var (
+		infraStatus = &apisazure.InfrastructureStatus{}
+		err         error
+	)
+	if cp.Spec.InfrastructureProviderStatus != nil {
+		if infraStatus, err = azureapihelper.InfrastructureStatusFromRaw(cp.Spec.InfrastructureProviderStatus); err != nil {
+			return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+		}
 	}
 
 	// Get client auth
@@ -437,11 +442,16 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 	checksums[azure.CloudProviderConfigName] = utils.ComputeChecksum(cpConfigSecret.Data)
 
-	infraStatus := &apisazure.InfrastructureStatus{}
-	if _, _, err := vp.Decoder().Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
-		return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+	// Decode infrastructureProviderStatus
+	var (
+		infraStatus = &apisazure.InfrastructureStatus{}
+		err         error
+	)
+	if cp.Spec.InfrastructureProviderStatus != nil {
+		if infraStatus, err = azureapihelper.InfrastructureStatusFromRaw(cp.Spec.InfrastructureProviderStatus); err != nil {
+			return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+		}
 	}
-
 	return getControlPlaneChartValues(cpConfig, cp, cluster, checksums, scaledDown, infraStatus)
 }
 
@@ -453,9 +463,14 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	checksums map[string]string,
 ) (map[string]interface{}, error) {
 	// Decode infrastructureProviderStatus
-	infraStatus := &apisazure.InfrastructureStatus{}
-	if _, _, err := vp.Decoder().Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
-		return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+	var (
+		infraStatus = &apisazure.InfrastructureStatus{}
+		err         error
+	)
+	if cp.Spec.InfrastructureProviderStatus != nil {
+		if infraStatus, err = azureapihelper.InfrastructureStatusFromRaw(cp.Spec.InfrastructureProviderStatus); err != nil {
+			return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
+		}
 	}
 
 	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -31,6 +31,8 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardener "github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -79,6 +81,7 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 
 type workerDelegate struct {
 	common.ClientContext
+	lenientDecoder runtime.Decoder
 
 	seedChartApplier gardener.ChartApplier
 	serverVersion    string
@@ -102,7 +105,8 @@ func NewWorkerDelegate(clientContext common.ClientContext, seedChartApplier gard
 	}
 
 	return &workerDelegate{
-		ClientContext: clientContext,
+		ClientContext:  clientContext,
+		lenientDecoder: serializer.NewCodecFactory(clientContext.Scheme()).UniversalDecoder(),
 
 		seedChartApplier: seedChartApplier,
 		serverVersion:    serverVersion,

--- a/pkg/controller/worker/add.go
+++ b/pkg/controller/worker/add.go
@@ -24,10 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var (
-	// DefaultAddOptions are the default AddOptions for AddToManager.
-	DefaultAddOptions = AddOptions{}
-)
+// DefaultAddOptions are the default AddOptions for AddToManager.
+var DefaultAddOptions = AddOptions{}
 
 // AddOptions are options to apply when adding the Azure worker controller to the manager.
 type AddOptions struct {

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -29,15 +29,15 @@ import (
 )
 
 func (w *workerDelegate) decodeAzureInfrastructureStatus() (*azureapi.InfrastructureStatus, error) {
-	var infrastructureStatus = &azureapi.InfrastructureStatus{}
-	if _, _, err := w.Decoder().Decode(w.worker.Spec.InfrastructureProviderStatus.Raw, nil, infrastructureStatus); err != nil {
+	infrastructureStatus := &azureapi.InfrastructureStatus{}
+	if _, _, err := w.lenientDecoder.Decode(w.worker.Spec.InfrastructureProviderStatus.Raw, nil, infrastructureStatus); err != nil {
 		return nil, err
 	}
 	return infrastructureStatus, nil
 }
 
 func (w *workerDelegate) decodeWorkerProviderStatus() (*azureapi.WorkerStatus, error) {
-	var workerStatus = &azureapi.WorkerStatus{}
+	workerStatus := &azureapi.WorkerStatus{}
 	if w.worker.Status.ProviderStatus == nil {
 		return workerStatus, nil
 	}
@@ -49,7 +49,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*azureapi.WorkerStatus, e
 }
 
 func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerStatus *azureapi.WorkerStatus) error {
-	var workerStatusV1alpha1 = &v1alpha1.WorkerStatus{
+	workerStatusV1alpha1 := &v1alpha1.WorkerStatus{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       "WorkerStatus",

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -204,7 +204,7 @@ func ComputeTerraformerTemplateValues(
 }
 
 func generateNatGatewayValues(config *api.InfrastructureConfig) (map[string]interface{}, bool) {
-	var natGatewayConfig = make(map[string]interface{})
+	natGatewayConfig := make(map[string]interface{})
 	if config.Networks.NatGateway == nil || !config.Networks.NatGateway.Enabled {
 		return natGatewayConfig, false
 	}
@@ -218,7 +218,7 @@ func generateNatGatewayValues(config *api.InfrastructureConfig) (map[string]inte
 	}
 
 	if len(config.Networks.NatGateway.IPAddresses) > 0 {
-		var ipAddresses = make([]map[string]interface{}, len(config.Networks.NatGateway.IPAddresses))
+		ipAddresses := make([]map[string]interface{}, len(config.Networks.NatGateway.IPAddresses))
 		for i, ip := range config.Networks.NatGateway.IPAddresses {
 			ipAddresses[i] = map[string]interface{}{
 				"name":          ip.Name,
@@ -270,15 +270,13 @@ type TerraformState struct {
 
 // ExtractTerraformState extracts the TerraformState from the given Terraformer.
 func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer, infra *extensionsv1alpha1.Infrastructure, config *api.InfrastructureConfig, cluster *controller.Cluster) (*TerraformState, error) {
-	var (
-		outputKeys = []string{
-			TerraformerOutputKeyResourceGroupName,
-			TerraformerOutputKeyRouteTableName,
-			TerraformerOutputKeySecurityGroupName,
-			TerraformerOutputKeySubnetName,
-			TerraformerOutputKeyVNetName,
-		}
-	)
+	outputKeys := []string{
+		TerraformerOutputKeyResourceGroupName,
+		TerraformerOutputKeyRouteTableName,
+		TerraformerOutputKeySecurityGroupName,
+		TerraformerOutputKeySubnetName,
+		TerraformerOutputKeyVNetName,
+	}
 
 	primaryAvSetRequired, err := isPrimaryAvailabilitySetRequired(infra, config, cluster)
 	if err != nil {
@@ -302,7 +300,7 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer, infr
 		return nil, err
 	}
 
-	var tfState = TerraformState{
+	tfState := TerraformState{
 		VNetName:          vars[TerraformerOutputKeyVNetName],
 		ResourceGroupName: vars[TerraformerOutputKeyResourceGroupName],
 		RouteTableName:    vars[TerraformerOutputKeyRouteTableName],
@@ -345,7 +343,7 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer, infr
 // StatusFromTerraformState computes an InfrastructureStatus from the given
 // Terraform variables.
 func StatusFromTerraformState(tfState *TerraformState) *apiv1alpha1.InfrastructureStatus {
-	var infraState = apiv1alpha1.InfrastructureStatus{
+	infraState := apiv1alpha1.InfrastructureStatus{
 		TypeMeta: StatusTypeMeta,
 		ResourceGroup: apiv1alpha1.ResourceGroup{
 			Name: tfState.ResourceGroupName,
@@ -428,7 +426,7 @@ func findDomainCounts(cluster *controller.Cluster, infra *extensionsv1alpha1.Inf
 	)
 
 	if infra.Status.ProviderStatus != nil {
-		infrastructureStatus, err := helper.InfrastructureStatusFromInfrastructure(infra)
+		infrastructureStatus, err := helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
 		if err != nil {
 			return nil, fmt.Errorf("error obtaining update and fault domain counts from infrastructure status: %v", err)
 		}
@@ -492,7 +490,7 @@ func isPrimaryAvailabilitySetRequired(infra *extensionsv1alpha1.Infrastructure, 
 	}
 
 	// If the infrastructureStatus already exists that mean the Infrastucture is already created.
-	infrastructureStatus, err := helper.InfrastructureStatusFromInfrastructure(infra)
+	infrastructureStatus, err := helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Fix an InfrastructureStatus decoding usage that was not addressed by https://github.com/gardener/gardener-extension-provider-azure/pull/414

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
