### PR TITLE
Fix Shoot reconciliation for K8s < 1.23 clusters

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -47,7 +47,7 @@ images:
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
   tag: "v1.23.2"
-  targetVersion: "1.23.x"
+  targetVersion: "< 1.24"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager


### PR DESCRIPTION
/area control-plane
/kind bug
/platform azure

After #509 azure Shoot cluster reconciliation for K8s < 1.23 clusters fails with:
```yaml
  lastErrors:
    - description: >-
        task "Waiting until shoot control plane has been reconciled" failed:
        Error while waiting for ControlPlane shoot-foo-bar/bar to become ready:
        error during reconciliation: Error reconciling controlplane: could not
        apply control plane shoot chart for controlplane 'shoot-foo-bar/bar':
        could not render chart: could not inject chart
        'cloud-controller-manager' images: could not find image
        "cloud-node-manager" opts runtime version 1.21.10 target version 1.21.10
      taskID: Waiting until shoot control plane has been reconciled
      lastUpdateTime: '2022-05-31T08:28:09Z'
```

This issue comes from 

https://github.com/gardener/gardener-extension-provider-azure/blob/9f6e5176483a8628bc396a6fc4c9510f1ab22d15/pkg/controller/controlplane/valuesprovider.go#L201-L203

Although the image is used only for K8s >= 1.23, the ChartApplier tries to find image also for the other K8s versions which fails with the above error.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
