### PR TITLE
Update testdef timeout

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -4,12 +4,12 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Integration test for infrastructure creation and deletion
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:
     - >-
-      go test -timeout=25m -mod=vendor ./test/integration/infrastructure
+      go test -timeout=0 -mod=vendor ./test/integration/infrastructure
       --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
       --kubeconfig=$TM_KUBECONFIG_PATH/testmachinery.config
       --subscription-id=${SUBSCRIPTION_ID}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind test
/platform azure

**What this PR does / why we need it**:

Updates the timeouts for the integration tests. After https://github.com/gardener/gardener-extension-provider-azure/pull/450 the test suite may not have enough time with the addition of the latest test. Now it relies on test-machinery's timeout and is increased to 1 hour (plus some buffer).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
