### PR TITLE
Adding support for shared gallery images

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -60,6 +60,8 @@ providerSpec:
         id: {{ $machineClass.image.id }}
 {{- else if $machineClass.image.communityGalleryImageID }}
         communityGalleryImageID: {{ $machineClass.image.communityGalleryImageID }}
+{{- else if $machineClass.image.sharedGalleryImageID }}
+        sharedGalleryImageID: {{ $machineClass.image.sharedGalleryImageID }}
 {{- else }}
         urn: {{ $machineClass.image.urn }}
 {{- end }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -33,6 +33,7 @@ machineClasses:
     urn: "CoreOS:CoreOS:Stable:1576.5.0"
     #id: "/subscriptions/<subscription ID where the gallery is located>/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0"
     #communityGalleryImageID: "/CommunityGalleries/<community gallery id>/Images/myImageDefinition/versions/1.0.0"
+    #sharedGalleryImageID: "/SharedGalleries/<sharedGalleryName>/Images/<sharedGalleryImageName>/Versions/<sharedGalleryImageVersionName>"
   osDisk:
     size: 50
     #type: Standard_LRS
@@ -60,6 +61,7 @@ machineClasses:
     #urn: "CoreOS:CoreOS:Stable:1576.5.0"
     id: "/subscriptions/<subscription ID where the gallery is located>/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0"
     #communityGalleryImageID: "/CommunityGalleries/<community gallery id>/Images/myImageDefinition/versions/1.0.0"
+    #sharedGalleryImageID: "/SharedGalleries/<sharedGalleryName>/Images/<sharedGalleryImageName>/Versions/<sharedGalleryImageVersionName>"
   osDisk:
     size: 50
     type: Standard_LRS
@@ -93,6 +95,7 @@ machineClasses:
     #urn: "CoreOS:CoreOS:Stable:1576.5.0"
     id: "/subscriptions/<subscription ID where the gallery is located>/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0"
     #communityGalleryImageID: "/CommunityGalleries/<community gallery id>/Images/myImageDefinition/versions/1.0.0"
+    #sharedGalleryImageID: "/SharedGalleries/<sharedGalleryName>/Images/<sharedGalleryImageName>/Versions/<sharedGalleryImageVersionName>"
   osDisk:
     size: 50
     type: Standard_LRS

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -12,9 +12,9 @@ This section describes, how the configuration for `CloudProfile`s looks like for
 
 ### `CloudProfileConfig`
 
-The cloud profile configuration contains information about the real machine image IDs in the Azure environment (image `urn`, `id` or `communityGalleryImageID`).
+The cloud profile configuration contains information about the real machine image IDs in the Azure environment (image `urn`, `id`, `communityGalleryImageID` or `sharedGalleryImageID`).
 You have to map every version that you specify in `.spec.machineImages[].versions` to an available VM image in your subscription.
-The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via an `urn`,, it can be a custom VM image from a shared image gallery and is then identified by its `id` or it can be from a community image gallery and is then identified by its `communityGalleryImageID`.
+The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via an `urn`, it can be a custom VM image from a shared image gallery and is then identified by its `id` or `sharedGalleryImageID`, or it can be from a community image gallery and is then identified by its `communityGalleryImageID`.
 
 An example `CloudProfileConfig` for the Azure extension looks as follows:
 
@@ -45,6 +45,10 @@ machineImages:
   versions:
   - version: 1.0.0
     communityGalleryImageID: "/CommunityGalleries/gardenlinux-567905d8-921f-4a85-b423-1fbf4e249d90/Images/gardenlinux/Versions/576.1.1"
+- name: SharedGalleryImageName
+  versions:
+    - version: 1.0.0
+      sharedGalleryImageID: "/SharedGalleries/sharedGalleryName/Images/sharedGalleryImageName/Versions/sharedGalleryImageVersionName"
 ```
 
 The cloud profile configuration contains information about the update via `.countUpdateDomains[]` and failure domain via `.countFaultDomains[]` counts in the Azure regions you want to offer.

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -14,7 +14,7 @@ This section describes, how the configuration for `CloudProfile`s looks like for
 
 The cloud profile configuration contains information about the real machine image IDs in the Azure environment (image `urn`, `id`, `communityGalleryImageID` or `sharedGalleryImageID`).
 You have to map every version that you specify in `.spec.machineImages[].versions` to an available VM image in your subscription.
-The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via a `urn`, it can be a custom VM image identified by its `id`, it can be from a shared image gallery and is then identified by a `sharedGalleryImageID`, or it can be from a community image gallery and is then identified by its `communityGalleryImageID`.
+The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via a `urn`, it can be a custom VM image from a shared image gallery and is then identified  `sharedGalleryImageID`, or it can be from a community image gallery and is then identified by its `communityGalleryImageID`. You can use `id` field also to specifiy the image location in the azure compute gallery (in which case it would have a different kind of path) but it is not recommended as it sometimes faces problems in cross subscription image sharing.
 
 An example `CloudProfileConfig` for the Azure extension looks as follows:
 

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -14,7 +14,7 @@ This section describes, how the configuration for `CloudProfile`s looks like for
 
 The cloud profile configuration contains information about the real machine image IDs in the Azure environment (image `urn`, `id`, `communityGalleryImageID` or `sharedGalleryImageID`).
 You have to map every version that you specify in `.spec.machineImages[].versions` to an available VM image in your subscription.
-The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via an `urn`, it can be a custom VM image from a shared image gallery and is then identified by its `id` or `sharedGalleryImageID`, or it can be from a community image gallery and is then identified by its `communityGalleryImageID`.
+The VM image can be either from the [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?filters=virtual-machine-images) and will then get identified via a `urn`, it can be a custom VM image identified by its `id`, it can be from a shared image gallery and is then identified by a `sharedGalleryImageID`, or it can be from a community image gallery and is then identified by its `communityGalleryImageID`.
 
 An example `CloudProfileConfig` for the Azure extension looks as follows:
 

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -784,6 +784,18 @@ string
 </tr>
 <tr>
 <td>
+<code>sharedGalleryImageID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SharedGalleryImageID is the Shared Image Gallery image id.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>acceleratedNetworking</code></br>
 <em>
 bool
@@ -858,6 +870,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>CommunityGalleryImageID is the Community Image Gallery image id, it has the format &lsquo;/CommunityGalleries/myGallery/Images/myImage/Versions/myVersion&rsquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sharedGalleryImageID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SharedGalleryImageID is the Shared Image Gallery image id, it has the format &lsquo;/SharedGalleries/sharedGalleryName/Images/sharedGalleryImageName/Versions/sharedGalleryImageVersionName&rsquo;</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -113,6 +113,7 @@ func FindImageFromCloudProfile(cloudProfileConfig *api.CloudProfileConfig, image
 						Version:                 version.Version,
 						URN:                     version.URN,
 						ID:                      version.ID,
+						SharedGalleryImageID:    version.SharedGalleryImageID,
 						CommunityGalleryImageID: version.CommunityGalleryImageID,
 						AcceleratedNetworking:   version.AcceleratedNetworking,
 					}, nil

--- a/pkg/apis/azure/helper/helper_test.go
+++ b/pkg/apis/azure/helper/helper_test.go
@@ -29,6 +29,7 @@ var (
 	profileURN              = "publisher:offer:sku:1.2.4"
 	profileID               = "/subscription/image/id"
 	profileCommunityImageId = "/CommunityGalleries/myGallery/Images/myImage/Versions/1.2.4"
+	profileSharedImageId    = "/SharedGalleries/myGallery/Images/myImage/Versions/1.2.4"
 )
 
 var _ = Describe("Helper", func() {
@@ -38,6 +39,7 @@ var _ = Describe("Helper", func() {
 		urn              string      = "publisher:offer:sku:version"
 		imageID          string      = "/image/id"
 		communityImageId string      = "/CommunityGalleries/myGallery/Images/myImage/Versions/1.0.0"
+		sharedImageId    string      = "/SharedGalleries/myGallery/Images/myImage/Versions/1.0.0"
 		boolTrue                     = true
 		boolFalse                    = false
 		zone                         = "zone"
@@ -106,6 +108,7 @@ var _ = Describe("Helper", func() {
 		Entry("entry exists(urn)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn}, false),
 		Entry("entry exists(id)", []api.MachineImage{{Name: "bar", Version: "1.2.3", ID: &imageID}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", ID: &imageID}, false),
 		Entry("entry exists(communityGalleryImageID)", []api.MachineImage{{Name: "bar", Version: "1.2.3", CommunityGalleryImageID: &communityImageId}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", CommunityGalleryImageID: &communityImageId}, false),
+		Entry("entry exists(sharedGalleryImageID)", []api.MachineImage{{Name: "bar", Version: "1.2.3", SharedGalleryImageID: &sharedImageId}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", SharedGalleryImageID: &sharedImageId}, false),
 		Entry("entry exists(accelerated networking active)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolTrue}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolTrue}, false),
 		Entry("entry exists(accelerated networking inactive)", []api.MachineImage{{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolFalse}}, "bar", "1.2.3", &api.MachineImage{Name: "bar", Version: "1.2.3", URN: &urn, AcceleratedNetworking: &boolFalse}, false),
 	)
@@ -139,18 +142,21 @@ var _ = Describe("Helper", func() {
 		Entry("list is nil", nil, "ubuntu", "1", nil),
 
 		Entry("profile empty list", []api.MachineImages{}, "ubuntu", "1", nil),
-		Entry("profile entry not found (image does not exist)", makeProfileMachineImages("debian", "1", "3", "5"), "ubuntu", "1", nil),
-		Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", "4", "6"), "ubuntu", "1", nil),
-		Entry("profile entry(urn)", makeProfileMachineImages("ubuntu", "1", "3", "5"), "ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN}),
-		Entry("profile entry(id)", makeProfileMachineImages("ubuntu", "1", "3", "5"), "ubuntu", "3", &api.MachineImage{Name: "ubuntu", Version: "3", ID: &profileID}),
-		Entry("profile entry(communiyGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5"), "ubuntu", "5", &api.MachineImage{Name: "ubuntu", Version: "5", CommunityGalleryImageID: &profileCommunityImageId}),
+		Entry("profile entry not found (image does not exist)", makeProfileMachineImages("debian", "1", "3", "5", "7"), "ubuntu", "1", nil),
+		Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", "4", "6", "7"), "ubuntu", "1", nil),
+		Entry("profile entry(urn)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN}),
+		Entry("profile entry(id)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "3", &api.MachineImage{Name: "ubuntu", Version: "3", ID: &profileID}),
+		Entry("profile entry(communityGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "5", &api.MachineImage{Name: "ubuntu", Version: "5", CommunityGalleryImageID: &profileCommunityImageId}),
+		Entry("profile entry(sharedGalleryId)", makeProfileMachineImages("ubuntu", "1", "3", "5", "6"), "ubuntu", "6", &api.MachineImage{Name: "ubuntu", Version: "6", SharedGalleryImageID: &profileSharedImageId}),
 
-		Entry("valid image reference, only urn", makeProfileMachineImageWithURNandIDandCommunityGalleryID("ubuntu", "1", &profileURN, nil, nil),
+		Entry("valid image reference, only urn", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", &profileURN, nil, nil, nil),
 			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", URN: &profileURN}),
-		Entry("valid image reference, only id", makeProfileMachineImageWithURNandIDandCommunityGalleryID("ubuntu", "1", nil, &profileID, nil),
+		Entry("valid image reference, only id", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, &profileID, nil, nil),
 			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", ID: &profileID}),
-		Entry("valid image reference, only communityGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryID("ubuntu", "1", nil, nil, &profileCommunityImageId),
+		Entry("valid image reference, only communityGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, nil, &profileCommunityImageId, nil),
 			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", CommunityGalleryImageID: &profileCommunityImageId}),
+		Entry("valid image reference, only sharedGalleryImageID", makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID("ubuntu", "1", nil, nil, nil, &profileSharedImageId),
+			"ubuntu", "1", &api.MachineImage{Name: "ubuntu", Version: "1", SharedGalleryImageID: &profileSharedImageId}),
 	)
 
 	DescribeTable("#IsVmoRequired",
@@ -190,7 +196,7 @@ var _ = Describe("Helper", func() {
 	)
 })
 
-func makeProfileMachineImages(name, urnVersion, idVersion, communityGalleryImageIdVersion string) []api.MachineImages {
+func makeProfileMachineImages(name, urnVersion, idVersion, communityGalleryImageIdVersion string, sharedGalleryImageIdVersion string) []api.MachineImages {
 	return []api.MachineImages{
 		{
 			Name: name,
@@ -207,12 +213,16 @@ func makeProfileMachineImages(name, urnVersion, idVersion, communityGalleryImage
 					Version:                 communityGalleryImageIdVersion,
 					CommunityGalleryImageID: &profileCommunityImageId,
 				},
+				{
+					Version:              sharedGalleryImageIdVersion,
+					SharedGalleryImageID: &profileSharedImageId,
+				},
 			},
 		},
 	}
 }
 
-func makeProfileMachineImageWithURNandIDandCommunityGalleryID(name, version string, urn, id, communityGalleryImageID *string) []api.MachineImages {
+func makeProfileMachineImageWithURNandIDandCommunityGalleryIDandSharedGalleryImageID(name, version string, urn, id, communityGalleryImageID *string, sharedGalleryImageID *string) []api.MachineImages {
 	return []api.MachineImages{
 		{
 			Name: name,
@@ -222,6 +232,7 @@ func makeProfileMachineImageWithURNandIDandCommunityGalleryID(name, version stri
 					URN:                     urn,
 					ID:                      id,
 					CommunityGalleryImageID: communityGalleryImageID,
+					SharedGalleryImageID:    sharedGalleryImageID,
 				},
 			},
 		},

--- a/pkg/apis/azure/types_cloudprofile.go
+++ b/pkg/apis/azure/types_cloudprofile.go
@@ -61,6 +61,8 @@ type MachineImageVersion struct {
 	ID *string
 	// CommunityGalleryImageID is the Community Image Gallery image id, it has the format '/CommunityGalleries/myGallery/Images/myImage/Versions/myVersion'
 	CommunityGalleryImageID *string
+	// SharedGalleryImageID is the Shared Image Gallery image id, it has the format '/SharedGalleries/sharedGalleryName/Images/sharedGalleryImageName/Versions/sharedGalleryImageVersionName'
+	SharedGalleryImageID *string
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	AcceleratedNetworking *bool
 }

--- a/pkg/apis/azure/types_worker.go
+++ b/pkg/apis/azure/types_worker.go
@@ -58,6 +58,8 @@ type MachineImage struct {
 	ID *string
 	// CommunityGalleryImageID is the Community Image Gallery image id.
 	CommunityGalleryImageID *string
+	// SharedGalleryImageID is the Shared Image Gallery image id.
+	SharedGalleryImageID *string
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	AcceleratedNetworking *bool
 }

--- a/pkg/apis/azure/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/azure/v1alpha1/types_cloudprofile.go
@@ -66,6 +66,9 @@ type MachineImageVersion struct {
 	// CommunityGalleryImageID is the Community Image Gallery image id, it has the format '/CommunityGalleries/myGallery/Images/myImage/Versions/myVersion'
 	// +optional
 	CommunityGalleryImageID *string `json:"communityGalleryImageID,omitempty"`
+	// SharedGalleryImageID is the Shared Image Gallery image id, it has the format '/SharedGalleries/sharedGalleryName/Images/sharedGalleryImageName/Versions/sharedGalleryImageVersionName'
+	// +optional
+	SharedGalleryImageID *string `json:"sharedGalleryImageID,omitempty"`
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	// +optional
 	AcceleratedNetworking *bool `json:"acceleratedNetworking,omitempty"`

--- a/pkg/apis/azure/v1alpha1/types_worker.go
+++ b/pkg/apis/azure/v1alpha1/types_worker.go
@@ -66,6 +66,9 @@ type MachineImage struct {
 	// CommunityGalleryImageID is the Community Image Gallery image id.
 	// +optional
 	CommunityGalleryImageID *string `json:"communityGalleryImageID,omitempty"`
+	// SharedGalleryImageID is the Shared Image Gallery image id.
+	// +optional
+	SharedGalleryImageID *string `json:"sharedGalleryImageID,omitempty"`
 	// AcceleratedNetworking is an indicator if the image supports Azure accelerated networking.
 	// +optional
 	AcceleratedNetworking *bool `json:"acceleratedNetworking,omitempty"`

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -570,6 +570,7 @@ func autoConvert_v1alpha1_MachineImage_To_azure_MachineImage(in *MachineImage, o
 	out.URN = (*string)(unsafe.Pointer(in.URN))
 	out.ID = (*string)(unsafe.Pointer(in.ID))
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
+	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
 	return nil
 }
@@ -585,6 +586,7 @@ func autoConvert_azure_MachineImage_To_v1alpha1_MachineImage(in *azure.MachineIm
 	out.URN = (*string)(unsafe.Pointer(in.URN))
 	out.ID = (*string)(unsafe.Pointer(in.ID))
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
+	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
 	return nil
 }
@@ -599,6 +601,7 @@ func autoConvert_v1alpha1_MachineImageVersion_To_azure_MachineImageVersion(in *M
 	out.URN = (*string)(unsafe.Pointer(in.URN))
 	out.ID = (*string)(unsafe.Pointer(in.ID))
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
+	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
 	return nil
 }
@@ -613,6 +616,7 @@ func autoConvert_azure_MachineImageVersion_To_v1alpha1_MachineImageVersion(in *a
 	out.URN = (*string)(unsafe.Pointer(in.URN))
 	out.ID = (*string)(unsafe.Pointer(in.ID))
 	out.CommunityGalleryImageID = (*string)(unsafe.Pointer(in.CommunityGalleryImageID))
+	out.SharedGalleryImageID = (*string)(unsafe.Pointer(in.SharedGalleryImageID))
 	out.AcceleratedNetworking = (*bool)(unsafe.Pointer(in.AcceleratedNetworking))
 	return nil
 }

--- a/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
@@ -310,6 +310,11 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SharedGalleryImageID != nil {
+		in, out := &in.SharedGalleryImageID, &out.SharedGalleryImageID
+		*out = new(string)
+		**out = **in
+	}
 	if in.AcceleratedNetworking != nil {
 		in, out := &in.AcceleratedNetworking, &out.AcceleratedNetworking
 		*out = new(bool)
@@ -343,6 +348,11 @@ func (in *MachineImageVersion) DeepCopyInto(out *MachineImageVersion) {
 	}
 	if in.CommunityGalleryImageID != nil {
 		in, out := &in.CommunityGalleryImageID, &out.CommunityGalleryImageID
+		*out = new(string)
+		**out = **in
+	}
+	if in.SharedGalleryImageID != nil {
+		in, out := &in.SharedGalleryImageID, &out.SharedGalleryImageID
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/apis/azure/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/zz_generated.deepcopy.go
@@ -310,6 +310,11 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SharedGalleryImageID != nil {
+		in, out := &in.SharedGalleryImageID, &out.SharedGalleryImageID
+		*out = new(string)
+		**out = **in
+	}
 	if in.AcceleratedNetworking != nil {
 		in, out := &in.AcceleratedNetworking, &out.AcceleratedNetworking
 		*out = new(bool)
@@ -343,6 +348,11 @@ func (in *MachineImageVersion) DeepCopyInto(out *MachineImageVersion) {
 	}
 	if in.CommunityGalleryImageID != nil {
 		in, out := &in.CommunityGalleryImageID, &out.CommunityGalleryImageID
+		*out = new(string)
+		**out = **in
+	}
+	if in.SharedGalleryImageID != nil {
+		in, out := &in.SharedGalleryImageID, &out.SharedGalleryImageID
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -46,7 +46,6 @@ func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	return nil
 }
 
-// return sharedGalleryImageID as well
 func (w *workerDelegate) findMachineImage(name, version string) (urn, id, communityGalleryImageID *string, sharedGalleryImageID *string, acceleratedNetworking *bool, err error) {
 	machineImage, err := helper.FindImageFromCloudProfile(w.cloudProfileConfig, name, version)
 	if err == nil {

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -46,28 +46,29 @@ func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) findMachineImage(name, version string) (urn, id, communityGalleryImageID *string, acceleratedNetworking *bool, err error) {
+// return sharedGalleryImageID as well
+func (w *workerDelegate) findMachineImage(name, version string) (urn, id, communityGalleryImageID *string, sharedGalleryImageID *string, acceleratedNetworking *bool, err error) {
 	machineImage, err := helper.FindImageFromCloudProfile(w.cloudProfileConfig, name, version)
 	if err == nil {
-		return machineImage.URN, machineImage.ID, machineImage.CommunityGalleryImageID, machineImage.AcceleratedNetworking, nil
+		return machineImage.URN, machineImage.ID, machineImage.CommunityGalleryImageID, machineImage.SharedGalleryImageID, machineImage.AcceleratedNetworking, nil
 	}
 
 	// Try to look up machine image in worker provider status as it was not found in componentconfig.
 	if providerStatus := w.worker.Status.ProviderStatus; providerStatus != nil {
 		workerStatus := &api.WorkerStatus{}
 		if _, _, err := w.Decoder().Decode(providerStatus.Raw, nil, workerStatus); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("could not decode worker status of worker '%s': %w", kutil.ObjectName(w.worker), err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("could not decode worker status of worker '%s': %w", kutil.ObjectName(w.worker), err)
 		}
 
 		machineImage, err := helper.FindMachineImage(workerStatus.MachineImages, name, version)
 		if err != nil {
-			return nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version)
+			return nil, nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version)
 		}
 
-		return machineImage.URN, machineImage.ID, machineImage.CommunityGalleryImageID, machineImage.AcceleratedNetworking, nil
+		return machineImage.URN, machineImage.ID, machineImage.CommunityGalleryImageID, machineImage.SharedGalleryImageID, machineImage.AcceleratedNetworking, nil
 	}
 
-	return nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version)
+	return nil, nil, nil, nil, nil, worker.ErrorMachineImageNotFound(name, version)
 }
 
 func appendMachineImage(machineImages []api.MachineImage, machineImage api.MachineImage) []api.MachineImage {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -127,7 +127,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			return err
 		}
 
-		urn, id, communityGalleryImageID, imageSupportAcceleratedNetworking, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version)
+		urn, id, communityGalleryImageID, sharedGalleryImageID, imageSupportAcceleratedNetworking, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version)
 		if err != nil {
 			return err
 		}
@@ -137,6 +137,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			URN:                     urn,
 			ID:                      id,
 			CommunityGalleryImageID: communityGalleryImageID,
+			SharedGalleryImageID:    sharedGalleryImageID,
 			AcceleratedNetworking:   imageSupportAcceleratedNetworking,
 		})
 
@@ -145,6 +146,8 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			image["urn"] = *urn
 		} else if communityGalleryImageID != nil {
 			image["communityGalleryImageID"] = *communityGalleryImageID
+		} else if sharedGalleryImageID != nil {
+			image["sharedGalleryImageID"] = *sharedGalleryImageID
 		} else {
 			image["id"] = *id
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR introduces support for shared gallery images to the Azure extension. Such images can be referenced in the CloudProfile like this:
```
machineImages:
- name: mySharedGalleryImage
  version: 1.0.0
  sharedGalleryImageID: /SharedGalleries/myGalleryID/Images/myImageID/Versions/1.0.0
```
This will result in the following MachineClass:
```
[...]
providerSpec:
  properties:
    storageProfile:
      imageReference:
        sharedGalleryImageID: /SharedGalleries/myGalleryID/Images/myImageID/Versions/1.0.0
```

This PR concerns the issue raised on mcm-provider-azure to enable support for shared gallery images. It can be checked out [here](https://github.com/gardener/machine-controller-manager-provider-azure/issues/71).

**Special notes for your reviewer**:
Cloud profile validation is tested. machine class with the provided sharedGalleryImageID in the cloud profile also gets created. Testing is done on the local shooted seed setup with nodeless garden cluster.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
support for Azure shared gallery images for workers is added
```
