### PR TITLE
[release-v1.28] Automated cherry pick of #539: disable CCM pod CIDR allocation

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -45,7 +45,7 @@ spec:
         {{- else }}
         - /azure-cloud-controller-manager
         {{- end }}
-        - --allocate-node-cidrs=true
+        - --allocate-node-cidrs=false
         - --cloud-provider=azure
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster-cidr={{ .Values.podNetwork }}


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #539 on release-v1.28.

#539: disable CCM pod CIDR allocation

**Release Notes:**
```other operator
Disable cloud-controller-manager node CIDR allocation. 
```