### PR TITLE
Fix csi-driver-controller-disk ClusterRoleBinding

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrolebinding-csi-driver-controller-disk.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrolebinding-csi-driver-controller-disk.yaml
@@ -8,6 +8,12 @@ roleRef:
   kind: ClusterRole
   name: {{ include "csi-driver-node.extensionsGroup" . }}:{{ include "csi-driver-node.name" . }}:csi-driver-controller-disk
 subjects:
+{{- if .Values.global.useTokenRequestor }}
+- kind: ServiceAccount
+  name: csi-driver-controller-disk
+  namespace: kube-system
+{{- else }}
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: {{ include "csi-driver-node.extensionsGroup" . }}:{{ include "csi-driver-node.name" . }}:csi-driver-controller-disk
+{{- end }}


### PR DESCRIPTION
/area security
/kind bug
/platform azure

**What this PR does / why we need it**:
In https://github.com/gardener/gardener-extension-provider-azure/pull/421 we missed to adapt the `charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrolebinding-csi-driver-controller-disk.yaml` ClusterRole.

Currently the following errors can be observed in the csi-driver-controller-disk/azure-csi-driver:
```
E0407 12:48:43.560990       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:49:43.655928       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:50:43.672364       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:51:43.689365       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:52:43.709170       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:53:43.722929       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:54:43.736579       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:55:43.746389       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:56:43.752852       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
E0407 12:57:43.755456       1 utils.go:100] GRPC error: rpc error: code = Internal desc = ListVolumes failed while fetching PersistentVolumes List with error: persistentvolumes is forbidden: User "system:serviceaccount:kube-system:csi-driver-controller-disk" cannot list resource "persistentvolumes" in API group "" at the cluster scope
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing csi-driver-controller-disk/azure-csi-driver to fail with forbidden error while trying to list PersistentVolumes is now fixed.
```
