### PR TITLE
[release-v1.26] Automated cherry pick of #462: Keep kubelet's `--cloud-provider` flag even for 1.23+

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -372,8 +372,9 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 
 func (e *ensurer) ensureKubeletCommandLineArgs(ctx context.Context, cluster *extensionscontroller.Cluster, command []string, csiEnabled bool, kubeletVersion *semver.Version) ([]string, error) {
 	if csiEnabled {
+		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
+
 		if !version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
-			command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 			command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
 		}
 	} else {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -445,8 +445,8 @@ var _ = Describe("Ensurer", func() {
 			Entry("kubelet < 1.21, w/ acr", eContextK8s117, semver.MustParse("1.17.0"), "azure", true, false),
 			Entry("1.21 <= kubelet < 1.23, w/o acr", eContextK8s121, semver.MustParse("1.21.0"), "external", false, true),
 			Entry("1.21 <= kubelet < 1.23, w/ acr", eContextK8s121, semver.MustParse("1.21.0"), "external", true, true),
-			Entry("kubelet >= 1.23, w/o acr", eContextK8s121, semver.MustParse("1.23.0"), "", false, false),
-			Entry("kubelet >= 1.23, w/ acr", eContextK8s121, semver.MustParse("1.23.0"), "", true, false),
+			Entry("kubelet >= 1.23, w/o acr", eContextK8s121, semver.MustParse("1.23.0"), "external", false, false),
+			Entry("kubelet >= 1.23, w/ acr", eContextK8s121, semver.MustParse("1.23.0"), "external", true, false),
 		)
 	})
 


### PR DESCRIPTION
/area/usability
/kind/bug

Cherry pick of #462 on release-v1.26.

#462: Keep kubelet's `--cloud-provider` flag even for 1.23+

**Release Notes:**
```bugfix user
An issue preventing load balancers from being functional for K8s 1.23 clusters has been fixed.
```