### PR TITLE
Remove the "garden.sapcloud.io/role" label from control plane components

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -20,7 +20,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl
@@ -30,7 +30,6 @@ spec:
       labels:
         app: csi
         role: controller-{{ .role }}
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed

--- a/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: remedy-controller-azure
         networking.gardener.cloud/to-dns: allowed


### PR DESCRIPTION
/kind cleanup
/platform azure

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/422

Ref gardener/gardener#1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
