### PR TITLE
fix printing tf template with multiple ip addresses

### DIFF
--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -134,7 +134,7 @@ resource "azurerm_subnet_nat_gateway_association" "{{ $natName }}-worker-subnet-
 #===============================================
 #= NAT Gateway User provided IP
 #===============================================
-{{ range $ipIndex, $ip := .natGateway.ipAddresses -}}
+{{ range $ipIndex, $ip := .natGateway.ipAddresses }}
 data "azurerm_public_ip" "{{ $natName }}-ip-user-provided-{{ $ipIndex }}" {
   name                = "{{ $ip.name }}"
   resource_group_name = "{{ $ip.resourceGroup }}"
@@ -144,8 +144,7 @@ resource "azurerm_nat_gateway_public_ip_association" "{{ $natName }}-ip-user-pro
   nat_gateway_id       = azurerm_nat_gateway.{{ $natName }}.id
   public_ip_address_id = data.azurerm_public_ip.{{ $natName }}-ip-user-provided-{{ $ipIndex }}.id
 }
-
-{{- end }}
+{{ end }}
 {{- else -}}
 #===============================================
 #= NAT Gateway managed IP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

Fixes an error when printing the terraform template when a user provides `>1` public IPs for the NAT Gateway
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a bug in the terraform manifest generation when more than one public IP Addresses were provided for the NAT Gateway
```
