### PR TITLE
Remove support for kubernetes < 1.17 for Azure extension provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.19 | 1.19.0+     | [![Gardener v1.19 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.19%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.19%20Azure) |
 | Kubernetes 1.18 | 1.18.0+     | [![Gardener v1.18 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.18%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.18%20Azure) |
 | Kubernetes 1.17 | 1.17.0+     | [![Gardener v1.17 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.17%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.17%20Azure) |
-| Kubernetes 1.16 | 1.16.0+, except 1.16.2 | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20Azure) |
-| Kubernetes 1.15 | 1.15.0+, except 1.15.5 | [1] |
-
-[1] Conformance tests are still executed and validated, unfortunately [no longer shown in TestGrid](https://github.com/kubernetes/test-infra/pull/18509#issuecomment-668204180).
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -5,10 +5,6 @@ images:
   tag: "v2.18.1"
 
 - name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: k8s.gcr.io/hyperkube
-  targetVersion: "< 1.17"
-- name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-azure
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-azure
   tag: "v1.17.17"

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -1,4 +1,4 @@
-kubernetesVersion: 1.15.5
+kubernetesVersion: 1.17.0
 tenantId: fooTenant
 subscriptionId: barSub
 aadClientId: fooClient

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -38,11 +38,7 @@ spec:
         image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
-        {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
-        - /hyperkube
-        - cloud-controller-manager
-        - --allocate-node-cidrs=true
-        {{- else if semverCompare ">= 1.23" .Values.kubernetesVersion }}
+        {{- if semverCompare ">= 1.23" .Values.kubernetesVersion }}
         - /usr/local/bin/cloud-controller-manager
         - --allocate-node-cidrs=false
         {{- else }}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 clusterName: shoot-foo-bar
-kubernetesVersion: 1.15.5
+kubernetesVersion: 1.23.9
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -403,7 +403,7 @@ spec:
     nodes: 10.250.0.0/16
     services: 100.64.0.0/13
   kubernetes:
-    version: 1.16.1
+    version: 1.24.3
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -460,7 +460,7 @@ spec:
     nodes: 10.250.0.0/16
     services: 100.64.0.0/13
   kubernetes:
-    version: 1.16.1
+    version: 1.24.3
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -532,7 +532,7 @@ spec:
     nodes: 10.250.0.0/16
     services: 100.64.0.0/13
   kubernetes:
-    version: 1.16.1
+    version: 1.24.3
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -77,9 +77,9 @@ spec:
   type: azure
   kubernetes:
     versions:
-    - version: 1.16.1
-    - version: 1.16.0
-      expirationDate: "2020-04-05T01:02:03Z"
+    - version: 1.24.3
+    - version: 1.23.8
+      expirationDate: "2022-10-31T23:59:59Z"
   machineImages:
   - name: coreos
     versions:

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -126,9 +126,8 @@ spec:
     spec:
       containers:
       - command:
-        - /hyperkube
-        - apiserver
-        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,PodSecurityPolicy,ServiceAccount,NodeRestriction,DefaultStorageClass,Initializers,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - /usr/local/bin/kube-apiserver
+        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,PodSecurityPolicy,ServiceAccount,NodeRestriction,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --disable-admission-plugins=PersistentVolumeLabel
         - --allow-privileged=true
         - --anonymous-auth=false
@@ -147,7 +146,7 @@ spec:
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key
         - --v=2
-        image: k8s.gcr.io/hyperkube:v1.15.6
+        image: registry.k8s.io/kube-apiserver:v1.17.17
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -38,7 +38,7 @@ spec:
       networking:
         pods: 10.250.0.0/19
       kubernetes:
-        version: 1.15.4
+        version: 1.24.3
       hibernation:
         enabled: false
     status:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -36,7 +36,7 @@ spec:
     kind: Shoot
     spec:
       kubernetes:
-        version: 1.15.4
+        version: 1.24.3
     status:
       lastOperation:
         state: Succeeded

--- a/hack/api-reference/api.json
+++ b/hack/api-reference/api.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }
     ],
     "typeDisplayNamePrefixOverrides": {

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -109,7 +109,7 @@ var _ = Describe("ValuesProvider", func() {
 		cidr                    = "10.250.0.0/19"
 		cloudProviderConfigData = "foo"
 
-		k8sVersionLessThan121    = "1.15.4"
+		k8sVersionLessThan121    = "1.17.1"
 		k8sVersionHigherEqual121 = "1.21.4"
 
 		enabledTrue  = map[string]interface{}{"enabled": true}
@@ -491,7 +491,7 @@ var _ = Describe("ValuesProvider", func() {
 					"checksum/configmap-" + azure.CloudProviderDiskConfigName: "",
 				},
 				"cloudProviderConfig": "",
-				"kubernetesVersion":   "1.15.4",
+				"kubernetesVersion":   "1.17.1",
 			})
 			globalVpaDisabled = map[string]interface{}{
 				"vpaEnabled": false,

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -33,7 +33,6 @@ import (
 	oscutils "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/version"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -335,11 +334,10 @@ func ensureKubeControllerManagerVolumeMounts(c *corev1.Container, version string
 	}
 
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount)
-	if mustMountEtcSSLFolder(version) {
-		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
-		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
-		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount)
-	}
+
+	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
+	// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount)
 }
 
 func ensureKubeAPIServerVolumes(ps *corev1.PodSpec, csiEnabled, csiMigrationComplete bool) {
@@ -360,22 +358,10 @@ func ensureKubeControllerManagerVolumes(ps *corev1.PodSpec, version string, csiE
 	}
 
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigVolume)
-	if mustMountEtcSSLFolder(version) {
-		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
-		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
-		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, usrShareCaCertsVolume)
-	}
-}
 
-// Beginning with 1.17 Gardener no longer uses the hyperkube image for the Kubernetes control plane components.
-// The hyperkube image contained all the well-known root CAs, but the dedicated images don't. This is why we
-// mount the /etc/ssl folder from the host here.
-func mustMountEtcSSLFolder(version string) bool {
-	k8sVersionAtLeast117, err := versionutils.CompareVersions(version, ">=", "1.17")
-	if err != nil {
-		return false
-	}
-	return k8sVersionAtLeast117
+	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
+	// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, usrShareCaCertsVolume)
 }
 
 func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace string, csiEnabled, csiMigrationComplete bool) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-provider-aws/issues/595

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
provider-azure no longer supports Shoots with Кubernetes version < 1.17.
```
