### PR TITLE
[release-v1.27] Automated cherry pick of #505: admission-azure: Add missing `cloudprofiles` resource to the ValidatingWebhookConfiguration

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/validatingwebhook-validator.yaml
@@ -14,6 +14,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
+    - cloudprofiles
     - shoots
   failurePolicy: Fail
   objectSelector:

--- a/example/40-validatingwebhookconfiguration.yaml
+++ b/example/40-validatingwebhookconfiguration.yaml
@@ -14,8 +14,8 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - shoots
     - cloudprofiles
+    - shoots
   failurePolicy: Fail
   # Please make sure you are running `gardener@v1.42` or later before enabling this
   objectSelector:


### PR DESCRIPTION
/area/quality
/kind/bug

Cherry pick of #505 on release-v1.27.

#505: admission-azure: Add missing `cloudprofiles` resource to the ValidatingWebhookConfiguration

**Release Notes:**
```bugfix operator
An issue causing admission-azure to do not validate CloudProfiles (with `.spec.type=azure`) is now fixed.
```