### PR TITLE
DDos protection plan for managed vnets

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -60,6 +60,7 @@ networks:
     # name: my-vnet
     # resourceGroup: my-vnet-resource-group
     cidr: 10.250.0.0/16
+    # ddosProtectionPlanID: /subscriptions/test/resourceGroups/test/providers/Microsoft.Network/ddosProtectionPlans/test-ddos-protection-plan
   workers: 10.250.0.0/19
   # natGateway:
   #   enabled: false
@@ -100,6 +101,7 @@ The `networks.vnet` section describes whether you want to create the shoot clust
 * If `networks.vnet.cidr` is given then you have to specify the VNet CIDR of a new VNet that will be created during shoot creation.
 You can freely choose a private CIDR range.
 * Either `networks.vnet.name` and `neworks.vnet.resourceGroup` or `networks.vnet.cidr` must be present, but not both at the same time.
+* The `networks.vnet.ddosProtectionPlanID` field can be used to specify the id of a ddos protection plan which should be assigned to the VNet. This will only work for a VNet managed by Gardener. For externally managed VNets the ddos protection plan must be assigned by other means.
 
 The `networks.workers` section describes the CIDR for a subnet that is used for all shoot worker nodes, i.e., VMs which later run your applications.
 The specified CIDR range must be contained in the VNet CIDR specified above, or the VNet CIDR of your already existing VNet.

--- a/example/30-infrastructure.yaml
+++ b/example/30-infrastructure.yaml
@@ -67,6 +67,7 @@ spec:
       # name: my-vnet
       # resourceGroup: my-vnet-group
         cidr: 10.250.0.0/16
+      # ddosProtectionPlanID: /subscriptions/test/resourceGroups/test/providers/Microsoft.Network/ddosProtectionPlans/test-ddos-protection-plan
       workers: 10.250.0.0/19
     # natGateway:
     #   enabled: false

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1478,6 +1478,18 @@ string
 <p>CIDR is the VNet CIDR</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ddosProtectionPlanID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DDosProtectionPlanID is the id of a ddos protection plan assigned to the vnet.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="azure.provider.extensions.gardener.cloud/v1alpha1.VNetStatus">VNetStatus

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -208,6 +208,8 @@ type VNet struct {
 	ResourceGroup *string
 	// CIDR is the VNet CIDR
 	CIDR *string
+	// DDosProtectionPlanID is the id of a ddos protection plan assigned to the vnet.
+	DDosProtectionPlanID *string
 }
 
 // VNetStatus contains the VNet name.

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -232,6 +232,9 @@ type VNet struct {
 	// CIDR is the VNet CIDR
 	// +optional
 	CIDR *string `json:"cidr,omitempty"`
+	// DDosProtectionPlanID is the id of a ddos protection plan assigned to the vnet.
+	// +optional
+	DDosProtectionPlanID *string `json:"ddosProtectionPlanID,omitempty"`
 }
 
 // VNetStatus contains the VNet name.

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -870,6 +870,7 @@ func autoConvert_v1alpha1_VNet_To_azure_VNet(in *VNet, out *azure.VNet, s conver
 	out.Name = (*string)(unsafe.Pointer(in.Name))
 	out.ResourceGroup = (*string)(unsafe.Pointer(in.ResourceGroup))
 	out.CIDR = (*string)(unsafe.Pointer(in.CIDR))
+	out.DDosProtectionPlanID = (*string)(unsafe.Pointer(in.DDosProtectionPlanID))
 	return nil
 }
 
@@ -882,6 +883,7 @@ func autoConvert_azure_VNet_To_v1alpha1_VNet(in *azure.VNet, out *VNet, s conver
 	out.Name = (*string)(unsafe.Pointer(in.Name))
 	out.ResourceGroup = (*string)(unsafe.Pointer(in.ResourceGroup))
 	out.CIDR = (*string)(unsafe.Pointer(in.CIDR))
+	out.DDosProtectionPlanID = (*string)(unsafe.Pointer(in.DDosProtectionPlanID))
 	return nil
 }
 

