### PR TITLE
Upgrade github.com/kubernetes-sigs/cloud-provider-azure

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -41,12 +41,12 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.23.2"
+  tag: "v1.23.13"
   targetVersion: "1.23.x"
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.23.2"
+  tag: "v1.23.13"
   targetVersion: "< 1.24"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure


### PR DESCRIPTION
/area control-plane open-source
/kind bug
/platform azure

This PR updates the out-of-tree CCM to adopt the following upstream fix https://github.com/kubernetes-sigs/cloud-provider-azure/pull/1513 (ref https://github.com/kubernetes-sigs/cloud-provider-azure/issues/1390). Currently for Nodes without a providerID the node lifecycle controller in CCM cannot delete the already non-existing Node.

```
E0615 13:32:44.384173       1 azure_instances.go:234] InstanceExists: failed to get the provider ID by node name shoot--foo--bar-worker-opt-z2-d9d5d-gdtvm: failed to get instance ID from cloud provider: instance not found
E0615 13:32:44.384182       1 node_lifecycle_controller.go:149] error checking if node shoot--foo--bar-worker-opt-z2-d9d5d-gdtvm exists: failed to get instance ID from cloud provider: instance not found
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following images are updated:
- mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager: v1.23.2 -> v1.23.13
- mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager: v1.23.2 -> v1.23.13
```
