### PR TITLE
Document detailed Azure permissions to manage a Shoot

### DIFF
--- a/docs/azure-permissions.md
+++ b/docs/azure-permissions.md
@@ -1,0 +1,133 @@
+# Azure Permissions
+
+The following document describes the required Azure actions manage a Shoot cluster on Azure split by the different Azure provider/services.
+
+Be aware some actions are just required if particilar deployment sceanrios or features e.g. bring your own vNet, use Azure-file, let the Shoot act as Seed etc. should be used.
+
+## `Microsoft.Compute`
+```
+# Required if a non zonal cluster based on Availability Set should be used.
+Microsoft.Compute/availabilitySets/delete
+Microsoft.Compute/availabilitySets/read
+Microsoft.Compute/availabilitySets/write
+
+# Required to let Kubernetes manage Azure disks.
+Microsoft.Compute/disks/delete
+Microsoft.Compute/disks/read
+Microsoft.Compute/disks/write
+
+# Required for to fetch meta information about disk and virtual machines sizes.
+Microsoft.Compute/locations/diskOperations/read
+Microsoft.Compute/locations/operations/read
+Microsoft.Compute/locations/vmSizes/read
+
+# Required if csi snapshot capabilities should be used and/or the Shoot should act as a Seed.
+Microsoft.Compute/snapshots/delete
+Microsoft.Compute/snapshots/read
+Microsoft.Compute/snapshots/write
+
+# Required to let Gardener/Machine-Controller-Manager manage the cluster nodes/machines.
+Microsoft.Compute/virtualMachines/delete
+Microsoft.Compute/virtualMachines/read
+Microsoft.Compute/virtualMachines/start/action
+Microsoft.Compute/virtualMachines/write
+
+# Required if a non zonal cluster based on VMSS Flex (VMO) should be used.
+Microsoft.Compute/virtualMachineScaleSets/delete
+Microsoft.Compute/virtualMachineScaleSets/read
+Microsoft.Compute/virtualMachineScaleSets/write
+```
+
+
+## `Microsoft.ManagedIdentity`
+
+```
+# Required if a user provided Azure managed identity should attached to the cluster nodes.
+Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
+Microsoft.ManagedIdentity/userAssignedIdentities/read
+```
+
+## `Microsoft.MarketplaceOrdering`
+
+```
+# Required if nodes/machines should be created with images hosted on the Azure Marketplace.
+Microsoft.MarketplaceOrdering/offertypes/publishers/offers/plans/agreements/read
+Microsoft.MarketplaceOrdering/offertypes/publishers/offers/plans/agreements/write
+```
+
+## `Microsoft.Network`
+
+```
+# Required to let Kubernetes manage services of type 'LoadBalancer'.
+Microsoft.Network/loadBalancers/backendAddressPools/join/action
+Microsoft.Network/loadBalancers/delete
+Microsoft.Network/loadBalancers/read
+Microsoft.Network/loadBalancers/write
+
+# Required in case the Shoot should use NatGateway(s).
+Microsoft.Network/natGateways/delete
+Microsoft.Network/natGateways/join/action
+Microsoft.Network/natGateways/read
+Microsoft.Network/natGateways/write
+
+# Required to let Gardener/Machine-Controller-Manager manage the cluster nodes/machines.
+Microsoft.Network/networkInterfaces/delete
+Microsoft.Network/networkInterfaces/ipconfigurations/join/action
+Microsoft.Network/networkInterfaces/ipconfigurations/read
+Microsoft.Network/networkInterfaces/join/action
+Microsoft.Network/networkInterfaces/read
+Microsoft.Network/networkInterfaces/write
+
+# Required to let Gardener maintain the basic infrastructure of the Shoot cluster and maintaing LoadBalancer services.
+Microsoft.Network/networkSecurityGroups/delete
+Microsoft.Network/networkSecurityGroups/join/action
+Microsoft.Network/networkSecurityGroups/read
+Microsoft.Network/networkSecurityGroups/write
+
+# Required for managing LoadBalancers and NatGateways.
+Microsoft.Network/publicIPAddresses/delete
+Microsoft.Network/publicIPAddresses/join/action
+Microsoft.Network/publicIPAddresses/read
+Microsoft.Network/publicIPAddresses/write
+
+# Required for managing the basic infrastructure of a cluster and maintaing LoadBalancer services.
+Microsoft.Network/routeTables/delete
+Microsoft.Network/routeTables/join/action
+Microsoft.Network/routeTables/read
+Microsoft.Network/routeTables/routes/delete
+Microsoft.Network/routeTables/routes/read
+Microsoft.Network/routeTables/routes/write
+Microsoft.Network/routeTables/write
+
+# Required to let Gardener maintain the basic infrastructure of the Shoot cluster.
+# Only a subset is required for the bring your own vNet scenario.
+Microsoft.Network/virtualNetworks/delete # not required for bring your own vnet
+Microsoft.Network/virtualNetworks/read
+Microsoft.Network/virtualNetworks/subnets/delete
+Microsoft.Network/virtualNetworks/subnets/join/action
+Microsoft.Network/virtualNetworks/subnets/read
+Microsoft.Network/virtualNetworks/subnets/write
+Microsoft.Network/virtualNetworks/write # not required for bring your own vnet
+```
+
+## `Microsoft.Resources`
+```
+# Required to let Gardener maintain the basic infrastructure of the Shoot cluster.
+Microsoft.Resources/subscriptions/resourceGroups/delete
+Microsoft.Resources/subscriptions/resourceGroups/read
+Microsoft.Resources/subscriptions/resourceGroups/write
+```
+
+## `Microsoft.Storage`
+```
+# Required if Azure File should be used and/or if the Shoot should act as Seed.
+Microsoft.Storage/operations/read
+Microsoft.Storage/storageAccounts/blobServices/containers/delete
+Microsoft.Storage/storageAccounts/blobServices/containers/read
+Microsoft.Storage/storageAccounts/blobServices/containers/write
+Microsoft.Storage/storageAccounts/blobServices/read
+Microsoft.Storage/storageAccounts/delete
+Microsoft.Storage/storageAccounts/listkeys/action
+Microsoft.Storage/storageAccounts/read
+Microsoft.Storage/storageAccounts/write
+```

