### PR TITLE
bastion creation when own vnet adopted

### DIFF
--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -185,12 +185,19 @@ func getPublicIP(ctx context.Context, log logr.Logger, factory azureclient.Facto
 }
 
 func getSubnet(ctx context.Context, log logr.Logger, factory azureclient.Factory, vNet, subnetWork string, opt *Options) (*network.Subnet, error) {
+	var sg string
 	subnetClient, err := factory.Subnet(ctx, opt.SecretReference)
 	if err != nil {
 		return nil, err
 	}
 
-	subnet, err := subnetClient.Get(ctx, opt.ResourceGroupName, vNet, subnetWork, "")
+	if opt.MyVnetEnabled {
+		sg = opt.MyVnetResourceGroupName
+	} else {
+		sg = opt.ResourceGroupName
+	}
+
+	subnet, err := subnetClient.Get(ctx, sg, vNet, subnetWork, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -21,15 +21,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
-	"github.com/go-logr/logr"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
+	"github.com/go-logr/logr"
+	"golang.org/x/crypto/ssh"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -147,7 +147,7 @@ func getNetworkSecurityGroup(ctx context.Context, log logr.Logger, factory azure
 }
 
 func getWorkersCIDR(cluster *controller.Cluster) ([]string, error) {
-	infrastructureConfig := &api.InfrastructureConfig{}
+	infrastructureConfig := &azure.InfrastructureConfig{}
 	err := json.Unmarshal(cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw, infrastructureConfig)
 	if err != nil {
 		return nil, err
@@ -184,26 +184,26 @@ func getPublicIP(ctx context.Context, log logr.Logger, factory azureclient.Facto
 	return ip, nil
 }
 
-func getSubnet(ctx context.Context, log logr.Logger, factory azureclient.Factory, vNet, subnetWork string, opt *Options) (*network.Subnet, error) {
+func getSubnet(ctx context.Context, log logr.Logger, factory azureclient.Factory, infrastructureStatus *azure.InfrastructureStatus, opt *Options) (*network.Subnet, error) {
 	var sg string
 	subnetClient, err := factory.Subnet(ctx, opt.SecretReference)
 	if err != nil {
 		return nil, err
 	}
 
-	if opt.MyVnetEnabled {
-		sg = opt.MyVnetResourceGroupName
+	if infrastructureStatus.Networks.VNet.ResourceGroup != nil {
+		sg = *infrastructureStatus.Networks.VNet.ResourceGroup
 	} else {
 		sg = opt.ResourceGroupName
 	}
 
-	subnet, err := subnetClient.Get(ctx, sg, vNet, subnetWork, "")
+	subnet, err := subnetClient.Get(ctx, sg, infrastructureStatus.Networks.VNet.Name, infrastructureStatus.Networks.Subnets[0].Name, "")
 	if err != nil {
 		return nil, err
 	}
 
 	if subnet == nil {
-		log.Info("subnet not found,", "subnet_name", subnetWork)
+		log.Info("subnet not found,", "subnet_name", infrastructureStatus.Networks.Subnets[0].Name)
 		return nil, nil
 	}
 

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -67,7 +67,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return err
 	}
 
-	nic, err := ensureNic(ctx, log, factory, opt, infrastructureStatus.Networks.VNet.Name, infrastructureStatus.Networks.Subnets[0].Name, publicIP)
+	nic, err := ensureNic(ctx, log, factory, infrastructureStatus, opt, publicIP)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func ensureComputeInstance(ctx context.Context, log logr.Logger, bastion *extens
 	return nil
 }
 
-func ensureNic(ctx context.Context, log logr.Logger, factory azureclient.Factory, opt *Options, vNet, subnetWork string, publicIP *network.PublicIPAddress) (*network.Interface, error) {
+func ensureNic(ctx context.Context, log logr.Logger, factory azureclient.Factory, infrastructureStatus *azure.InfrastructureStatus, opt *Options, publicIP *network.PublicIPAddress) (*network.Interface, error) {
 	nic, err := getNic(ctx, log, factory, opt)
 	if err != nil {
 		return nil, err
@@ -308,7 +308,7 @@ func ensureNic(ctx context.Context, log logr.Logger, factory azureclient.Factory
 
 	log.Info("create new bastion compute instance nic")
 
-	subnet, err := getSubnet(ctx, log, factory, vNet, subnetWork, opt)
+	subnet, err := getSubnet(ctx, log, factory, infrastructureStatus, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -67,10 +67,6 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return err
 	}
 
-	if infrastructureStatus.Networks.VNet.Name == "" || len(infrastructureStatus.Networks.Subnets) == 0 {
-		return errors.New("virtual network name and subnet must be set")
-	}
-
 	nic, err := ensureNic(ctx, log, factory, opt, infrastructureStatus.Networks.VNet.Name, infrastructureStatus.Networks.Subnets[0].Name, publicIP)
 	if err != nil {
 		return err
@@ -140,6 +136,14 @@ func getInfrastructureStatus(ctx context.Context, a *actuator, cluster *extensio
 
 	if infrastructureStatus.ResourceGroup.Name == "" {
 		return nil, errors.New("resource group name must be not empty for infrastructure provider status")
+	}
+
+	if infrastructureStatus.Networks.VNet.Name == "" {
+		return nil, errors.New("virtual network name must be not empty for infrastructure provider status")
+	}
+
+	if len(infrastructureStatus.Networks.Subnets) == 0 {
+		return nil, errors.New("subnets name must be not empty for infrastructure provider status")
 	}
 	return infrastructureStatus, nil
 }

--- a/pkg/controller/bastion/bastion_test.go
+++ b/pkg/controller/bastion/bastion_test.go
@@ -192,20 +192,6 @@ var _ = Describe("Bastion test", func() {
 		})
 	})
 
-	Describe("Determine options own vnet name and resourceGroup", func() {
-		It("should return options", func() {
-			vNetCIDR := api.VNet{
-				Name:          pointer.String("my-vnet"),
-				ResourceGroup: pointer.String("my-vnet-resource-group"),
-			}
-			cluster = createAzureTestCluster(vNetCIDR)
-			options, err := DetermineOptions(bastion, cluster, "cluster1")
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(options.MyVnetResourceGroupName).To(Equal("my-vnet-resource-group"))
-			Expect(options.MyVnetEnabled).To(BeTrue())
-		})
-	})
-
 	Describe("check Names generations", func() {
 		It("should generate idempotent name", func() {
 			expected := "clusterName-shortName-bastion-79641"

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -16,12 +16,10 @@ package bastion
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"net"
 
 	"github.com/Azure/go-autorest/autorest/to"
-	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -37,22 +35,20 @@ const maxLengthForBaseName = 33
 // bastion instance name with the IDs of pre-existing cloud provider
 // resources, like the nic name etc.
 type Options struct {
-	BastionInstanceName     string
-	BastionPublicIPName     string
-	PrivateIPAddressV4      string
-	PrivateIPAddressV6      string
-	ResourceGroupName       string
-	MyVnetEnabled           bool
-	MyVnetResourceGroupName string
-	SecurityGroupName       string
-	Location                string
-	NicName                 string
-	NicID                   string
-	DiskName                string
-	SecretReference         corev1.SecretReference
-	WorkersCIDR             []string
-	CIDRs                   []string
-	Tags                    map[string]*string
+	BastionInstanceName string
+	BastionPublicIPName string
+	PrivateIPAddressV4  string
+	PrivateIPAddressV6  string
+	ResourceGroupName   string
+	SecurityGroupName   string
+	Location            string
+	NicName             string
+	NicID               string
+	DiskName            string
+	SecretReference     corev1.SecretReference
+	WorkersCIDR         []string
+	CIDRs               []string
+	Tags                map[string]*string
 }
 
 // DetermineOptions determines the information that are required to reconcile a Bastion on Azure. This
@@ -83,31 +79,19 @@ func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.C
 		"Name": &baseResourceName,
 		"Type": to.StringPtr("gardenctl"),
 	}
-	infrastructureConfig := &api.InfrastructureConfig{}
-	if err = json.Unmarshal(cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw, infrastructureConfig); err != nil {
-		return nil, err
-	}
-	// own vnet enabled if own vnet resourceGroup exist
-	myVnetEnabled := false
-	vNetrg := ""
-	if infrastructureConfig.Networks.VNet.ResourceGroup != nil && *infrastructureConfig.Networks.VNet.ResourceGroup != "" {
-		vNetrg = *infrastructureConfig.Networks.VNet.ResourceGroup
-		myVnetEnabled = true
-	}
+
 	return &Options{
-		BastionInstanceName:     baseResourceName,
-		BastionPublicIPName:     publicIPResourceName(baseResourceName),
-		SecretReference:         secretReference,
-		CIDRs:                   cidrs,
-		WorkersCIDR:             workersCidr,
-		DiskName:                DiskResourceName(baseResourceName),
-		Location:                cluster.Shoot.Spec.Region,
-		ResourceGroupName:       resourceGroup,
-		MyVnetEnabled:           myVnetEnabled,
-		MyVnetResourceGroupName: vNetrg,
-		NicName:                 NicResourceName(baseResourceName),
-		Tags:                    tags,
-		SecurityGroupName:       NSGName(clusterName),
+		BastionInstanceName: baseResourceName,
+		BastionPublicIPName: publicIPResourceName(baseResourceName),
+		SecretReference:     secretReference,
+		CIDRs:               cidrs,
+		WorkersCIDR:         workersCidr,
+		DiskName:            DiskResourceName(baseResourceName),
+		Location:            cluster.Shoot.Spec.Region,
+		ResourceGroupName:   resourceGroup,
+		NicName:             NicResourceName(baseResourceName),
+		Tags:                tags,
+		SecurityGroupName:   NSGName(clusterName),
 	}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform azure

**What this PR does / why we need it**:
bastion resource group fetch fixed, when own vNet is adopted, the vNet resource group name is different from the default resource group name.

```
      kind: InfrastructureStatus
      networks:
        layout: SingleSubnet
        subnets:
        - name: shoot--sxxxa-xxx--azr-nodes
          purpose: nodes
        vnet:
          name: vnet-azr
          resourceGroup: rg-azr
      resourceGroup:
        name: shoot--sxxxa-xxx--azr
```
 
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/551

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix own vNet resource group name fetch in bastion creation
```
/invite @vpnachev