### PR TITLE
Correct the metricsPort check for admission-azure deployment

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-azure/charts/runtime/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- if .Values.global.kubeconfig }}
         - --kubeconfig=/etc/gardener-extension-admission-azure/kubeconfig/kubeconfig
         {{- end }}
-        {{- if .Values.metricsPort }}
+        {{- if .Values.global.metricsPort }}
         - --metrics-bind-address=:{{ .Values.global.metricsPort }}
         {{- end }}
         - --health-bind-address=:{{ .Values.global.healthPort }}


### PR DESCRIPTION
/kind bug
/platform azure

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/604

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
