### PR TITLE
Cherry pick of #430 #433

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -164,7 +164,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					Maximum:              pool.Maximum,
 					MaxSurge:             pool.MaxSurge,
 					MaxUnavailable:       pool.MaxUnavailable,
-					Labels:               addTopologyLabel(pool.Labels, csiEnabled, zone),
+					Labels:               addTopologyLabel(pool.Labels, csiEnabled, w.worker.Spec.Region, zone),
 					Annotations:          pool.Annotations,
 					Taints:               pool.Taints,
 					MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
@@ -373,9 +373,9 @@ func SanitizeAzureVMTag(label string) string {
 	return tagRegex.ReplaceAllString(strings.ToLower(label), "_")
 }
 
-func addTopologyLabel(labels map[string]string, csiEnabled bool, zone *zoneInfo) map[string]string {
+func addTopologyLabel(labels map[string]string, csiEnabled bool, region string, zone *zoneInfo) map[string]string {
 	if csiEnabled && zone != nil {
-		return utils.MergeStringMaps(labels, map[string]string{azureCSIDiskDriverTopologyKey: zone.name})
+		return utils.MergeStringMaps(labels, map[string]string{azureCSIDiskDriverTopologyKey: region + "-" + zone.name})
 	}
 	return labels
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -102,8 +102,6 @@ var _ = Describe("Machines", func() {
 		})
 
 		Describe("#GenerateMachineDeployments, #DeployMachineClasses", func() {
-			const azureCSIDiskDriverTopologyKey = "topology.disk.csi.azure.com/zone"
-
 			var (
 				machineImageName      string
 				machineImageVersion   string

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -102,6 +102,8 @@ var _ = Describe("Machines", func() {
 		})
 
 		Describe("#GenerateMachineDeployments, #DeployMachineClasses", func() {
+			const azureCSIDiskDriverTopologyKey = "topology.disk.csi.azure.com/zone"
+
 			var (
 				machineImageName      string
 				machineImageVersion   string
@@ -192,7 +194,13 @@ var _ = Describe("Machines", func() {
 				maxSurgePool2 = intstr.FromInt(10)
 				maxUnavailablePool2 = intstr.FromInt(15)
 
-				shootVersionMajorMinor = "1.2"
+				namePool2 = "pool-zones"
+				minPool2 = 30
+				maxPool2 = 45
+				maxSurgePool2 = intstr.FromInt(10)
+				maxUnavailablePool2 = intstr.FromInt(15)
+
+				shootVersionMajorMinor = "1.21"
 				shootVersion = shootVersionMajorMinor + ".3"
 
 				machineImages = []apiv1alpha1.MachineImages{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR cherry picks the changes from master which adds topology label to machinedeployment
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The unit tests have been removed as they needed other feature to be cherrypicked as well which is a part of master.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
topology label `topology.disk.csi.azure.com/zone` is added to machinedeployment to assist in scale-from-zero
```
