### PR TITLE
Update CCM and CNM images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -41,22 +41,22 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.23.13"
+  tag: "v1.23.14"
   targetVersion: "1.23.x"
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.23.13"
+  tag: "v1.23.14"
   targetVersion: "< 1.24"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.24.0"
+  tag: "v1.24.2"
   targetVersion: ">= 1.24"
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.24.0"
+  tag: "v1.24.2"
   targetVersion: ">= 1.24"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager: v1.23.13 -> v1.23.14 (for kubernetes 1.23)
- mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager: v1.23.13 -> v1.23.14 (for kubernetes 1.23)
- mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager: v1.24.0 -> v1.24.2 (for kubernetes 1.24)
- mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager: v1.24.0 -> v1.24.2 (for kubernetes 1.24)
```