### PR TITLE
Support for Kubernetes v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.23 | 1.23.0+     | N/A |
 | Kubernetes 1.22 | 1.22.0+     | [![Gardener v1.22 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.22%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.22%20Azure) |
 | Kubernetes 1.21 | 1.21.0+     | [![Gardener v1.21 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.21%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.21%20Azure) |
 | Kubernetes 1.20 | 1.20.0+     | [![Gardener v1.20 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.20%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.20%20Azure) |

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -37,7 +37,16 @@ images:
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
   tag: "v1.22.6"
-  targetVersion: ">= 1.22"
+  targetVersion: "1.22.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  tag: "v1.23.2"
+  targetVersion: ">= 1.23"
+- name: cloud-node-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
+  tag: "v1.23.2"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,17 +26,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.20.12"
+  tag: "v1.20.15"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.21.6"
+  tag: "v1.21.9"
   targetVersion: "1.21.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
-  tag: "v1.22.3"
+  tag: "v1.22.6"
   targetVersion: ">= 1.22"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -40,6 +40,8 @@ spec:
         {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
         - cloud-controller-manager
+        {{- else if semverCompare ">= 1.23" .Values.kubernetesVersion }}
+        - /usr/local/bin/cloud-controller-manager
         {{- else }}
         - /azure-cloud-controller-manager
         {{- end }}
@@ -50,6 +52,10 @@ spec:
         - --cluster-name={{ .Values.clusterName }}
         - --concurrent-service-syncs=1
         - --configure-cloud-routes=true
+        {{- if semverCompare ">= 1.23" .Values.kubernetesVersion }}
+        - --controllers=*,-cloud-node
+        - --route-reconciliation-period=10s
+        {{- end }}
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         {{- if .Values.global.useTokenRequestor }}
         - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
@@ -1,0 +1,123 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: cloud-node-manager
+  name: cloud-node-manager
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.global.useProjectedTokenMount }}
+automountServiceAccountToken: false
+{{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-node-manager
+  labels:
+    k8s-app: cloud-node-manager
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch","list","get","update", "patch"]
+- apiGroups: [""]
+  resources: ["nodes/status"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-node-manager
+  labels:
+    k8s-app: cloud-node-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-node-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-node-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: cloud-node-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cloud-node-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: cloud-node-manager
+      annotations:
+        cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
+        {{- if .Values.global.useProjectedTokenMount }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
+        {{- end }}
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: cloud-node-manager
+      hostNetwork: true   # required to fetch correct hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: NoExecute
+      - operator: "Exists"
+        effect: NoSchedule
+      containers:
+      - name: cloud-node-manager
+        image: {{ index .Values.images "cloud-node-manager" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - cloud-node-manager
+        - --node-name=$(NODE_NAME)
+        - --wait-routes=true   # only set to true when --configure-cloud-routes=true in cloud-controller-manager.
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+
+{{- if .Values.global.vpaEnabled }}
+---
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: cloud-node-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 20m
+        memory: 25Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: cloud-node-manager
+  updatePolicy:
+    updateMode: "Auto"
+{{- end }}
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/rbac-cloud-controller.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/rbac-cloud-controller.yaml
@@ -1,3 +1,112 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    k8s-app: cloud-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: User
+  name: system:cloud-controller-manager
+- kind: User
+  name: cloud-controller-manager
+{{- else }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -23,3 +132,4 @@ subjects:
 - kind: ServiceAccount
   name: azure-cloud-provider
   namespace: kube-system
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/rbac-node-controller.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/rbac-node-controller.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.23" .Capabilities.KubeVersion.GitVersion -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -41,3 +42,4 @@ subjects:
 - kind: ServiceAccount
   name: cloud-node-controller
   namespace: kube-system
+{{- end -}}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/values.yaml
@@ -1,0 +1,5 @@
+images:
+  cloud-node-manager: image-repository:image-tag
+
+global:
+  vpaEnabled: false

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_vpa.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_vpa.tpl
@@ -1,5 +1,5 @@
 {{- define "csi-driver-node.vpa" -}}
-{{- if .Values.vpaEnabled -}}
+{{- if .Values.global.vpaEnabled -}}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -9,7 +9,9 @@ images:
   csi-liveness-probe: image-repository:image-tag
 
 socketPath: /csi/csi.sock
-vpaEnabled: false
+
+global:
+  vpaEnabled: false
 
 resources:
   driver:

--- a/charts/internal/shoot-system-components/values.yaml
+++ b/charts/internal/shoot-system-components/values.yaml
@@ -9,3 +9,6 @@ csi-driver-node:
   enabled: false
 remedy-controller-azure:
   enabled: true
+
+global:
+  vpaEnabled: false

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -32,6 +32,8 @@ const (
 
 	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
 	CloudControllerManagerImageName = "cloud-controller-manager"
+	// CloudNodeManagerImageName is the name of the cloud-node-manager image.
+	CloudNodeManagerImageName = "cloud-node-manager"
 	// CSIDriverDiskImageName is the name of the csi-driver-disk image.
 	CSIDriverDiskImageName = "csi-driver-disk"
 	// CSIDriverFileImageName is the name of the csi-driver-file image.

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -318,6 +318,9 @@ var (
 			},
 			{
 				Name: azure.CloudControllerManagerName,
+				Images: []string{
+					azure.CloudNodeManagerImageName,
+				},
 				Objects: []*chart.Object{
 					{Type: &rbacv1.ClusterRole{}, Name: "system:controller:cloud-node-controller"},
 					{Type: &rbacv1.ClusterRoleBinding{}, Name: "system:controller:cloud-node-controller"},
@@ -810,18 +813,20 @@ func getControlPlaneShootChartValues(
 		"global": map[string]interface{}{
 			"useTokenRequestor":      useTokenRequestor,
 			"useProjectedTokenMount": useProjectedTokenMount,
+			"vpaEnabled":             gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 		},
 		azure.AllowEgressName:            map[string]interface{}{"enabled": infraStatus.Zoned || azureapihelper.IsVmoRequired(infraStatus)},
 		azure.CloudControllerManagerName: map[string]interface{}{"enabled": true},
 		azure.CSINodeName: map[string]interface{}{
 			"enabled":           !k8sVersionLessThan121,
 			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-			"vpaEnabled":        gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 			"podAnnotations": map[string]interface{}{
 				"checksum/configmap-" + azure.CloudProviderDiskConfigName: cloudProviderDiskConfigChecksum,
 			},
 			"cloudProviderConfig": cloudProviderDiskConfig,
 		},
-		azure.RemedyControllerName: map[string]interface{}{"enabled": !disableRemedyController},
+		azure.RemedyControllerName: map[string]interface{}{
+			"enabled": !disableRemedyController,
+		},
 	}
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -498,15 +498,23 @@ var _ = Describe("ValuesProvider", func() {
 				"podAnnotations": map[string]interface{}{
 					"checksum/configmap-" + azure.CloudProviderDiskConfigName: "",
 				},
-				"vpaEnabled":          false,
 				"cloudProviderConfig": "",
 				"kubernetesVersion":   "1.15.4",
 			})
+			globalVpaDisabled = map[string]interface{}{
+				"useTokenRequestor":      true,
+				"useProjectedTokenMount": true,
+				"vpaEnabled":             false,
+			}
+			globalVpaEnabled = map[string]interface{}{
+				"useTokenRequestor":      true,
+				"useProjectedTokenMount": true,
+				"vpaEnabled":             true,
+			}
 			csiNodeEnabled = utils.MergeMaps(enabledTrue, map[string]interface{}{
 				"podAnnotations": map[string]interface{}{
 					"checksum/configmap-" + azure.CloudProviderDiskConfigName: checksums[azure.CloudProviderDiskConfigName],
 				},
-				"vpaEnabled":          true,
 				"cloudProviderConfig": cloudProviderConfigData,
 				"kubernetesVersion":   "1.21.4",
 			})
@@ -519,10 +527,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaDisabled,
 					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
@@ -538,10 +543,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaDisabled,
 					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
@@ -574,10 +576,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaEnabled,
 					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeEnabled,
@@ -593,10 +592,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaEnabled,
 					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeEnabled,
@@ -612,10 +608,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaEnabled,
 					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeEnabled,
@@ -636,10 +629,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaDisabled,
 					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,
@@ -655,10 +645,7 @@ var _ = Describe("ValuesProvider", func() {
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, checksums)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
-					"global": map[string]interface{}{
-						"useTokenRequestor":      true,
-						"useProjectedTokenMount": true,
-					},
+					"global":                         globalVpaDisabled,
 					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: enabledTrue,
 					azure.CSINodeName:                csiNodeNotEnabled,

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -32,6 +32,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	oscutils "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/version"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -361,7 +362,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 
 	if opt := extensionswebhook.UnitOptionWithSectionAndName(new, "Service", "ExecStart"); opt != nil {
 		command := extensionswebhook.DeserializeCommandLine(opt.Value)
-		command, err := e.ensureKubeletCommandLineArgs(ctx, cluster, command, csiEnabled)
+		command, err := e.ensureKubeletCommandLineArgs(ctx, cluster, command, csiEnabled, kubeletVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -370,10 +371,12 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 	return new, nil
 }
 
-func (e *ensurer) ensureKubeletCommandLineArgs(ctx context.Context, cluster *extensionscontroller.Cluster, command []string, csiEnabled bool) ([]string, error) {
+func (e *ensurer) ensureKubeletCommandLineArgs(ctx context.Context, cluster *extensionscontroller.Cluster, command []string, csiEnabled bool, kubeletVersion *semver.Version) ([]string, error) {
 	if csiEnabled {
-		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
-		command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
+		if !version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
+			command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
+			command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
+		}
 	} else {
 		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "azure")
 		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-config=", "/var/lib/kubelet/cloudprovider.conf")
@@ -414,6 +417,10 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		// kubelets of new worker nodes can directly be started with the `CSIMigrationAzure<*>Complete` feature gates
 		new.FeatureGates["InTreePluginAzureDiskUnregister"] = true
 		new.FeatureGates["InTreePluginAzureFileUnregister"] = true
+
+		if version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
+			new.EnableControllerAttachDetach = pointer.Bool(true)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform azure
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.23 to the extension.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#5102

**Special notes for your reviewer**:
* ✅ ~Depends on #428, hence, PR is in draft state.~
* ✅ ~Depends on #421, hence, PR is in draft state.~
* I have successfully validated the functionality as follows:
  * :white_check_mark: Create new clusters with versions < 1.23
  * :white_check_mark: Create new clusters with version  = 1.23
  * :white_check_mark: Upgrade old clusters from version 1.22 to version 1.23
  * :white_check_mark: Delete clusters with versions < 1.23
  * :white_check_mark: Delete clusters with version  = 1.23

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```feature user
The Azure extension does now support shoot clusters with Kubernetes version 1.23. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md) before upgrading to 1.23. 
```