### PR TITLE
Forbid k8s version upgrade from `< v1.21` to `>= v1.21.0`

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -179,6 +179,9 @@ func (s *shoot) validateUpdate(oldShoot, shoot *core.Shoot, cloudProfile *garden
 
 	allErrs = append(allErrs, s.validateShoot(shoot, oldInfraConfig, infraConfig, cloudProfile, cpConfig)...)
 
+	// TODO(dkistner) remove this once csi-driver async operation issues are resolved.
+	allErrs = append(allErrs, azurevalidation.ValidateUpgradeV120ToV121(shoot, oldShoot, specPath.Child("kubernetes", "version"))...)
+
 	return allErrs.ToAggregate()
 }
 

--- a/pkg/apis/azure/validation/shoot.go
+++ b/pkg/apis/azure/validation/shoot.go
@@ -31,6 +31,12 @@ import (
 
 const maxDataVolumeCount = 64
 
+var k8sV121 *semver.Version
+
+func init() {
+	k8sV121 = semver.MustParse("v1.21.0")
+}
+
 // ValidateNetworking validates the network settings of a Shoot.
 func ValidateNetworking(networking core.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -156,5 +162,30 @@ func validateVolumeFunc(volumeType *string, volumeSize string, encrypted *bool, 
 	if encrypted != nil {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("encrypted"), *encrypted, nil))
 	}
+	return allErrs
+}
+
+// ValidateUpgradeV120ToV121 prevents that Shoots get updated from k8s v1.20 to v1.21.
+// TODO(dkistner) remove this once csi-driver async operation issues are resolved.
+func ValidateUpgradeV120ToV121(newShoot, oldShoot *core.Shoot, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	oldShootVersion, err := semver.NewVersion(oldShoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath, oldShoot.Spec.Kubernetes.Version, "could not parse kubernetes version"))
+	}
+
+	newShootVersion, err := semver.NewVersion(newShoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath, newShoot.Spec.Kubernetes.Version, "could not parse kubernetes version"))
+	}
+
+	if oldShootVersion.LessThan(k8sV121) && (newShootVersion.Equal(k8sV121) || newShootVersion.GreaterThan(k8sV121)) {
+		if value, ok := newShoot.Annotations[azure.ForceK8sVersionUpgrade]; ok && value == "true" {
+			return allErrs
+		}
+		allErrs = append(allErrs, field.Forbidden(fldPath, "upgrade Kubernetes version from < v1.21 to >= v1.21.0 are disabled"))
+	}
+
 	return allErrs
 }

--- a/pkg/apis/azure/validation/shoot_test.go
+++ b/pkg/apis/azure/validation/shoot_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
 )
@@ -370,6 +372,48 @@ var _ = Describe("Shoot validation", func() {
 				})
 			})
 		})
+
+		DescribeTable("#ValidateUpgradeV120ToV121",
+			func(oldShoot, newShoot *core.Shoot, matcher types.GomegaMatcher) {
+				Expect(ValidateUpgradeV120ToV121(newShoot, oldShoot, field.NewPath("spec", "kubernetes", "version"))).To(matcher)
+			},
+			Entry(
+				"should forbid version upgrade from < v1.21 to >= v1.21.0",
+				makeShootWithVersion("v1.20.0", map[string]string{}),
+				makeShootWithVersion("v1.21.0", map[string]string{}),
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.version"),
+				}))),
+			),
+			Entry(
+				"should allow k8s version upgrade from < v1.21 to < v1.21",
+				makeShootWithVersion("v1.20.0", map[string]string{}),
+				makeShootWithVersion("v1.20.1", map[string]string{}),
+				HaveLen(0),
+			),
+			Entry(
+				"should allow k8s version upgrade >= v1.21 to > v1.21",
+				makeShootWithVersion("v1.21.0", map[string]string{}),
+				makeShootWithVersion("v1.21.1", map[string]string{}),
+				HaveLen(0),
+			),
+			Entry(
+				"should allow enforced k8s version upgrade from < v1.21 to >= v1.21",
+				makeShootWithVersion("v1.20.0", map[string]string{}),
+				makeShootWithVersion("v1.21.0", map[string]string{"shoot.gardener.cloud/force-version-upgrade": "true"}),
+				HaveLen(0),
+			),
+			Entry(
+				"should forbid enforced k8s version upgrade from < v1.21 to >= v1.21 due to invalid annotation",
+				makeShootWithVersion("v1.20.0", map[string]string{}),
+				makeShootWithVersion("v1.21.0", map[string]string{"shoot.gardener.cloud/force-version-upgrade": "abc"}),
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.version"),
+				}))),
+			),
+		)
 	})
 })
 
@@ -379,4 +423,17 @@ func copyWorkers(workers []core.Worker) []core.Worker {
 		copy[i].Zones = append(workers[i].Zones[:0:0], workers[i].Zones...)
 	}
 	return copy
+}
+
+func makeShootWithVersion(version string, annotations map[string]string) *core.Shoot {
+	return &core.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+		Spec: core.ShootSpec{
+			Kubernetes: core.Kubernetes{
+				Version: version,
+			},
+		},
+	}
 }

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -153,6 +153,10 @@ const (
 	// CSIMigrationKubernetesVersion is a constant for the Kubernetes version for which the Shoot's CSI migration will be
 	// performed.
 	CSIMigrationKubernetesVersion = "1.21"
+
+	// ForceK8sVersionUpgrade is an annotation set on the Shoot resource that allows to enforce a k8s version upgrade
+	// even if it would otherwise be forbidden by the admission controller.
+	ForceK8sVersionUpgrade = "shoot.gardener.cloud/force-version-upgrade"
 )
 
 var (


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/platform azure

**What this PR does / why we need it**:
As we are currently experience severe issues with the csi-driver for Azure, we will temporally forbid Shoot to upgrade from `< v1.21` to `>= v1.21.0` as with `v1.21` Azure clusters start to adopt csi.

This is a safety measure to not affect existing cluster with the current csi related issues.
The upgrade can still be enforced by adding the annotation `shoot.gardener.cloud/force-version-upgrade=true` to the Shoot on own risk.

New Shoot can still be created with `>= v1.21.0`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Azure Shoot cluster can temporally not be upgrade from Kubernetes version < v1.21 to >= v1.21.0. The upgrade can still be enforced by adding the annotation `shoot.gardener.cloud/force-version-upgrade=true` to the Shoot on own risk.
```
