### PR TITLE
Setting CSI Azure topology label on machine deployment creation to allow scale-up

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/utils"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -102,6 +103,8 @@ var _ = Describe("Machines", func() {
 		})
 
 		Describe("#GenerateMachineDeployments, #DeployMachineClasses", func() {
+			const azureCSIDiskDriverTopologyKey = "topology.disk.csi.azure.com/zone"
+
 			var (
 				machineImageName      string
 				machineImageVersion   string
@@ -204,7 +207,7 @@ var _ = Describe("Machines", func() {
 				maxSurgePool2 = intstr.FromInt(10)
 				maxUnavailablePool2 = intstr.FromInt(15)
 
-				shootVersionMajorMinor = "1.2"
+				shootVersionMajorMinor = "1.21"
 				shootVersion = shootVersionMajorMinor + ".3"
 
 				machineImages = []apiv1alpha1.MachineImages{
@@ -502,6 +505,8 @@ var _ = Describe("Machines", func() {
 						machineClassNamePool2 = fmt.Sprintf("%s-z%s", basename, zone2)
 						machineClassWithHashPool1 = fmt.Sprintf("%s-%s-z%s", basename, workerPoolHashZ1, zone1)
 						machineClassWithHashPool2 = fmt.Sprintf("%s-%s-z%s", basename, workerPoolHashZ2, zone2)
+						labelsPool1 := utils.MergeStringMaps(labels, map[string]string{azureCSIDiskDriverTopologyKey: zone1})
+						labelsPool2 := utils.MergeStringMaps(labels, map[string]string{azureCSIDiskDriverTopologyKey: zone2})
 
 						machineDeployments = worker.MachineDeployments{
 							{
@@ -512,7 +517,7 @@ var _ = Describe("Machines", func() {
 								Maximum:              maxPoolZones,
 								MaxSurge:             maxSurgePoolZones,
 								MaxUnavailable:       maxUnavailablePoolZones,
-								Labels:               labels,
+								Labels:               labelsPool1,
 								MachineConfiguration: &machinev1alpha1.MachineConfiguration{},
 							},
 							{
@@ -523,7 +528,7 @@ var _ = Describe("Machines", func() {
 								Maximum:              maxPoolZones,
 								MaxSurge:             maxSurgePoolZones,
 								MaxUnavailable:       maxUnavailablePoolZones,
-								Labels:               labels,
+								Labels:               labelsPool2,
 								MachineConfiguration: &machinev1alpha1.MachineConfiguration{},
 							},
 						}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform azure

**What this PR does / why we need it**:
adds driver specific CSI label `topology.disk.csi.azure.com/zone` during machineDeployment creation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
machineDeployment will have the label `topology.disk.csi.azure.com/zone` when created if the shoot has csi enabled
```
