### PR TITLE
Do not allow containers in privileged mode for the cloud-node-manager PodSecurityPolicy

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
@@ -5,7 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   name: extensions.gardener.cloud.provider-azure.cloud-node-manager
 spec:
-  privileged: true
+  privileged: false
   volumes:
   - projected
   hostNetwork: true


### PR DESCRIPTION
/area security
/kind enhancement
/platform azure

**What this PR does / why we need it**:
There is no need to allow a container to run in privileged mode for the cloud-node-manager PodSecurityPolicy when there is no container currently in the cloud-node-manager that requires to run in privileged mode.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-azure/pull/521
Indirectly part of https://github.com/gardener-security/standard-compliance/issues/3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
