### PR TITLE
Add support for sa token volume projection in admission charts

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
@@ -34,6 +34,12 @@ roleRef:
   kind: ClusterRole
   name: {{ include "name" . }}
 subjects:
+{{- if and .Values.global.virtualGarden.enabled .Values.global.virtualGarden.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.virtualGarden.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gardener-extension-admission-azure/charts/application/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.global.virtualGarden.enabled ( not .Values.global.virtualGarden.user.name ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "labels" . | indent 4 }}
+{{- end }}

--- a/charts/gardener-extension-admission-azure/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-azure/charts/runtime/templates/deployment.yaml
@@ -21,10 +21,15 @@ spec:
       labels:
 {{ include "labels" . | indent 8 }}
     spec:
+      {{- if not .Values.global.virtualGarden.enabled }}
+      serviceAccountName: {{ include "name" . }}
+      {{- else if and .Values.global.virtualGarden.enabled .Values.global.virtualGarden.user.name }}
+      {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+      serviceAccountName: {{ include "name" . }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.global.kubeconfig }}
       automountServiceAccountToken: false
-      {{- else }}
-      serviceAccountName: {{ include "name" . }}
       {{- end }}
       containers:
       - name: {{ include "name" . }}
@@ -54,6 +59,11 @@ spec:
           mountPath: /etc/gardener-extension-admission-azure/kubeconfig
           readOnly: true
         {{- end }}
+        {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+        - name: service-account-token
+          mountPath: /var/run/secrets/projected/serviceaccount
+          readOnly: true
+        {{- end }}
       volumes:
       - name: gardener-extension-admission-azure-cert
         secret:
@@ -64,4 +74,15 @@ spec:
         secret:
           secretName: gardener-extension-admission-azure-kubeconfig
           defaultMode: 420
+      {{- end }}
+      {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: {{ .Values.global.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- if .Values.global.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.global.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
       {{- end }}

--- a/charts/gardener-extension-admission-azure/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-azure/charts/runtime/templates/serviceaccount.yaml
@@ -1,0 +1,19 @@
+{{- if not .Values.global.virtualGarden.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+{{- else if and .Values.global.virtualGarden.enabled .Values.global.virtualGarden.user.name }}
+{{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/gardener-extension-admission-azure/values.yaml
+++ b/charts/gardener-extension-admission-azure/values.yaml
@@ -1,6 +1,8 @@
 global:
   virtualGarden:
     enabled: false
+    user:
+      name: ""
   image:
     repository: eu.gcr.io/gardener-project/gardener/extensions/admission-azure
     tag: latest
@@ -32,3 +34,8 @@ global:
         -----END RSA PRIVATE KEY-----
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:
+
+  serviceAccountTokenVolumeProjection:
+    enabled: false
+    expirationSeconds: 43200
+    audience: ""

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,16 +21,16 @@ clusters:
 - cluster:
     certificate-authority-data: <CA-DATA>
     server: https://default.kubernetes.svc.cluster.local
-    name: garden
+  name: garden
 contexts:
 - context:
     cluster: garden
     user: garden
-    name: garden
+  name: garden
 current-context: garden
 users:
 - name: garden
-    user:
+  user:
     tokenFile: /var/run/secrets/projected/serviceaccount/token
 ```
 
@@ -70,15 +70,15 @@ clusters:
 - cluster:
     certificate-authority-data: <CA-DATA>
     server: https://virtual-garden.api
-    name: virtual-garden
+  name: virtual-garden
 contexts:
 - context:
     cluster: virtual-garden
     user: virtual-garden
-    name: virtual-garden
+  name: virtual-garden
 current-context: virtual-garden
 users:
 - name: virtual-garden
-    user:
+  user:
     tokenFile: /var/run/secrets/projected/serviceaccount/token
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,84 @@
+# Deployment of the Azure provider extension
+
+**Disclaimer:** This document is NOT a step by step installation guide for the Azure provider extension and only contains some configuration specifics regarding the installation of different components via the helm charts residing in the Azure provider extension [repository](https://github.com/gardener/gardener-extension-provider-azure).
+
+## gardener-extension-admission-azure
+
+### Authentication against the Garden cluster
+There are several authentication possibilities depending on whether or not [the concept of *Virtual Garden*](https://github.com/gardener/garden-setup#concept-the-virtual-cluster) is used.
+
+#### *Virtual Garden* is not used, i.e., the `runtime` Garden cluster is also the `target` Garden cluster.
+
+**Automounted Service Account Token**
+The easiest way to deploy the `gardener-extension-admission-azure` component will be to not provide `kubeconfig` at all. This way in-cluster configuration and an automounted service account token will be used. The drawback of this approach is that the automounted token will not be automatically rotated.
+
+**Service Account Token Volume Projection**
+Another solution will be to use [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) combined with a `kubeconfig` referencing a token file (see example below).
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: <CA-DATA>
+    server: https://default.kubernetes.svc.cluster.local
+    name: garden
+contexts:
+- context:
+    cluster: garden
+    user: garden
+    name: garden
+current-context: garden
+users:
+- name: garden
+    user:
+    tokenFile: /var/run/secrets/projected/serviceaccount/token
+```
+
+This will allow for automatic rotation of the service account token by the `kubelet`. The configuration can be achieved by setting both `.Values.global.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.kubeconfig` in the respective chart's `values.yaml` file.
+
+#### *Virtual Garden* is used, i.e., the `runtime` Garden cluster is different from the `target` Garden cluster.
+
+**Service Account**
+The easiest way to setup the authentication will be to create a service account and the respective roles will be bound to this service account in the `target` cluster. Then use the generated service account token and craft a `kubeconfig` which will be used by the workload in the `runtime` cluster. This approach does not provide a solution for the rotation of the service account token. However, this setup can be achieved by setting `.Values.global.virtualGarden.enabled: true` and following these steps:
+
+1. Deploy the `application` part of the charts in the `target` cluster.
+2. Get the service account token and craft the `kubeconfig`.
+3. Set the crafted `kubeconfig` and deploy the `runtime` part of the charts in the `runtime` cluster.
+
+**Client Certificate**
+Another solution will be to bind the roles in the `target` cluster to a `User` subject instead of a service account and use a client certificate for authentication. This approach does not provide a solution for the client certificate rotation. However, this setup can be achieved by setting both `.Values.global.virtualGarden.enabled: true` and `.Values.global.virtualGarden.user.name`, then following these steps:
+
+1. Generate a client certificate for the `target` cluster for the respective user.
+2. Deploy the `application` part of the charts in the `target` cluster.
+3. Craft a `kubeconfig` using the already generated client certificate.
+4. Set the crafted `kubeconfig` and deploy the `runtime` part of the charts in the `runtime` cluster.
+
+**Projected Service Account Token**
+This approach requires an already deployed and configured [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator) for the `target` cluster. Also the `runtime` cluster should be registered as a trusted identity provider in the `target` cluster. Then projected service accounts tokens from the `runtime` cluster can be used to authenticate against the `target` cluster. The needed steps are as follows:
+
+1. Deploy [OWA](https://github.com/gardener/oidc-webhook-authenticator) and establish the needed trust.
+2. Set `.Values.global.virtualGarden.enabled: true` and `.Values.global.virtualGarden.user.name`. **Note:** username value will depend on the trust configuration, e.g., `<prefix>:system:serviceaccount:<namespace>:<serviceaccount>`
+3. Set `.Values.global.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.serviceAccountTokenVolumeProjection.audience`. **Note:** audience value will depend on the trust configuration, e.g., `<cliend-id-from-trust-config>`.
+4. Craft a kubeconfig (see example below).
+5. Deploy the `application` part of the charts in the `target` cluster.
+6. Deploy the `runtime` part of the charts in the `runtime` cluster.
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: <CA-DATA>
+    server: https://virtual-garden.api
+    name: virtual-garden
+contexts:
+- context:
+    cluster: virtual-garden
+    user: virtual-garden
+    name: virtual-garden
+current-context: virtual-garden
+users:
+- name: virtual-garden
+    user:
+    tokenFile: /var/run/secrets/projected/serviceaccount/token
+```


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR adds: 

- The ability to configure the admission deployment to use service account token volume projection ([ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)).
- The ability to configure a user instead of a service account subject in the `clusterrolebinding` definition when using a "virtual garden" setup. This will enable other possibilities for authentication to the virtual garden, i.e., leveraging [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is related to gardener/gardener-extension-provider-gcp#380

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-extension-admission-azure` now supports configuration for enabling service account token volume projection. It is exposed through the `.Values.global.serviceAccountTokenVolumeProjection` section in the respective chart's values.
```

```feature operator
It is now possible to configure a `user` instead of a `serviceaccount` subject in the `clusterrolebinding` for the `gardener-extension-admission-azure` when using virtual garden setup by setting `.Values.global.virtualGarden.user.name`.
```

