### PR TITLE
Add arm support

### DIFF
--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -15,6 +15,7 @@ This section describes, how the configuration for `CloudProfile`s looks like for
 The cloud profile configuration contains information about the real machine image IDs in the Azure environment (image `urn`, `id`, `communityGalleryImageID` or `sharedGalleryImageID`).
 You have to map every version that you specify in `.spec.machineImages[].versions` to an available VM image in your subscription.
 The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via a `urn`, it can be a custom VM image from a shared image gallery and is then identified  `sharedGalleryImageID`, or it can be from a community image gallery and is then identified by its `communityGalleryImageID`. You can use `id` field also to specifiy the image location in the azure compute gallery (in which case it would have a different kind of path) but it is not recommended as it sometimes faces problems in cross subscription image sharing.
+For each machine image version an `architecture` field can be specified which specifies the CPU architecture of the machine on which given machine image can be used.
 
 An example `CloudProfileConfig` for the Azure extension looks as follows:
 
@@ -36,6 +37,7 @@ machineImages:
   versions:
   - version: 2135.6.0
     urn: "CoreOS:CoreOS:Stable:2135.6.0"
+    # architecture: amd64 # optional
     acceleratedNetworking: true
 - name: myimage
   versions:
@@ -121,9 +123,11 @@ spec:
       versions:
       - version: 2303.3.0
         urn: CoreOS:CoreOS:Stable:2303.3.0
+        # architecture: amd64 # optional
         acceleratedNetworking: true
       - version: 2135.6.0
         urn: "CoreOS:CoreOS:Stable:2135.6.0"
