### PR TITLE
[release-v1.28] Automated cherry pick of #521: Add PodSecurityPolicy for cloud-node-manager

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-clusterrole.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:psp:kube-system:cloud-node-manager
+rules:
+- apiGroups:
+  - policy
+  - extensions
+  resourceNames:
+  - extensions.gardener.cloud.provider-azure.cloud-node-manager
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-rolebinding.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gardener.cloud:psp:kube-system:cloud-node-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:psp:kube-system:cloud-node-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-manager
+  namespace: kube-system
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
@@ -1,0 +1,21 @@
+{{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: extensions.gardener.cloud.provider-azure.cloud-node-manager
+spec:
+  privileged: true
+  volumes:
+  - projected
+  hostNetwork: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: false
+{{- end }}


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #521 on release-v1.28.

#521: Add PodSecurityPolicy for cloud-node-manager

**Release Notes:**
```bugfix user
An issue causing Shoot creation to fail for K8s >= 1.23 clusters with `spec.kubenetes.allowPrivilegedContainers=false` is now fixed.
```