### PR TITLE
Assign value to `nodeTemplate.zone` in case of non-zonal setup

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -202,6 +202,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 
 			if pool.NodeTemplate != nil {
+				//TODO: make Zone field in nodeTemplate optional and not to pass it in case of non-zonal setup
 				zoneName := "no-zone"
 
 				if zone != nil {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -202,7 +202,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 
 			if pool.NodeTemplate != nil {
-				//TODO: make Zone field in nodeTemplate optional and not to pass it in case of non-zonal setup
+				//	Currently Zone field is mandatory, and passing it an
+				//	empty string turns it to `null` string during marshalling which fails CRD validation
+				//	so setting it to a dummy value `no-zone`
+				//	TODO: Zone field in nodeTemplate optional and not to pass it in case of non-zonal setup
 				zoneName := "no-zone"
 
 				if zone != nil {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -202,7 +202,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 
 			if pool.NodeTemplate != nil {
-				var zoneName string
+				zoneName := "no-zone"
 
 				if zone != nil {
 					zoneName = w.worker.Spec.Region + "-" + zone.name

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -210,14 +210,14 @@ var _ = Describe("Machines", func() {
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
-					Zone:         "",
+					Zone:         "no-zone",
 				}
 
 				nodeTemplateZone2 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
-					Zone:         "",
+					Zone:         "no-zone",
 				}
 
 				namePool2 = "pool-2"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind regression
/platform azure

**What this PR does / why we need it**:
Earlier in case of non-zonal setup the `nodeTemplate.zone` field was left empty because of which it got converted to `null` string during marshalling to json, and failed CRD validation as the field is non-nullable.
Now `nodeTemplate.zone` is assigned value `no-zone` in case its a non-zonal setup.
The field value is used in CA to create a label during creation of template for node during scale-from-zero, and wouldn't affect any autoscaling.

**Which issue(s) this PR fixes**:
Fixes #476 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
/invite @kon-angelo @ialidzhikov 