### PR TITLE
Adds `QPS` , `Burst` to `HealthCheckConfig`

### DIFF
--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -25,7 +25,8 @@ import (
 // FindSubnetByPurposeAndZone takes a list of subnets and tries to find the first entry whose purpose matches with the given purpose.
 // Optionally, if the zone argument is not nil, the Zone field of a candidate subnet must match that value.
 // FindSubnetByPurposeAndZone returns the index of the subnet in the array and the subnet object.
-//  If no such entry is found then an error will be returned.
+//
+//	If no such entry is found then an error will be returned.
 func FindSubnetByPurposeAndZone(subnets []api.Subnet, purpose api.Purpose, zone *string) (int, *api.Subnet, error) {
 	for index, subnet := range subnets {
 		if subnet.Purpose == purpose && (zone == nil || (subnet.Zone != nil && *subnet.Zone == *zone)) {

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -16,6 +16,7 @@ package healthcheck
 
 import (
 	"context"
+	"k8s.io/utils/pointer"
 	"time"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
@@ -41,7 +42,11 @@ var (
 	defaultSyncPeriod = time.Second * 30
 	// DefaultAddOptions are the default DefaultAddArgs for AddToManager.
 	DefaultAddOptions = healthcheck.DefaultAddArgs{
-		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod}},
+		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod},
+			ShootRESTOptions: &healthcheckconfig.RESTOptions{
+				QPS:   pointer.Float32(100),
+				Burst: pointer.Int(130),
+			}},
 	}
 )
 

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -16,8 +16,9 @@ package healthcheck
 
 import (
 	"context"
-	"k8s.io/utils/pointer"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 	healthcheckconfig "github.com/gardener/gardener/extensions/pkg/apis/config"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR adds QPS and Burst to the config passed to HealthCheck client.
The values used here are from
https://github.com/gardener/gardener-extension-provider-azure/blob/f1cb846fa61c30ad889f6a66591f943c48b870f9/example/00-componentconfig.yaml#L7-L8

This is to prevent client-side throttling issues during health check execution.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```enhancement operator
`QPS` and `Burst` are set in the HealthCheckConfig passed to the Controller.
```