+        # architecture: amd64 # optional
 ```
 
 ## `Seed` resource

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -806,6 +806,18 @@ bool
 <p>AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>architecture</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Architecture is the CPU architecture of the machine image.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="azure.provider.extensions.gardener.cloud/v1alpha1.MachineImageVersion">MachineImageVersion
@@ -894,6 +906,18 @@ bool
 <td>
 <em>(Optional)</em>
 <p>AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>architecture</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Architecture is the CPU architecture of the machine image.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/azure/helper/helper_test.go
+++ b/pkg/apis/azure/helper/helper_test.go
@@ -96,21 +96,22 @@ var _ = Describe("Helper", func() {
 	)
 
 	DescribeTable("#FindMachineImage",
-		func(machineImages []api.MachineImage, name, version string, expectedMachineImage *api.MachineImage, expectErr bool) {
-			machineImage, err := FindMachineImage(machineImages, name, version)
+		func(machineImages []api.MachineImage, name, version string, architecture *string, expectedMachineImage *api.MachineImage, expectErr bool) {
+			machineImage, err := FindMachineImage(machineImages, name, version, architecture)
 			expectResults(machineImage, expectedMachineImage, err, expectErr)
 		},
 
-		Entry("list is nil", nil, "foo", "1.2.3", nil, true),
-		Entry("empty list", []api.MachineImage{}, "foo", "1.2.3", nil, true),
-		Entry("entry not found (no name)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn}}, "foo", "1.2.3", nil, true),
-		Entry("entry not found (no version)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn}}, "bar", "1.2.4", nil, true),
-		Entry("entry exists(urn)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn}, false),
-		Entry("entry exists(id)", []api.MachineImage{{Name: "bar", Version: "1.2.3", ID: &imageID}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", ID: &imageID}, false),
-		Entry("entry exists(communityGalleryImageID)", []api.MachineImage{{Name: "bar", Version: "1.2.3", CommunityGalleryImageID: &communityImageId}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", CommunityGalleryImageID: &communityImageId}, false),
-		Entry("entry exists(sharedGalleryImageID)", []api.MachineImage{{Name: "bar", Version: "1.2.3", SharedGalleryImageID: &sharedImageId}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", SharedGalleryImageID: &sharedImageId}, false),
-		Entry("entry exists(accelerated networking active)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolTrue}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolTrue}, false),
-		Entry("entry exists(accelerated networking inactive)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolFalse}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolFalse}, false),
+		Entry("list is nil", nil, "foo", "1.2.3", pointer.String("foo"), nil, true),
+		Entry("empty list", []api.MachineImage{}, "foo", "1.2.3", pointer.String("foo"), nil, true),
+		Entry("entry not found (no name)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, Architecture: pointer.String("foo")}}, "foo", "1.2.3", pointer.String("foo"), nil, true),
+		Entry("entry not found (no version)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, Architecture: pointer.String("foo")}}, "bar", "1.2.4", pointer.String("foo"), nil, true),
+		Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, Architecture: pointer.String("bar")}}, "bar", "1.2.3", pointer.String("foo"), nil, true),
+		Entry("entry exists(urn)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, Architecture: pointer.String("foo")}, false),
+		Entry("entry exists(id)", []api.MachineImage{{Name: "bar", Version: "1.2.3", ID: &imageID, Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", ID: &imageID, Architecture: pointer.String("foo")}, false),
+		Entry("entry exists(communityGalleryImageID)", []api.MachineImage{{Name: "bar", Version: "1.2.3", CommunityGalleryImageID: &communityImageId, Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", CommunityGalleryImageID: &communityImageId, Architecture: pointer.String("foo")}, false),
+		Entry("entry exists(sharedGalleryImageID)", []api.MachineImage{{Name: "bar", Version: "1.2.3", SharedGalleryImageID: &sharedImageId, Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", SharedGalleryImageID: &sharedImageId, Architecture: pointer.String("foo")}, false),
+		Entry("entry exists(accelerated networking active)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolTrue, Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolTrue, Architecture: pointer.String("foo")}, false),
+		Entry("entry exists(accelerated networking inactive)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolFalse, Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolFalse, Architecture: pointer.String("foo")}, false),
 	)
 
 	DescribeTable("#FindDomainCountByRegion",
@@ -126,10 +127,10 @@ var _ = Describe("Helper", func() {
 	)
 
 	DescribeTable("#FindImage",
-		func(profileImages []api.MachineImages, imageName, version string, expectedImage *api.MachineImage) {
+		func(profileImages []api.MachineImages, imageName, version string, architecture *string, expectedImage *api.MachineImage) {
 			cfg := &api.CloudProfileConfig{}
 			cfg.MachineImages = profileImages
-			image, err := FindImageFromCloudProfile(cfg, imageName, version)
+			image, err := FindImageFromCloudProfile(cfg, imageName, version, architecture)
 
 			Expect(image).To(Equal(expectedImage))
 			if expectedImage != nil {
@@ -139,24 +140,25 @@ var _ = Describe("Helper", func() {
 			}
 		},
 
-		Entry("list is nil", nil, "ubuntu", "1", nil),
+		Entry("list is nil", nil, "ubuntu", "1", pointer.String("foo"), nil),
 
-		Entry("profile empty list", []api.MachineImages{}, "ubuntu", "1", nil),
-		Entry("profile entry not found (image does not exist)", makeProfileMachineImages("debian", "1", "3", "5", "7"), "ubuntu", "1", nil),
-		Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", "4", "6", "7"), "ubuntu", "1", nil),
-		Entry("profile entry(urn)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN}),
-		Entry("profile entry(id)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "3", &api.MachineImage{Name: "ubuntu", Version: "3", ID: &profileID}),
-		Entry("profile entry(communityGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "5", &api.MachineImage{Name: "ubuntu", Version: "5", CommunityGalleryImageID: &profileCommunityImageId}),
-		Entry("profile entry(sharedGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "6", &api.MachineImage{Name: "ubuntu", Version: "6", SharedGalleryImageID: &profileSharedImageId}),
+		Entry("profile empty list", []api.MachineImages{}, "ubuntu", "1", pointer.String("foo"), nil),
+		Entry("profile entry not found (image does not exist)", makeProfileMachineImages("debian", "1", "3", "5", "7", pointer.String("foo")), "ubuntu", "1", pointer.String("foo"), nil),
+		Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", "4", "6", "7", pointer.String("foo")), "ubuntu", "1", pointer.String("foo"), nil),
+		Entry("profile entry not found (no architecture)", makeProfileMachineImages("ubuntu", "2", "4", "6", "7", pointer.String("bar")), "ubuntu", "2", pointer.String("foo"), nil),
+		Entry("profile entry(urn)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6", pointer.String("foo")), "ubuntu", "1", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN, Architecture: pointer.String("foo")}),
+		Entry("profile entry(id)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6", pointer.String("foo")), "ubuntu", "3", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "3", ID: &profileID, Architecture: pointer.String("foo")}),
+		Entry("profile entry(communiyGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6", pointer.String("foo")), "ubuntu", "5", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "5", CommunityGalleryImageID: &profileCommunityImageId, Architecture: pointer.String("foo")}),
+		Entry("profile entry(sharedGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6", pointer.String("foo")), "ubuntu", "6", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "6", SharedGalleryImageID: &profileSharedImageId, Architecture: pointer.String("foo")}),
 
-		Entry("valid image reference, only urn", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", &profileURN, nil, nil, nil),
-			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN}),
-		Entry("valid image reference, only id", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, &profileID, nil, nil),
-			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", ID: &profileID}),
-		Entry("valid image reference, only communityGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, nil, &profileCommunityImageId, nil),
-			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", CommunityGalleryImageID: &profileCommunityImageId}),
-		Entry("valid image reference, only sharedGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, nil, nil, &profileSharedImageId),
-			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", SharedGalleryImageID: &profileSharedImageId}),
+		Entry("valid image reference, only urn", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", &profileURN, nil, nil, nil, pointer.String("foo")),
+			"ubuntu", "1", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN, Architecture: pointer.String("foo")}),
+		Entry("valid image reference, only id", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, &profileID, nil, nil, pointer.String("foo")),
+			"ubuntu", "1", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "1", ID: &profileID, Architecture: pointer.String("foo")}),
+		Entry("valid image reference, only communityGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, nil, &profileCommunityImageId, nil, pointer.String("foo")),
+			"ubuntu", "1", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "1", CommunityGalleryImageID: &profileCommunityImageId, Architecture: pointer.String("foo")}),
+		Entry("valid image reference, only sharedGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, nil, nil, &profileSharedImageId, pointer.String("foo")),
+			"ubuntu", "1", pointer.String("foo"), &api.MachineImage{Name: "ubuntu", Version: "1", SharedGalleryImageID: &profileSharedImageId, Architecture: pointer.String("foo")}),
 	)
 
 	DescribeTable("#IsVmoRequired",
@@ -196,33 +198,37 @@ var _ = Describe("Helper", func() {
 	)
 })
 
-func makeProfileMachineImages(name, urnVersion, idVersion, communityGalleryImageIdVersion string, sharedGalleryImageIdVersion string) []api.MachineImages {
+func makeProfileMachineImages(name, urnVersion, idVersion, communityGalleryImageIdVersion string, sharedGalleryImageIdVersion string, architecture *string) []api.MachineImages {
 	return []api.MachineImages{
 		{
 			Name: name,
 			Versions: []api.MachineImageVersion{
 				{
-					Version: urnVersion,
-					URN:     &profileURN,
+					Version:      urnVersion,
+					URN:          &profileURN,
+					Architecture: architecture,
 				},
 				{
-					Version: idVersion,
-					ID:      &profileID,
+					Version:      idVersion,
+					ID:           &profileID,
+					Architecture: architecture,
 				},
 				{
 					Version:                 communityGalleryImageIdVersion,
 					CommunityGalleryImageID: &profileCommunityImageId,
+					Architecture:            architecture,
 				},
 				{
 					Version:              sharedGalleryImageIdVersion,
 					SharedGalleryImageID: &profileSharedImageId,
+					Architecture:         architecture,
 				},
 			},
 		},
 	}
 }
 
-func makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID(name, version string, urn, id, communityGalleryImageID *string, sharedGalleryImageID *string) []api.MachineImages {
+func makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID(name, version string, urn, id, communityGalleryImageID, sharedGalleryImageID, architecture *string) []api.MachineImages {
 	return []api.MachineImages{
 		{
 			Name: name,
@@ -233,6 +239,7 @@ func makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryIma
 					ID:                      id,
 					CommunityGalleryImageID: communityGalleryImageID,
 					SharedGalleryImageID:    sharedGalleryImageID,
+					Architecture:            architecture,
 				},
 			},
 		},

--- a/pkg/apis/azure/types_cloudprofile.go
+++ b/pkg/apis/azure/types_cloudprofile.go
@@ -65,6 +65,8 @@ type MachineImageVersion struct {
 	SharedGalleryImageID *string
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	AcceleratedNetworking *bool
+	// Architecture is the CPU architecture of the machine image.
+	Architecture *string
 }
 
 // MachineType contains provider specific information to a machine type.

--- a/pkg/apis/azure/types_worker.go
+++ b/pkg/apis/azure/types_worker.go
@@ -62,6 +62,8 @@ type MachineImage struct {
 	SharedGalleryImageID *string
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	AcceleratedNetworking *bool
+	// Architecture is the CPU architecture of the machine image.
+	Architecture *string
 }
 
 // VmoDependency is dependency reference for a workerpool to a VirtualMachineScaleSet Orchestration Mode VM (VMO).

--- a/pkg/apis/azure/v1alpha1/defaults.go
+++ b/pkg/apis/azure/v1alpha1/defaults.go
@@ -15,9 +15,19 @@
 package v1alpha1
 
 import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+// SetDefaults_MachineImageVersion set the architecture of machine image.
+func SetDefaults_MachineImageVersion(obj *MachineImageVersion) {
+	if obj.Architecture == nil {
+		obj.Architecture = pointer.String(v1beta1constants.ArchitectureAMD64)
+	}
 }

--- a/pkg/apis/azure/v1alpha1/defaults_test.go
+++ b/pkg/apis/azure/v1alpha1/defaults_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	. "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Defaults", func() {
+	Describe("#SetDefaults_MachineImageVersion", func() {
+		It("should default the architecture to amd64", func() {
+			obj := &MachineImageVersion{}
+
+			SetDefaults_MachineImageVersion(obj)
+
+			Expect(*obj.Architecture).To(Equal(v1beta1constants.ArchitectureAMD64))
+		})
+	})
+})

--- a/pkg/apis/azure/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/azure/v1alpha1/types_cloudprofile.go
@@ -72,6 +72,9 @@ type MachineImageVersion struct {
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	// +optional
 	AcceleratedNetworking *bool `json:"acceleratedNetworking,omitempty"`
+	// Architecture is the CPU architecture of the machine image.
+	// +optional
+	Architecture *string `json:"architecture,omitempty"`
 }
 
 // MachineType contains provider specific information to a machine type.

--- a/pkg/apis/azure/v1alpha1/types_worker.go
+++ b/pkg/apis/azure/v1alpha1/types_worker.go
@@ -72,6 +72,9 @@ type MachineImage struct {
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	// +optional
 	AcceleratedNetworking *bool `json:"acceleratedNetworking,omitempty"`
+	// Architecture is the CPU architecture of the machine image.
+	// +optional
+	Architecture *string `json:"architecture,omitempty"`
 }
 
 // VmoDependency is dependency reference for a workerpool to a VirtualMachineScaleSet Orchestration Mode VM (VMO).

--- a/pkg/apis/azure/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/azure/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API V1Alpha1 Suite")
+}

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -572,6 +572,7 @@ func autoConvert_v1alpha1_MachineImage_To_azure_MachineImage(in *MachineImage, o
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
 	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
+	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
 	return nil
 }
 
@@ -588,6 +589,7 @@ func autoConvert_azure_MachineImage_To_v1alpha1_MachineImage(in *azure.MachineIm
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
 	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
+	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
 	return nil
 }
 
@@ -603,6 +605,7 @@ func autoConvert_v1alpha1_MachineImageVersion_To_azure_MachineImageVersion(in *M
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
 	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
+	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
 	return nil
 }
 
@@ -618,6 +621,7 @@ func autoConvert_azure_MachineImageVersion_To_v1alpha1_MachineImageVersion(in *a
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
 	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
+	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
 	return nil
 }
 

--- a/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
@@ -320,6 +320,11 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Architecture != nil {
+		in, out := &in.Architecture, &out.Architecture
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -359,6 +364,11 @@ func (in *MachineImageVersion) DeepCopyInto(out *MachineImageVersion) {
 	if in.AcceleratedNetworking != nil {
 		in, out := &in.AcceleratedNetworking, &out.AcceleratedNetworking
 		*out = new(bool)
+		**out = **in
+	}
+	if in.Architecture != nil {
+		in, out := &in.Architecture, &out.Architecture
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/pkg/apis/azure/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.defaults.go
@@ -29,5 +29,16 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&CloudProfileConfig{}, func(obj interface{}) { SetObjectDefaults_CloudProfileConfig(obj.(*CloudProfileConfig)) })
 	return nil
+}
+
+func SetObjectDefaults_CloudProfileConfig(in *CloudProfileConfig) {
+	for i := range in.MachineImages {
+		a := &in.MachineImages[i]
+		for j := range a.Versions {
+			b := &a.Versions[j]
+			SetDefaults_MachineImageVersion(b)
+		}
+	}
 }

--- a/pkg/apis/azure/validation/cloudprofile.go
+++ b/pkg/apis/azure/validation/cloudprofile.go
@@ -20,7 +20,9 @@ import (
 
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/strings/slices"
 )
 
 // ValidateCloudProfileConfig validates a CloudProfileConfig object.
@@ -74,6 +76,7 @@ func ValidateCloudProfileConfig(cloudProfile *apisazure.CloudProfileConfig, fldP
 						version.CommunityGalleryImageID, "communityGalleryImageID must start with '/CommunityGalleries/' prefix"))
 				}
 			}
+
 			if version.SharedGalleryImageID != nil {
 				if len(*version.SharedGalleryImageID) == 0 {
 					allErrs = append(allErrs, field.Required(jdxPath.Child("sharedGalleryImageID"), "SharedGalleryImageID cannot be empty when defined"))
@@ -84,6 +87,10 @@ func ValidateCloudProfileConfig(cloudProfile *apisazure.CloudProfileConfig, fldP
 					allErrs = append(allErrs, field.Invalid(jdxPath.Child("sharedGalleryImageID"),
 						version.SharedGalleryImageID, "SharedGalleryImageID must start with '/SharedGalleries/' prefix"))
 				}
+			}
+
+			if !slices.Contains(v1beta1constants.ValidArchitectures, *version.Architecture) {
+				allErrs = append(allErrs, field.NotSupported(jdxPath.Child("architecture"), *version.Architecture, v1beta1constants.ValidArchitectures))
 			}
 		}
 	}

--- a/pkg/apis/azure/validation/cloudprofile_test.go
+++ b/pkg/apis/azure/validation/cloudprofile_test.go
@@ -59,8 +59,9 @@ var _ = Describe("CloudProfileConfig validation", func() {
 						Name: "ubuntu",
 						Versions: []apisazure.MachineImageVersion{
 							{
-								Version: "Version",
-								URN:     &urn,
+								Version:      "Version",
+								URN:          &urn,
+								Architecture: pointer.String("amd64"),
 							},
 						},
 					},
@@ -69,6 +70,11 @@ var _ = Describe("CloudProfileConfig validation", func() {
 		})
 
 		Context("machine image validation", func() {
+			It("should allow valid cloudProfileConfig", func() {
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should enforce that at least one machine image has been defined", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{}
 
@@ -94,6 +100,16 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				}))))
 			})
 
+			It("should forbid unsupported machine image architecture", func() {
+				cloudProfileConfig.MachineImages[0].Versions[0].Architecture = pointer.String("foo")
+
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("root.machineImages[0].versions[0].architecture"),
+				}))))
+			})
+
 			DescribeTable("forbid unsupported machine image urn",
 				func(urn string, matcher gomegatypes.GomegaMatcher) {
 					cloudProfileConfig.MachineImages = []apisazure.MachineImages{
@@ -101,8 +117,9 @@ var _ = Describe("CloudProfileConfig validation", func() {
 							Name: "my-image",
 							Versions: []apisazure.MachineImageVersion{
 								{
-									Version: "1.2.3",
-									URN:     &urn,
+									Version:      "1.2.3",
+									URN:          &urn,
+									Architecture: pointer.String("amd64"),
 								},
 							},
 						},
@@ -127,8 +144,9 @@ var _ = Describe("CloudProfileConfig validation", func() {
 							Name: "my-image",
 							Versions: []apisazure.MachineImageVersion{
 								{
-									Version: "1.2.3",
-									ID:      &id,
+									Version:      "1.2.3",
+									ID:           &id,
+									Architecture: pointer.String("amd64"),
 								},
 							},
 						},
@@ -151,6 +169,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 								{
 									Version:                 "1.2.3",
 									CommunityGalleryImageID: &communityGalleryImageID,
+									Architecture:            pointer.String("amd64"),
 								},
 							},
 						},
@@ -175,6 +194,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 								{
 									Version:              "1.2.3",
 									SharedGalleryImageID: &sharedGalleryImageID,
+									Architecture:         pointer.String("amd64"),
 								},
 							},
 						},
@@ -202,6 +222,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 									CommunityGalleryImageID: communityGalleryImageID,
 									SharedGalleryImageID:    sharedGalleryImageID,
 									URN:                     urn,
+									Architecture:            pointer.String("amd64"),
 								},
 							},
 						},
@@ -269,7 +290,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{
 					{
 						Name:     "abc",
-						Versions: []apisazure.MachineImageVersion{{}},
+						Versions: []apisazure.MachineImageVersion{{Architecture: pointer.String("amd64")}},
 					},
 				}
 

--- a/pkg/apis/azure/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/zz_generated.deepcopy.go
@@ -320,6 +320,11 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Architecture != nil {
+		in, out := &in.Architecture, &out.Architecture
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -359,6 +364,11 @@ func (in *MachineImageVersion) DeepCopyInto(out *MachineImageVersion) {
 	if in.AcceleratedNetworking != nil {
 		in, out := &in.AcceleratedNetworking, &out.AcceleratedNetworking
 		*out = new(bool)
+		**out = **in
+	}
+	if in.Architecture != nil {
+		in, out := &in.Architecture, &out.Architecture
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -46,8 +46,8 @@ func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) findMachineImage(name, version string) (urn, id, communityGalleryImageID *string, sharedGalleryImageID *string, acceleratedNetworking *bool, err error) {
-	machineImage, err := helper.FindImageFromCloudProfile(w.cloudProfileConfig, name, version)
+func (w *workerDelegate) findMachineImage(name, version string, architecture *string) (urn, id, communityGalleryImageID *string, sharedGalleryImageID *string, acceleratedNetworking *bool, err error) {
+	machineImage, err := helper.FindImageFromCloudProfile(w.cloudProfileConfig, name, version, architecture)
 	if err == nil {
 		return machineImage.URN, machineImage.ID, machineImage.CommunityGalleryImageID, machineImage.SharedGalleryImageID, machineImage.AcceleratedNetworking, nil
 	}
@@ -59,19 +59,19 @@ func (w *workerDelegate) findMachineImage(name, version string) (urn, id, commun
 			return nil, nil, nil, nil, nil, fmt.Errorf("could not decode worker status of worker '%s': %w", kutil.ObjectName(w.worker), err)
 		}
 
-		machineImage, err := helper.FindMachineImage(workerStatus.MachineImages, name, version)
+		machineImage, err := helper.FindMachineImage(workerStatus.MachineImages, name, version, architecture)
 		if err != nil {
-			return nil, nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version)
+			return nil, nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version, *architecture)
 		}
 
 		return machineImage.URN, machineImage.ID, machineImage.CommunityGalleryImageID, machineImage.SharedGalleryImageID, machineImage.AcceleratedNetworking, nil
 	}
 
-	return nil, nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version)
+	return nil, nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version, *architecture)
 }
 
 func appendMachineImage(machineImages []api.MachineImage, machineImage api.MachineImage) []api.MachineImage {
-	if _, err := helper.FindMachineImage(machineImages, machineImage.Name, machineImage.Version); err != nil {
+	if _, err := helper.FindMachineImage(machineImages, machineImage.Name, machineImage.Version, machineImage.Architecture); err != nil {
 		return append(machineImages, machineImage)
 	}
 	return machineImages

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -25,6 +25,7 @@ import (
 	azureapi "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	azureapihelper "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
@@ -127,7 +128,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			return err
 		}
 
-		urn, id, communityGalleryImageID, sharedGalleryImageID, imageSupportAcceleratedNetworking, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version)
+		arch := pointer.StringDeref(pool.Architecture, v1beta1constants.ArchitectureAMD64)
+
+		urn, id, communityGalleryImageID, sharedGalleryImageID, imageSupportAcceleratedNetworking, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version, &arch)
 		if err != nil {
 			return err
 		}
@@ -139,6 +142,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			CommunityGalleryImageID: communityGalleryImageID,
 			SharedGalleryImageID:    sharedGalleryImageID,
 			AcceleratedNetworking:   imageSupportAcceleratedNetworking,
+			Architecture:            &arch,
 		})
 
 		image := map[string]interface{}{}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -738,6 +738,15 @@ var _ = Describe("Machines", func() {
 				Expect(result).To(BeNil())
 			})
 
+			It("should fail because the machine image for given architecture cannot be found", func() {
+				w.Spec.Pools[0].Architecture = pointer.String("arm64")
+				workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+			})
+
 			It("should fail because the infrastructure status cannot be decoded", func() {
 				w.Spec.InfrastructureProviderStatus = &runtime.RawExtension{Raw: []byte("definitely not correct")}
 				workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR Adds a new `architecture` field in `WorkerStatus` and `CloudProfileConfig` to support specifying architecture.
 - `CloudProfileConfig` now supports a new field `.machineImages[].machineImageVersion[].architecture`. It specifies the supported CPU architecture of the given machine image.
 - `WorkerStatus` now supports a new field `.machineImage[].architecture`. It specifies the supported CPU architecture of the given worker pool.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`CloudProfileConfig` now supports a new field `.machineImages[].machineImageVersion[].architecture`. It specifies the supported CPU architecture of the given machine image.
```
```feature operator
`WorkerStatus` now supports a new field `.machineImage[].architecture`. It specifies the supported CPU architecture of the given worker pool.
```
