### PR TITLE
Keep kubelet's `--cloud-provider` flag even for 1.23+

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -372,8 +372,9 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 
 func (e *ensurer) ensureKubeletCommandLineArgs(ctx context.Context, cluster *extensionscontroller.Cluster, command []string, csiEnabled bool, kubeletVersion *semver.Version) ([]string, error) {
 	if csiEnabled {
+		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
+
 		if !version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
-			command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 			command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
 		}
 	} else {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -445,8 +445,8 @@ var _ = Describe("Ensurer", func() {
 			Entry("kubelet < 1.21, w/ acr", eContextK8s117, semver.MustParse("1.17.0"), "azure", true, false),
 			Entry("1.21 <= kubelet < 1.23, w/o acr", eContextK8s121, semver.MustParse("1.21.0"), "external", false, true),
 			Entry("1.21 <= kubelet < 1.23, w/ acr", eContextK8s121, semver.MustParse("1.21.0"), "external", true, true),
-			Entry("kubelet >= 1.23, w/o acr", eContextK8s121, semver.MustParse("1.23.0"), "", false, false),
-			Entry("kubelet >= 1.23, w/ acr", eContextK8s121, semver.MustParse("1.23.0"), "", true, false),
+			Entry("kubelet >= 1.23, w/o acr", eContextK8s121, semver.MustParse("1.23.0"), "external", false, false),
+			Entry("kubelet >= 1.23, w/ acr", eContextK8s121, semver.MustParse("1.23.0"), "external", true, false),
 		)
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform azure

**What this PR does / why we need it**:
Even for 1.23, the `providerID` field in the `NodeSpec` is not maintained without this field, making it impossible for load balancers to function correctly.

**Special notes for your reviewer**:
See for reference: https://github.com/gardener/gardener-extension-provider-aws/issues/514#issuecomment-1064163827 and https://github.com/gardener/gardener-extension-provider-aws/pull/515

/invite @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue preventing load balancers from being functional for K8s 1.23 clusters has been fixed.
```
