### PR TITLE
Add default seccomp profile for shoot components

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager-psp.yaml
@@ -3,6 +3,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: extensions.gardener.cloud.provider-azure.cloud-node-manager
 spec:
   privileged: false

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
@@ -72,6 +72,11 @@ spec:
         effect: NoExecute
       - operator: "Exists"
         effect: NoSchedule
+      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       containers:
       - name: cloud-node-manager
         image: {{ index .Values.images "cloud-node-manager" }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_daemonset.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_daemonset.tpl
@@ -47,6 +47,11 @@ spec:
         operator: Exists
       - effect: NoExecute
         operator: Exists
+      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       containers:
       - name: csi-driver
         image: {{ index .Values.images (print "csi-driver-" .role) }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -2,6 +2,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: {{ include "csi-driver-node.extensionsGroup" . }}.{{ include "csi-driver-node.name" . }}.csi-driver-node
 spec:
   privileged: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Pods deployed in the shoot by the extension now have their seccomp profile set to "RuntimeDefault".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `csi-driver-node` and `cloud-node-manager` pods now have their seccomp profile set to "RuntimeDefault".
```
