### PR TITLE
admission-azure: Add missing `cloudprofiles` resource to the ValidatingWebhookConfiguration

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml
@@ -14,6 +14,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
+    - cloudprofiles
     - shoots
   failurePolicy: Fail
   objectSelector:

--- a/example/40-validatingwebhookconfiguration.yaml
+++ b/example/40-validatingwebhookconfiguration.yaml
@@ -14,8 +14,8 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - shoots
     - cloudprofiles
+    - shoots
   failurePolicy: Fail
   # Please make sure you are running `gardener@v1.42` or later before enabling this
   objectSelector:


### PR DESCRIPTION
/area quality
/kind bug
/platform azure

#245 adds CloudProfile validator but does not adapt the resources section in the ValidatingWebhookConfiguration with the new CloudProfile resource that is being validated.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing admission-azure to do not validate CloudProfiles (with `.spec.type=azure`) is now fixed.
```
