### PR TITLE
Add PodSecurityPolicy for cloud-node-manager

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-clusterrole.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:psp:kube-system:cloud-node-manager
+rules:
+- apiGroups:
+  - policy
+  - extensions
+  resourceNames:
+  - extensions.gardener.cloud.provider-azure.cloud-node-manager
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-rolebinding.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gardener.cloud:psp:kube-system:cloud-node-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:psp:kube-system:cloud-node-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-manager
+  namespace: kube-system
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
@@ -1,0 +1,21 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: extensions.gardener.cloud.provider-azure.cloud-node-manager
+spec:
+  privileged: true
+  volumes:
+  - projected
+  hostNetwork: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: false
+{{- end }}


### PR DESCRIPTION
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
With K8s 1.23 we enable OOT azure CCM. Currently for Shoots with `spec.kubenetes.allowPrivilegedContainers=false` the Shoot creation fails. The root cause is that cloud-node-manager is missing PSP and no cloud-node-manager Pods can be created:

```
$ k -n kube-system describe ds cloud-node-manager

Events:
  Type     Reason        Age                    From                  Message
  ----     ------        ----                   ----                  -------
  Warning  FailedCreate  15m (x79 over 15h)     daemonset-controller  Error creating: pods "cloud-node-manager-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used]
  Warning  FailedCreate  2m5s (x16 over 4m49s)  daemonset-controller  Error creating: pods "cloud-node-manager-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used]
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing Shoot creation to fail for K8s > 1.23 clusters with `spec.kubenetes.allowPrivilegedContainers=false` is now fixed.
```