--- a/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
@@ -605,6 +605,11 @@ func (in *VNet) DeepCopyInto(out *VNet) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DDosProtectionPlanID != nil {
+		in, out := &in.DDosProtectionPlanID, &out.DDosProtectionPlanID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/azure/validation/infrastructure.go
+++ b/pkg/apis/azure/validation/infrastructure.go
@@ -210,6 +210,10 @@ func validateVnetConfig(networkConfig *apisazure.NetworkConfig, resourceGroupCon
 		if resourceGroupConfig != nil && *networkConfig.VNet.ResourceGroup == resourceGroupConfig.Name {
 			allErrs = append(allErrs, field.Invalid(vNetPath.Child("resourceGroup"), *vnetConfig.ResourceGroup, "the vnet resource group must not be the same as the cluster resource group"))
 		}
+
+		if networkConfig.VNet.DDosProtectionPlanID != nil {
+			allErrs = append(allErrs, field.Forbidden(vNetPath.Child("ddosProtectionPlanID"), "cannot assign a ddos protection plan to a vnet not managed by Gardener"))
+		}
 		return allErrs
 	}
 

--- a/pkg/apis/azure/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/zz_generated.deepcopy.go
@@ -605,6 +605,11 @@ func (in *VNet) DeepCopyInto(out *VNet) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DDosProtectionPlanID != nil {
+		in, out := &in.DDosProtectionPlanID, &out.DDosProtectionPlanID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -33,6 +33,12 @@ resource "azurerm_virtual_network" "vnet" {
   resource_group_name = {{ template "resource-group-reference" $ }}
   location            = "{{ .azure.region }}"
   address_space       = ["{{ .resourceGroup.vnet.cidr }}"]
+  {{- if .resourceGroup.vnet.ddosProtectionPlanID }}
+  ddos_protection_plan {
+    id = "{{ .resourceGroup.vnet.ddosProtectionPlanID }}"
+    enable = true
+  }
+  {{- end }}
 }
 {{- else -}}
 data "azurerm_virtual_network" "vnet" {

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -224,6 +224,10 @@ func generateVNetConfig(n *api.NetworkConfig, defaultVnetName string) (bool, map
 		return false, nil, nil, fmt.Errorf("no VNet or workers configuration provided")
 	}
 
+	if createVNet && n.VNet.DDosProtectionPlanID != nil {
+		vnetConfig["ddosProtectionPlanID"] = *n.VNet.DDosProtectionPlanID
+	}
+
 	return createVNet, vnetConfig, outputKeys, err
 }
 

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -382,6 +382,22 @@ var _ = Describe("Terraform", func() {
 			Expect(values).To(BeEquivalentTo(expectedValues))
 		})
 
+		It("should correctly compute terraform chart values with ddos protection plan id assigned to the vnet", func() {
+			var ddosProtectionPlanID = "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/ddosProtectionPlans/test-ddos-protection-plan"
+
+			config.Networks.VNet.DDosProtectionPlanID = &ddosProtectionPlanID
+
+			expectedResourceGroupValues["vnet"] = map[string]interface{}{
+				"name":                 infra.Namespace,
+				"cidr":                 *config.Networks.Workers,
+				"ddosProtectionPlanID": ddosProtectionPlanID,
+			}
+
+			values, err := ComputeTerraformerTemplateValues(infra, config, cluster)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(values).To(BeEquivalentTo(expectedValues))
+		})
+
 		Context("NatGateway", func() {
 			It("should correctly compute terraform chart values with NatGateway", func() {
 				config.Networks.NatGateway = &api.NatGatewayConfig{


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Allow to attach a ddos protection plan to the vnet managed by Gardener.
Caution: Only compatible for Shoots where Gardener manages the vnet and not the bring your own vnet scenario is applied.

**Which issue(s) this PR fixes**:
Fixes #528

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user feature
Allow to attach a ddos protection plan to the vnet managed by Gardener.  Caution: Only compatible for Shoots where Gardener manages the vnet and not the bring your own vnet scenario is applied. Find more information here: https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage-as-end-user.md#infrastructureconfig
```