--- a/docs/tutorials/kubernetes-cluster-on-azure-with-gardener/kubernetes-cluster-on-azure-with-gardener.md
+++ b/docs/tutorials/kubernetes-cluster-on-azure-with-gardener/kubernetes-cluster-on-azure-with-gardener.md
@@ -23,12 +23,12 @@ Gardener allows you to create a Kubernetes cluster on different infrastructure p
 
 
 1. Get the properties of your Azure AD tenant, Subscription and Service Principal.
-    ```
-    Before you can provision and access a Kubernetes cluster on Azure, you need to add the Azure service principal, AD tenant and subscription credentials in Gardener. 
+
+    Before you can provision and access a Kubernetes cluster on Azure, you need to add the Azure service principal, AD tenant and subscription credentials in Gardener.
     Gardener needs the credentials to provision and operate the Azure infrastructure for your Kubernetes cluster.
 
-    **Ensure that the Azure service principal has the `Contributor` role within your Subscription assigned.**
-    ```
+    **Ensure that the Azure service princiapl has the actions defined [here](../../azure-permissions.md) within your Subscription assigned.
+    If no fine-grained permission/actions required then simply the buildin `Contributer` role can be assigned.**
 
 
     - Tenant ID

--- a/docs/tutorials/kubernetes-cluster-on-azure-with-gardener/kubernetes-cluster-on-azure-with-gardener.md
+++ b/docs/tutorials/kubernetes-cluster-on-azure-with-gardener/kubernetes-cluster-on-azure-with-gardener.md
@@ -27,8 +27,8 @@ Gardener allows you to create a Kubernetes cluster on different infrastructure p
     Before you can provision and access a Kubernetes cluster on Azure, you need to add the Azure service principal, AD tenant and subscription credentials in Gardener.
     Gardener needs the credentials to provision and operate the Azure infrastructure for your Kubernetes cluster.
 
-    **Ensure that the Azure service princiapl has the actions defined [here](../../azure-permissions.md) within your Subscription assigned.
-    If no fine-grained permission/actions required then simply the buildin `Contributer` role can be assigned.**
+    **Ensure that the Azure service principal has the actions defined [here](../../azure-permissions.md) within your Subscription assigned.
+    If no fine-grained permission/actions are required then simply the buildin `Contributor` role can be assigned.**
 
 
     - Tenant ID

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -11,8 +11,9 @@ Every shoot cluster references a `SecretBinding` which itself references a `Secr
 The `SecretBinding` is configurable in the [Shoot cluster](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) with the field `secretBindingName`.
 
 Create an [Azure Application and Service Principle](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) and obtain its credentials.
-Please make sure the Azure application has the following IAM roles.
-- [Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor)
+
+Please ensure that the Azure application (spn) has the IAM actions defined [here](azure-permissions.md) assigned.
+If no fine-grained permissions/actions required then simply assign the [Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) role.
 
 The example below demonstrates how the secret containing the client credentials of the Azure Application has to look like:
 


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Document detailed Azure provider/service actions to manage a Shoot cluster on Azure.

**Which issue(s) this PR fixes**:
Fixes #26

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
A detailed list of Azure provider/service permissions/actions that are required to manage Azure Shoot clusters is now available [here](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/azure-permissions.md).
```

/invite @kon-angelo 
