### PR TITLE
[release-v1.28] Automated cherry pick of #544: Reenable the pod allocation for k8s <=1.23.x

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -40,12 +40,14 @@ spec:
         {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
         - /hyperkube
         - cloud-controller-manager
+        - --allocate-node-cidrs=true
         {{- else if semverCompare ">= 1.23" .Values.kubernetesVersion }}
         - /usr/local/bin/cloud-controller-manager
+        - --allocate-node-cidrs=false
         {{- else }}
         - /azure-cloud-controller-manager
+        - --allocate-node-cidrs=true
         {{- end }}
-        - --allocate-node-cidrs=false
         - --cloud-provider=azure
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster-cidr={{ .Values.podNetwork }}


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #544 on release-v1.28.

#544: Reenable the pod allocation for k8s <1.23.x

**Release Notes:**
```bugfix user
An issue preventing azure CCM to create routes for K8s < 1.21 Shoot clusters is now fixed.
```