### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver.yaml
@@ -16,7 +16,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch", "update", "patch"]
+{{- if not .Values.pspDisabled }}
 - apiGroups: ["policy", "extensions"]
   resourceNames: ["{{ include "csi-driver-node.extensionsGroup" . }}.{{ include "csi-driver-node.name" . }}.csi-driver-node"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -32,3 +33,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -45,3 +45,5 @@ resources:
       memory: 32Mi
     limits:
       memory: 150Mi
+
+pspDisabled: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/chart"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/secrets"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/version"
@@ -76,7 +75,7 @@ func secretConfigsFunc(namespace string) []extensionssecretsmanager.SecretConfig
 				Name:                        cloudControllerManagerServerName,
 				CommonName:                  azure.CloudControllerManagerName,
 				DNSNames:                    kutil.DNSNamesForService(azure.CloudControllerManagerName, namespace),
-				CertType:                    secrets.ServerCert,
+				CertType:                    secretutils.ServerCert,
 				SkipPublishingCACertificate: true,
 			},
 			Options: []secretsmanager.GenerateOption{secretsmanager.SignedByCA(caNameControlPlane)},

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -710,6 +710,7 @@ func getControlPlaneShootChartValues(
 				"url":      "https://" + azure.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 				"caBundle": caBundle,
 			},
+			"pspDisabled": gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
 		},
 		azure.RemedyControllerName: map[string]interface{}{
 			"enabled": !disableRemedyController,

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -186,7 +186,7 @@ var _ = BeforeSuite(func() {
 
 	log = logf.Log.WithName("bastion-test")
 
-	log.Info("test environment client publicIP: ", myPublicIP)
+	log.Info("test environment client publicIP", "publicIP", myPublicIP)
 
 	By("starting test environment")
 	testEnv = &envtest.Environment{
@@ -397,7 +397,7 @@ func verifyPort42IsClosed(ctx context.Context, c client.Client, bastion *extensi
 }
 
 func prepareNewResourceGroup(ctx context.Context, log logr.Logger, az *azureClientSet, groupName, location string) error {
-	log.Info("generating new ResourceGroups: %s", groupName)
+	log.Info("generating new ResourceGroups", "groupName", groupName)
 	_, err := az.groups.CreateOrUpdate(ctx, groupName, resources.Group{
 		Location: to.StringPtr(location),
 	})
@@ -405,7 +405,7 @@ func prepareNewResourceGroup(ctx context.Context, log logr.Logger, az *azureClie
 }
 
 func prepareSecurityGroup(ctx context.Context, log logr.Logger, resourceGroupName string, securityGroupName string, az *azureClientSet, location string) (network.SecurityGroup, error) {
-	log.Info("generating new SecurityGroups: %s", securityGroupName)
+	log.Info("generating new SecurityGroups", "securityGroupName", securityGroupName)
 	future, err := az.securityGroups.CreateOrUpdate(ctx, resourceGroupName, securityGroupName, network.SecurityGroup{
 		Location: to.StringPtr(location),
 	})
@@ -418,7 +418,7 @@ func prepareSecurityGroup(ctx context.Context, log logr.Logger, resourceGroupNam
 }
 
 func prepareNewVNet(ctx context.Context, log logr.Logger, az *azureClientSet, resourceGroupName, vNetName, subnetName, location, cidr string, nsg network.SecurityGroup) error {
-	log.Info("generating new resource Group/VNet/subnetName: %s/%s/%s", resourceGroupName, vNetName, subnetName)
+	log.Info("generating new resource Group/VNet/subnetName", "resourceGroupName", resourceGroupName, " vNetName", vNetName, "subnetName", subnetName)
 	vNetFuture, err := az.vnet.CreateOrUpdate(ctx, resourceGroupName, vNetName, network.VirtualNetwork{
 		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 			AddressSpace: &network.AddressSpace{

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -496,7 +496,7 @@ func runTest(
 		infra      *extensionsv1alpha1.Infrastructure
 		identifier azureIdentifier
 	)
-	log.Info("test running in namespace: %s", namespaceName)
+	log.Info("test running in namespace", "namespaceName", namespaceName)
 
 	// Cleanup
 	defer func() {
@@ -742,7 +742,7 @@ func newInfrastructure(namespace string, providerConfig *azurev1alpha1.Infrastru
 }
 
 func prepareNewResourceGroup(ctx context.Context, log logr.Logger, az *azureClientSet, groupName, location string) error {
-	log.Info("generating new ResourceGroups: %s", groupName)
+	log.Info("generating new ResourceGroups", "groupName", groupName)
 	_, err := az.groups.CreateOrUpdate(ctx, groupName, resources.Group{
 		Location: pointer.StringPtr(location),
 	})
@@ -750,7 +750,7 @@ func prepareNewResourceGroup(ctx context.Context, log logr.Logger, az *azureClie
 }
 
 func prepareNewVNet(ctx context.Context, log logr.Logger, az *azureClientSet, groupName, vNetName, location, cidr string) error {
-	log.Info("generating new VNet: %s/%s", groupName, vNetName)
+	log.Info("generating new VNet", "groupName", groupName, "vNetName", vNetName)
 	vNetFuture, err := az.vnet.CreateOrUpdate(ctx, groupName, vNetName, network.VirtualNetwork{
 		VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 			AddressSpace: &network.AddressSpace{
@@ -774,7 +774,7 @@ func prepareNewVNet(ctx context.Context, log logr.Logger, az *azureClientSet, gr
 }
 
 func prepareNewIdentity(ctx context.Context, log logr.Logger, az *azureClientSet, groupName, idName, location string) error {
-	log.Info("generating new Identity %s/%s", groupName, idName)
+	log.Info("generating new Identity", "groupName", groupName, "idName", idName)
 	_, err := az.msi.CreateOrUpdate(ctx, groupName, idName, msi.Identity{
 		Location: pointer.StringPtr(location),
 	})
@@ -782,7 +782,7 @@ func prepareNewIdentity(ctx context.Context, log logr.Logger, az *azureClientSet
 }
 
 func prepareNewNatIp(ctx context.Context, log logr.Logger, az *azureClientSet, groupName, pubIpName, location, zone string) error {
-	log.Info("generating new nat ip %s/%s", groupName, pubIpName)
+	log.Info("generating new nat ip", "groupName", groupName, "pubIpName", pubIpName)
 	_, err := az.pubIp.CreateOrUpdate(ctx, groupName, pubIpName, network.PublicIPAddress{
 		Name: pointer.String(pubIpName),
 		Sku: &network.PublicIPAddressSku{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform azure

**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR stops deploying PSPs related to `provider-azure` if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/587
/hold
Depends on #554 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```
