### PR TITLE
[release-v1.26] Automated cherry pick of #477: Fix csi-driver-controller-disk ClusterRoleBinding

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrolebinding-csi-driver-controller-disk.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrolebinding-csi-driver-controller-disk.yaml
@@ -8,6 +8,12 @@ roleRef:
   kind: ClusterRole
   name: {{ include "csi-driver-node.extensionsGroup" . }}:{{ include "csi-driver-node.name" . }}:csi-driver-controller-disk
 subjects:
+{{- if .Values.global.useTokenRequestor }}
+- kind: ServiceAccount
+  name: csi-driver-controller-disk
+  namespace: kube-system
+{{- else }}
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: {{ include "csi-driver-node.extensionsGroup" . }}:{{ include "csi-driver-node.name" . }}:csi-driver-controller-disk
+{{- end }}


### PR DESCRIPTION
/area/security
/kind/bug

Cherry pick of #477 on release-v1.26.

#477: Fix csi-driver-controller-disk ClusterRoleBinding

**Release Notes:**
```bugfix operator
An issue causing csi-driver-controller-disk/azure-csi-driver to fail with forbidden error while trying to list PersistentVolumes is now fixed.
```