### PR TITLE
Kubernetes Version Configurability per Worker Pool

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -520,6 +520,11 @@ Both are compatible with the legacy in-tree volume provisioners that were deprec
 End-users might want to update their custom `StorageClass`es to the new `disk.csi.azure.com` or `file.csi.azure.com` provisioner, respectively.
 Shoot clusters with Kubernetes v1.20 or less will use the in-tree `kubernetes.io/azure-disk` and `kubernetes.io/azure-file` volume provisioners in the kube-controller-manager and the kubelet.
 
+## Kubernetes Versions per Worker Pool
+
+This extension supports `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) since `gardener-extension-provider-azure@v1.25`.
+Note that this feature is only usable for `Shoot`s whose `.spec.kubernetes.version` is greater or equal than the CSI migration version (`1.21`).
+
 ## Miscellaneous
 
 ### Azure Accelerated Networking

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
+	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azurevalidation "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/validation"
 
@@ -105,7 +105,7 @@ func (s *shoot) validateCreation(ctx context.Context, shoot *core.Shoot, cloudPr
 		return err
 	}
 
-	var cpConfig *azure.ControlPlaneConfig
+	var cpConfig *api.ControlPlaneConfig
 	if shoot.Spec.Provider.ControlPlaneConfig != nil {
 		cpConfig, err = decodeControlPlaneConfig(s.decoder, shoot.Spec.Provider.ControlPlaneConfig)
 		if err != nil {
@@ -120,7 +120,7 @@ func (s *shoot) validateCreation(ctx context.Context, shoot *core.Shoot, cloudPr
 	return s.validateShootSecret(ctx, shoot)
 }
 
-func (s *shoot) validateShoot(shoot *core.Shoot, oldInfraConfig, infraConfig *azure.InfrastructureConfig, cloudProfile *gardencorev1beta1.CloudProfile, cpConfig *azure.ControlPlaneConfig) field.ErrorList {
+func (s *shoot) validateShoot(shoot *core.Shoot, oldInfraConfig, infraConfig *api.InfrastructureConfig, cloudProfile *gardencorev1beta1.CloudProfile, cpConfig *api.ControlPlaneConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Network validation
@@ -161,7 +161,7 @@ func (s *shoot) validateUpdate(oldShoot, shoot *core.Shoot, cloudProfile *garden
 	}
 
 	// Decode the new controlplane config
-	var cpConfig *azure.ControlPlaneConfig
+	var cpConfig *api.ControlPlaneConfig
 	if shoot.Spec.Provider.ControlPlaneConfig != nil {
 		cpConfig, err = decodeControlPlaneConfig(s.decoder, shoot.Spec.Provider.ControlPlaneConfig)
 		if err != nil {

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -149,6 +149,10 @@ const (
 	// ExtensionPurposeServicePrincipalSecret is the label value for a Secret resource
 	// that hold service principal information to a corresponding AD tenant.
 	ExtensionPurposeServicePrincipalSecret = "tenant-service-principal-secret"
+
+	// CSIMigrationKubernetesVersion is a constant for the Kubernetes version for which the Shoot's CSI migration will be
+	// performed.
+	CSIMigrationKubernetesVersion = "1.21"
 )
 
 var (

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -519,7 +519,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		}
 	}
 
-	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +550,7 @@ func (vp *valuesProvider) GetControlPlaneShootCRDsChartValues(
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func getCSIControllerChartValues(
 	scaledDown bool,
 	infraStatus *apisazure.InfrastructureStatus,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.21")
+	k8sVersionLessThan121, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/csimigration/add.go
+++ b/pkg/controller/csimigration/add.go
@@ -36,7 +36,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return csimigration.Add(mgr, csimigration.AddArgs{
 		ControllerOptions:             opts.Controller,
-		CSIMigrationKubernetesVersion: "1.21",
+		CSIMigrationKubernetesVersion: azure.CSIMigrationKubernetesVersion,
 		Type:                          azure.Type,
 		StorageClassNameToLegacyProvisioner: map[string]string{
 			"default":              "kubernetes.io/azure-disk",

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -48,7 +48,7 @@ var (
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g azure) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
 	csiEnabledPreCheckFunc := func(_ client.Object, cluster *extensionscontroller.Cluster) bool {
-		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.21")
+		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", azure.CSIMigrationKubernetesVersion)
 		if err != nil {
 			return false
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -394,7 +394,7 @@ func (e *ensurer) ensureKubeletCommandLineArgs(ctx context.Context, cluster *ext
 }
 
 // EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.
-func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.GardenContext, kubeletVersion *semver.Version, new, old *kubeletconfigv1beta1.KubeletConfiguration) error {
+func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.GardenContext, kubeletVersion *semver.Version, new, _ *kubeletconfigv1beta1.KubeletConfiguration) error {
 	cluster, err := gctx.GetCluster(ctx)
 	if err != nil {
 		return err
@@ -413,7 +413,7 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		new.FeatureGates["CSIMigration"] = true
 		new.FeatureGates["CSIMigrationAzureDisk"] = true
 		new.FeatureGates["CSIMigrationAzureFile"] = true
-		// kubelets of new worker nodes can directly be started with the `CSIMigrationAzure<*>Complete` feature gates
+		// kubelets of new worker nodes can directly be started with the `InTreePluginAzure<*>Unregister` feature gates
 		new.FeatureGates["InTreePluginAzureDiskUnregister"] = true
 		new.FeatureGates["InTreePluginAzureFileUnregister"] = true
 
@@ -426,7 +426,7 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 }
 
 // ShouldProvisionKubeletCloudProviderConfig returns true if the cloud provider config file should be added to the kubelet configuration.
-func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, gctx gcontext.GardenContext, kubeletVersion *semver.Version) bool {
+func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, gctx gcontext.GardenContext, _ *semver.Version) bool {
 	cluster, err := gctx.GetCluster(ctx)
 	if err != nil {
 		return false
@@ -441,7 +441,7 @@ func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context,
 }
 
 // EnsureKubeletCloudProviderConfig ensures that the cloud provider config file conforms to the provider requirements.
-func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, _ gcontext.GardenContext, kubeletVersion *semver.Version, data *string, namespace string) error {
+func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, _ gcontext.GardenContext, _ *semver.Version, data *string, namespace string) error {
 	secret := &corev1.Secret{}
 	if err := e.client.Get(ctx, kutil.Key(namespace, azure.CloudProviderDiskConfigName), secret); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -462,7 +462,7 @@ func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, _ gconte
 	return nil
 }
 
-// EnsureAdditionalFile ensures additional systemd files
+// EnsureAdditionalFiles ensures additional systemd files
 func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
 	return e.ensureAcrConfigFile(ctx, gctx, new)
 }

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -44,8 +44,7 @@ import (
 )
 
 const (
-	acrConfigPath       = "/var/lib/kubelet/acr.conf"
-	csiMigrationVersion = "1.21"
+	acrConfigPath = "/var/lib/kubelet/acr.conf"
 )
 
 // NewEnsurer creates a new controlplane ensurer.
@@ -77,7 +76,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -101,7 +100,7 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -126,7 +125,7 @@ func (e *ensurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -355,7 +354,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 		return nil, err
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +400,7 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		return err
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -433,7 +432,7 @@ func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context,
 		return false
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, azure.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform azure
/merge squash

**What this PR does / why we need it**:
This PR implements support for `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate. As explained in https://github.com/gardener/gardener/issues/3501#issuecomment-1009061189, it
- adds validation to prevent using kubelet versions lower than the CSI migration version (note that this ensures that the feature is only usable once the cluster with its control plane and **all** its worker pools was upgraded to at least the CSI migration version).


Note that there is no need for adapting the `controlpane` webhook to use the effective kubelet version since there are no version specific constraints.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#3501

**Special notes for your reviewer**:
✅ ~Depends on #428, hence, PR is in draft state.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
This extension does now support `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70).
```
```feature user
In case `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate is enabled, it's possible having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) for `Shoot`s whose `.spec.kubernetes.version` is greater or equal than the CSI migration version (`1.21`).
```