### PR TITLE
Adapt `ClusterRoleBinding` for `remedy-controller` in case token requestor is enabled

### DIFF
--- a/charts/internal/shoot-system-components/charts/remedy-controller-azure/templates/clusterrolebinding.yaml
+++ b/charts/internal/shoot-system-components/charts/remedy-controller-azure/templates/clusterrolebinding.yaml
@@ -7,5 +7,11 @@ roleRef:
   kind: ClusterRole
   name: {{ include "remedy-controller-azure.extensionsGroup" . }}:{{ include "remedy-controller-azure.name" . }}:remedy-controller-azure
 subjects:
+{{- if .Values.global.useTokenRequestor }}
+- kind: ServiceAccount
+  name: remedy-controller-azure
+  namespace: kube-system
+{{- else }}
 - kind: User
   name: {{ include "remedy-controller-azure.extensionsGroup" . }}:{{ include "remedy-controller-azure.name" . }}:remedy-controller-azure
+{{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform azure

**What this PR does / why we need it**:
With #421, the remedy-controller `Deployment` was adapted to the token requestor. However, its `ClusterRoleBinding` was not. This prevents it from starting:

```
E0219 16:12:08.902743       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:241: Failed to watch *v1.Node: failed to list *v1.Node: nodes is forbidden: User "system:serviceaccount:kube-system:remedy-controller-azure" cannot list resource "nodes" in API group "" at the cluster scope
E0219 16:12:08.902757       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:241: Failed to watch *v1.Service: failed to list *v1.Service: services is forbidden: User "system:serviceaccount:kube-system:remedy-controller-azure" cannot list resource "services" in API group "" at the cluster scope
```

**Special notes for your reviewer**:
/invite @dkistner @kon-angelo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
