### PR TITLE
Fix bastion for multi subnet

### DIFF
--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -183,19 +183,19 @@ func getPublicIP(ctx context.Context, factory azureclient.Factory, opt *Options)
 	return ip, nil
 }
 
-func getSubnet(ctx context.Context, factory azureclient.Factory, opt *Options) (*network.Subnet, error) {
+func getSubnet(ctx context.Context, factory azureclient.Factory, vNet, subnetWork string, opt *Options) (*network.Subnet, error) {
 	subnetClient, err := factory.Subnet(ctx, opt.SecretReference)
 	if err != nil {
 		return nil, err
 	}
 
-	subnet, err := subnetClient.Get(ctx, opt.ResourceGroupName, opt.VirtualNetwork, opt.Subnetwork, "")
+	subnet, err := subnetClient.Get(ctx, opt.ResourceGroupName, vNet, subnetWork, "")
 	if err != nil {
 		return nil, err
 	}
 
 	if subnet == nil {
-		logger.Info("subnet not found,", "subnet_name", opt.Subnetwork)
+		logger.Info("subnet not found,", "subnet_name", subnetWork)
 		return nil, nil
 	}
 

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -35,7 +35,12 @@ func (a *actuator) Delete(ctx context.Context, bastion *extensionsv1alpha1.Basti
 
 	var factory = azureclient.NewAzureClientFactory(a.client)
 
-	opt, err := DetermineOptions(bastion, cluster)
+	infrastructureStatus, err := getInfrastructureStatus(ctx, a, cluster)
+	if err != nil {
+		return err
+	}
+
+	opt, err := DetermineOptions(bastion, cluster, infrastructureStatus.ResourceGroup.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -21,12 +21,15 @@ import (
 	"net"
 	"time"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	ctrlerror "github.com/gardener/gardener/pkg/controllerutils/reconciler"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +55,12 @@ func (a *actuator) Reconcile(ctx context.Context, bastion *extensionsv1alpha1.Ba
 		factory = azureclient.NewAzureClientFactory(a.client)
 	)
 
-	opt, err := DetermineOptions(bastion, cluster)
+	infrastructureStatus, err := getInfrastructureStatus(ctx, a, cluster)
+	if err != nil {
+		return err
+	}
+
+	opt, err := DetermineOptions(bastion, cluster, infrastructureStatus.ResourceGroup.Name)
 	if err != nil {
 		return err
 	}
@@ -62,7 +70,15 @@ func (a *actuator) Reconcile(ctx context.Context, bastion *extensionsv1alpha1.Ba
 		return err
 	}
 
-	nic, err := ensureNic(ctx, factory, opt, publicIP)
+	if infrastructureStatus.Networks.Layout != "SingleSubnet" {
+		return fmt.Errorf("unsupported network layout %s", infrastructureStatus.Networks.Layout)
+	}
+
+	if infrastructureStatus.Networks.VNet.Name == "" || len(infrastructureStatus.Networks.Subnets) == 0 {
+		return errors.New("virtual network name and subnet must be set")
+	}
+
+	nic, err := ensureNic(ctx, factory, opt, infrastructureStatus.Networks.VNet.Name, infrastructureStatus.Networks.Subnets[0].Name, publicIP)
 	if err != nil {
 		return err
 	}
@@ -108,6 +124,28 @@ func (a *actuator) Reconcile(ctx context.Context, bastion *extensionsv1alpha1.Ba
 	patch := client.MergeFrom(bastion.DeepCopy())
 	bastion.Status.Ingress = endpoints.public
 	return a.client.Status().Patch(ctx, bastion, patch)
+}
+
+func getInfrastructureStatus(ctx context.Context, a *actuator, cluster *extensions.Cluster) (*azure.InfrastructureStatus, error) {
+	var infrastructureStatus *azure.InfrastructureStatus
+	worker := &extensionsv1alpha1.Worker{}
+	err := a.client.Get(ctx, client.ObjectKey{Namespace: cluster.ObjectMeta.Name, Name: cluster.Shoot.Name}, worker)
+	if err != nil {
+		return nil, err
+	}
+
+	if worker == nil || worker.Spec.InfrastructureProviderStatus == nil {
+		return nil, errors.New("infrastructure provider status must be not empty for worker")
+	}
+
+	if infrastructureStatus, err = helper.InfrastructureStatusFromRaw(worker.Spec.InfrastructureProviderStatus); err != nil {
+		return nil, err
+	}
+
+	if infrastructureStatus.ResourceGroup.Name == "" {
+		return nil, errors.New("resource group name must be not empty for infrastructure provider status")
+	}
+	return infrastructureStatus, nil
 }
 
 func getPrivateIPv4Address(nic *network.Interface) (string, error) {
@@ -257,7 +295,7 @@ func ensureComputeInstance(ctx context.Context, logger logr.Logger, bastion *ext
 	return nil
 }
 
-func ensureNic(ctx context.Context, factory azureclient.Factory, opt *Options, publicIP *network.PublicIPAddress) (*network.Interface, error) {
+func ensureNic(ctx context.Context, factory azureclient.Factory, opt *Options, vNet, subnetWork string, publicIP *network.PublicIPAddress) (*network.Interface, error) {
 	nic, err := getNic(ctx, factory, opt)
 	if err != nil {
 		return nil, err
@@ -271,7 +309,7 @@ func ensureNic(ctx context.Context, factory azureclient.Factory, opt *Options, p
 
 	logger.Info("create new bastion compute instance nic")
 
-	subnet, err := getSubnet(ctx, factory, opt)
+	subnet, err := getSubnet(ctx, factory, vNet, subnetWork, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +426,7 @@ func addOrReplaceNsgRulesDefinition(existingRules *[]network.SecurityRule, desir
 
 	// filter rules intended to be replaced
 	for _, existentRule := range *existingRules {
-		if ruleExist(existentRule.Name, desiredRules) {
+		if RuleExist(existentRule.Name, desiredRules) {
 			continue
 		}
 		result = append(result, existentRule)
@@ -403,7 +441,8 @@ func addOrReplaceNsgRulesDefinition(existingRules *[]network.SecurityRule, desir
 	*existingRules = result
 }
 
-func ruleExist(ruleName *string, rules *[]network.SecurityRule) bool {
+// RuleExist checks if the rule with the given name is present in the list of rules.
+func RuleExist(ruleName *string, rules *[]network.SecurityRule) bool {
 	if ruleName == nil {
 		return false
 	}

--- a/pkg/controller/bastion/bastion_test.go
+++ b/pkg/controller/bastion/bastion_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Bastion test", func() {
 		It("getWorkersCIDR", func() {
 			cidr, err := getWorkersCIDR(createAzureTestCluster())
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(cidr).To(Equal("10.250.0.0/16"))
+			Expect(cidr).To(Equal([]string{"10.250.0.0/16"}))
 		})
 	})
 
@@ -171,7 +171,7 @@ var _ = Describe("Bastion test", func() {
 				Name:      "cloudprovider",
 			}))
 			Expect(options.CIDRs).To(Equal([]string{"213.69.151.0/24"}))
-			Expect(options.WorkersCIDR).To(Equal("10.250.0.0/16"))
+			Expect(options.WorkersCIDR).To(Equal([]string{"10.250.0.0/16"}))
 			Expect(options.DiskName).To(Equal("cluster1-bastionName1-bastion-1cdc8-disk"))
 			Expect(options.Location).To(Equal("westeurope"))
 			Expect(options.ResourceGroupName).To(Equal("cluster1"))
@@ -238,7 +238,6 @@ var _ = Describe("Bastion test", func() {
 			res, err := ingressPermissions(bastion)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(res[0]).To(Equal("213.69.151.0/24"))
-
 		})
 		It("Should throw an error with invalid CIDR entry", func() {
 			bastion.Spec.Ingress = []extensionsv1alpha1.BastionIngressPolicy{
@@ -261,7 +260,6 @@ var _ = Describe("Bastion test", func() {
 			res, err := ingressPermissions(bastion)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(res[0]).To(Equal("2001:1db8:85a3:1111:1111:8a2e:1370:7334/128"))
-
 		})
 	})
 
@@ -275,7 +273,6 @@ var _ = Describe("Bastion test", func() {
 		})
 
 		It("Should return single security rule and keep with NIL name", func() {
-
 			original := &[]network.SecurityRule{
 				{Name: nil},
 				{Name: pointer.String("ruleName1")},
@@ -330,7 +327,6 @@ var _ = Describe("Bastion test", func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 	})
-
 })
 
 func createShootTestStruct() *gardencorev1beta1.Shoot {
@@ -342,7 +338,9 @@ func createShootTestStruct() *gardencorev1beta1.Shoot {
 			Provider: gardencorev1beta1.Provider{
 				InfrastructureConfig: &runtime.RawExtension{
 					Raw: []byte(json),
-				}}},
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/controller/bastion/bastion_test.go
+++ b/pkg/controller/bastion/bastion_test.go
@@ -161,13 +161,11 @@ var _ = Describe("Bastion test", func() {
 
 	Describe("Determine options", func() {
 		It("should return options", func() {
-			options, err := DetermineOptions(bastion, cluster)
+			options, err := DetermineOptions(bastion, cluster, "cluster1")
 			Expect(err).To(Not(HaveOccurred()))
 
 			Expect(options.BastionInstanceName).To(Equal("cluster1-bastionName1-bastion-1cdc8"))
-			Expect(options.Subnetwork).To(Equal("cluster1-nodes"))
 			Expect(options.BastionPublicIPName).To(Equal("cluster1-bastionName1-bastion-1cdc8-public-ip"))
-			Expect(options.VirtualNetwork).To(Equal("cluster1"))
 			Expect(options.SecretReference).To(Equal(corev1.SecretReference{
 				Namespace: "cluster1",
 				Name:      "cloudprovider",

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -26,8 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-//Maximum length for "base" name due to fact that we use this name to name other Azure resources,
-//https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+// Maximum length for "base" name due to fact that we use this name to name other Azure resources,
+// https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
 const maxLengthForBaseName = 33
 
 // Options contains provider-related information required for setting up
@@ -46,7 +46,7 @@ type Options struct {
 	NicID               string
 	DiskName            string
 	SecretReference     corev1.SecretReference
-	WorkersCIDR         string
+	WorkersCIDR         []string
 	CIDRs               []string
 	Tags                map[string]*string
 }

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -33,7 +33,7 @@ const maxLengthForBaseName = 33
 // Options contains provider-related information required for setting up
 // a bastion instance. This struct combines precomputed values like the
 // bastion instance name with the IDs of pre-existing cloud provider
-// resources, like the nic name, subnet name etc.
+// resources, like the nic name etc.
 type Options struct {
 	BastionInstanceName string
 	BastionPublicIPName string
@@ -45,8 +45,6 @@ type Options struct {
 	NicName             string
 	NicID               string
 	DiskName            string
-	Subnetwork          string
-	VirtualNetwork      string
 	SecretReference     corev1.SecretReference
 	WorkersCIDR         string
 	CIDRs               []string
@@ -55,7 +53,7 @@ type Options struct {
 
 // DetermineOptions determines the information that are required to reconcile a Bastion on Azure. This
 // function does not create any IaaS resources.
-func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.Cluster) (*Options, error) {
+func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.Cluster, resourceGroup string) (*Options, error) {
 	clusterName := cluster.ObjectMeta.Name
 	baseResourceName, err := generateBastionBaseResourceName(clusterName, bastion.Name)
 	if err != nil {
@@ -84,15 +82,13 @@ func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.C
 
 	return &Options{
 		BastionInstanceName: baseResourceName,
-		Subnetwork:          nodesResourceName(clusterName),
 		BastionPublicIPName: publicIPResourceName(baseResourceName),
-		VirtualNetwork:      clusterName,
 		SecretReference:     secretReference,
 		CIDRs:               cidrs,
 		WorkersCIDR:         workersCidr,
 		DiskName:            DiskResourceName(baseResourceName),
 		Location:            cluster.Shoot.Spec.Region,
-		ResourceGroupName:   cluster.ObjectMeta.Name,
+		ResourceGroupName:   resourceGroup,
 		NicName:             NicResourceName(baseResourceName),
 		Tags:                tags,
 		SecurityGroupName:   NSGName(clusterName),

--- a/pkg/controller/bastion/resourcesdefine.go
+++ b/pkg/controller/bastion/resourcesdefine.go
@@ -33,7 +33,8 @@ func nicDefine(opt *Options, publicIP *network.PublicIPAddress, subnet *network.
 					Name: to.StringPtr("ipConfig1"),
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							ID: subnet.ID},
+							ID: subnet.ID,
+						},
 						PrivateIPAllocationMethod: network.Dynamic,
 						PublicIPAddress:           publicIP,
 					},
@@ -150,15 +151,15 @@ func nsgEgressAllowSSHToWorkerIPv4(opt *Options) network.SecurityRule {
 	return network.SecurityRule{
 		Name: to.StringPtr(NSGEgressAllowOnlyResourceName(opt.BastionInstanceName)),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Protocol:                 network.SecurityRuleProtocolTCP,
-			SourceAddressPrefix:      &opt.PrivateIPAddressV4,
-			SourcePortRange:          to.StringPtr("*"),
-			DestinationAddressPrefix: to.StringPtr(opt.WorkersCIDR),
-			DestinationPortRange:     to.StringPtr(SSHPort),
-			Access:                   network.SecurityRuleAccessAllow,
-			Direction:                network.SecurityRuleDirectionOutbound,
-			Priority:                 to.Int32Ptr(401),
-			Description:              to.StringPtr("Allow Bastion egress to Shoot workers ipv4"),
+			Protocol:                   network.SecurityRuleProtocolTCP,
+			SourceAddressPrefix:        &opt.PrivateIPAddressV4,
+			SourcePortRange:            to.StringPtr("*"),
+			DestinationAddressPrefixes: to.StringSlicePtr(opt.WorkersCIDR),
+			DestinationPortRange:       to.StringPtr(SSHPort),
+			Access:                     network.SecurityRuleAccessAllow,
+			Direction:                  network.SecurityRuleDirectionOutbound,
+			Priority:                   to.Int32Ptr(401),
+			Description:                to.StringPtr("Allow Bastion egress to Shoot workers ipv4"),
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Bastion now correctly computes network information (vnet, subnet) from infrastructure status.
```
```feature user
Add bastion support for multi-subnet deployments
```