### PR TITLE
No egress when NAT-Gateway is used

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1473,13 +1473,13 @@ Only the subnet that was used prior to the migration should have this attribute 
 </tr>
 <tr>
 <td>
-<code>NatGateway</code></br>
+<code>NatGatewayName</code></br>
 <em>
-bool
+string
 </em>
 </td>
 <td>
-<p>NatGateway is enabled</p>
+<p>NatGatewayName is enabled</p>
 </td>
 </tr>
 </tbody>

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1471,6 +1471,17 @@ bool
 Only the subnet that was used prior to the migration should have this attribute set.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>NatGateway</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>NatGateway is enabled</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="azure.provider.extensions.gardener.cloud/v1alpha1.VNet">VNet

--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -147,7 +147,7 @@ func ShouldDeployEgressChart(infraStatus *api.InfrastructureStatus, cluster *ext
 
 func AllNatEnabled(subnets []api.Subnet) bool {
 	for _, v := range subnets {
-		if !v.NatGateway {
+		if !v.HasNatGateway() {
 			return false
 		}
 	}

--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -138,14 +138,15 @@ func IsVmoRequired(infrastructureStatus *api.InfrastructureStatus) bool {
 	return !infrastructureStatus.Zoned && len(infrastructureStatus.AvailabilitySets) == 0
 }
 
+// ShouldDeployEgressChart determines if chart should be deployed
 func ShouldDeployEgressChart(infraStatus *api.InfrastructureStatus, cluster *extensions.Cluster) bool {
 	case1 := !infraStatus.Zoned && len(infraStatus.AvailabilitySets) != 0
-	case2 := !infraStatus.Zoned && HasShootVmoAlphaAnnotation(cluster.Shoot.Annotations) && AllNatEnabled(infraStatus.Networks.Subnets)
-	case3 := infraStatus.Zoned && AllNatEnabled(GetAllPurposeNodes(infraStatus.Networks.Subnets))
+	case2 := !infraStatus.Zoned && HasShootVmoAlphaAnnotation(cluster.Shoot.Annotations) && allNatEnabled(infraStatus.Networks.Subnets)
+	case3 := infraStatus.Zoned && allNatEnabled(getAllPurposeNodes(infraStatus.Networks.Subnets))
 	return !(case1 || case2 || case3)
 }
 
-func AllNatEnabled(subnets []api.Subnet) bool {
+func allNatEnabled(subnets []api.Subnet) bool {
 	for _, v := range subnets {
 		if !v.HasNatGateway() {
 			return false
@@ -154,7 +155,7 @@ func AllNatEnabled(subnets []api.Subnet) bool {
 	return true
 }
 
-func GetAllPurposeNodes(subnets []api.Subnet) []api.Subnet {
+func getAllPurposeNodes(subnets []api.Subnet) []api.Subnet {
 	res := []api.Subnet{}
 	for _, v := range subnets {
 		if v.Purpose == api.PurposeNodes {

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -167,7 +167,8 @@ type Subnet struct {
 	Zone *string
 	// Migrated is set when the network layout is migrated from NetworkLayoutSingleSubnet to NetworkLayoutMultipleSubnet.
 	// Only the subnet that was used prior to the migration should have this attribute set.
-	Migrated bool
+	Migrated   bool
+	NatGateway bool
 }
 
 // AvailabilitySet contains information about the azure availability set

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -171,6 +171,7 @@ type Subnet struct {
 	NatGatewayName *string
 }
 
+// HasNatGateway returns if NAT is enabled
 func (s Subnet) HasNatGateway() bool {
 	return s.NatGatewayName != nil
 }

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -167,8 +167,12 @@ type Subnet struct {
 	Zone *string
 	// Migrated is set when the network layout is migrated from NetworkLayoutSingleSubnet to NetworkLayoutMultipleSubnet.
 	// Only the subnet that was used prior to the migration should have this attribute set.
-	Migrated   bool
-	NatGateway bool
+	Migrated       bool
+	NatGatewayName *string
+}
+
+func (s Subnet) HasNatGateway() bool {
+	return s.NatGatewayName != nil
 }
 
 // AvailabilitySet contains information about the azure availability set

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -187,8 +187,8 @@ type Subnet struct {
 	// Migrated is set when the network layout is migrated from NetworkLayoutSingleSubnet to NetworkLayoutMultipleSubnet.
 	// Only the subnet that was used prior to the migration should have this attribute set.
 	Migrated bool `json:"migrated,omitempty"`
-	// NatGateway is enabled
-	NatGateway bool
+	// NatGatewayName is enabled
+	NatGatewayName *string
 }
 
 // AvailabilitySet contains information about the azure availability set

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -191,6 +191,11 @@ type Subnet struct {
 	NatGatewayName *string
 }
 
+// HasNatGateway returns if NAT is enabled
+func (s Subnet) HasNatGateway() bool {
+	return s.NatGatewayName != nil
+}
+
 // AvailabilitySet contains information about the azure availability set
 type AvailabilitySet struct {
 	// Purpose is the purpose of the availability set

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -187,6 +187,8 @@ type Subnet struct {
 	// Migrated is set when the network layout is migrated from NetworkLayoutSingleSubnet to NetworkLayoutMultipleSubnet.
 	// Only the subnet that was used prior to the migration should have this attribute set.
 	Migrated bool `json:"migrated,omitempty"`
+	// NatGateway is enabled
+	NatGateway bool
 }
 
 // AvailabilitySet contains information about the azure availability set

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -853,6 +853,7 @@ func autoConvert_v1alpha1_Subnet_To_azure_Subnet(in *Subnet, out *azure.Subnet, 
 	out.Purpose = azure.Purpose(in.Purpose)
 	out.Zone = (*string)(unsafe.Pointer(in.Zone))
 	out.Migrated = in.Migrated
+	out.NatGateway = in.NatGateway
 	return nil
 }
 
@@ -866,6 +867,7 @@ func autoConvert_azure_Subnet_To_v1alpha1_Subnet(in *azure.Subnet, out *Subnet, 
 	out.Purpose = Purpose(in.Purpose)
 	out.Zone = (*string)(unsafe.Pointer(in.Zone))
 	out.Migrated = in.Migrated
+	out.NatGateway = in.NatGateway
 	return nil
 }
 

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -853,7 +853,7 @@ func autoConvert_v1alpha1_Subnet_To_azure_Subnet(in *Subnet, out *azure.Subnet, 
 	out.Purpose = azure.Purpose(in.Purpose)
 	out.Zone = (*string)(unsafe.Pointer(in.Zone))
 	out.Migrated = in.Migrated
-	out.NatGateway = in.NatGateway
+	out.NatGatewayName = (*string)(unsafe.Pointer(in.NatGatewayName))
 	return nil
 }
 
@@ -867,7 +867,7 @@ func autoConvert_azure_Subnet_To_v1alpha1_Subnet(in *azure.Subnet, out *Subnet, 
 	out.Purpose = Purpose(in.Purpose)
 	out.Zone = (*string)(unsafe.Pointer(in.Zone))
 	out.Migrated = in.Migrated
-	out.NatGateway = in.NatGateway
+	out.NatGatewayName = (*string)(unsafe.Pointer(in.NatGatewayName))
 	return nil
 }
 

--- a/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
@@ -594,6 +594,11 @@ func (in *Subnet) DeepCopyInto(out *Subnet) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NatGatewayName != nil {
+		in, out := &in.NatGatewayName, &out.NatGatewayName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/azure/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/zz_generated.deepcopy.go
@@ -594,6 +594,11 @@ func (in *Subnet) DeepCopyInto(out *Subnet) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NatGatewayName != nil {
+		in, out := &in.NatGatewayName, &out.NatGatewayName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -697,7 +697,7 @@ func getControlPlaneShootChartValues(
 		"global": map[string]interface{}{
 			"vpaEnabled": gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 		},
-		azure.AllowEgressName: map[string]interface{}{"enabled": infraStatus.Zoned || azureapihelper.IsVmoRequired(infraStatus)},
+		azure.AllowEgressName: map[string]interface{}{"enabled": azureapihelper.ShouldDeployEgressChart(infraStatus, cluster)},
 		azure.CloudControllerManagerName: map[string]interface{}{
 			"enabled":     true,
 			"pspDisabled": pspDisabled,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -567,14 +567,14 @@ var _ = Describe("ValuesProvider", func() {
 				infrastructureStatus.Zoned = true
 				infrastructureStatus.Networks.Subnets = []apisazure.Subnet{
 					{
-						Name:       "subnet-abcd1234-nodes",
-						Purpose:    "nodes",
-						NatGateway: true,
+						Name:           "subnet-abcd1234-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: pointer.String("name"),
 					},
 					{
-						Name:       "subnet-abcd5678-nodes",
-						Purpose:    "internal",
-						NatGateway: false,
+						Name:           "subnet-abcd5678-nodes",
+						Purpose:        "internal",
+						NatGatewayName: pointer.String("name"),
 					},
 				}
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
@@ -586,14 +586,14 @@ var _ = Describe("ValuesProvider", func() {
 				infrastructureStatus.Zoned = true
 				infrastructureStatus.Networks.Subnets = []apisazure.Subnet{
 					{
-						Name:       "subnet-abcd1234-nodes",
-						Purpose:    "nodes",
-						NatGateway: true,
+						Name:           "subnet-abcd1234-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: pointer.String("name"),
 					},
 					{
-						Name:       "subnet-abcd5678-nodes",
-						Purpose:    "nodes",
-						NatGateway: false,
+						Name:           "subnet-abcd5678-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: nil,
 					},
 				}
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
@@ -606,14 +606,14 @@ var _ = Describe("ValuesProvider", func() {
 				infrastructureStatus.AvailabilitySets = []apisazure.AvailabilitySet{}
 				infrastructureStatus.Networks.Subnets = []apisazure.Subnet{
 					{
-						Name:       "subnet-abcd1234-nodes",
-						Purpose:    "nodes",
-						NatGateway: true,
+						Name:           "subnet-abcd1234-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: pointer.String("name"),
 					},
 					{
-						Name:       "subnet-abcd5678-nodes",
-						Purpose:    "nodes",
-						NatGateway: true,
+						Name:           "subnet-abcd5678-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: pointer.String("name"),
 					},
 				}
 				cluster = generateCluster(cidr, k8sVersionLessThan121, false, map[string]string{azure.ShootVmoUsageAnnotation: "true"})
@@ -627,14 +627,14 @@ var _ = Describe("ValuesProvider", func() {
 				infrastructureStatus.AvailabilitySets = []apisazure.AvailabilitySet{}
 				infrastructureStatus.Networks.Subnets = []apisazure.Subnet{
 					{
-						Name:       "subnet-abcd1234-nodes",
-						Purpose:    "nodes",
-						NatGateway: true,
+						Name:           "subnet-abcd1234-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: pointer.String("name"),
 					},
 					{
-						Name:       "subnet-abcd5678-nodes",
-						Purpose:    "nodes",
-						NatGateway: false, // TODO purpose matters?
+						Name:           "subnet-abcd5678-nodes",
+						Purpose:        "nodes",
+						NatGatewayName: nil, // TODO purpose matters?
 					},
 				}
 				cluster = generateCluster(cidr, k8sVersionLessThan121, false, map[string]string{azure.ShootVmoUsageAnnotation: "true"})

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -562,6 +562,8 @@ func ComputeStatus(ctx context.Context, tf terraformer.Terraformer, infra *exten
 	return status, nil
 }
 
+// StatusFromTerraformState computes an InfrastructureStatus from the given
+// Terraform variables.
 func StatusFromTerraformState(cluster *controller.Cluster, config *api.InfrastructureConfig, tfState *TerraformState) *apiv1alpha1.InfrastructureStatus {
 	status := statusFromTerraformStateWithoutNatGateway(config, tfState)
 	setNatGatewayConfigForSubnets(cluster.ObjectMeta.Name, config, status)

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -670,6 +670,22 @@ var _ = Describe("Terraform", func() {
 				Zoned: false,
 			}))
 		})
+		It("should add NatGateway config to infrastructure status", func() {
+			config.Networks.Zones = []api.Zone{{Name: 1, NatGateway: &api.ZonedNatGatewayConfig{Enabled: true}}, {Name: 2, NatGateway: &api.ZonedNatGatewayConfig{Enabled: true}}}
+			state.Subnets = []terraformSubnet{
+				{
+					name: "subnet1",
+					zone: pointer.String("1"),
+				},
+				{
+					name: "subnet2",
+					zone: pointer.String("2"),
+				},
+			}
+			status := StatusFromTerraformState(config, state)
+			Expect(status.Networks.Subnets[0].NatGateway).To(Equal(true))
+			Expect(status.Networks.Subnets[1].NatGateway).To(Equal(true))
+		})
 
 		It("should correctly compute the status for cluster with identity", func() {
 			var (
@@ -724,14 +740,19 @@ var _ = Describe("Terraform", func() {
 			config.Networks = api.NetworkConfig{
 				Zones: []api.Zone{
 					{
-						Name: 1,
+						Name:       1,
+						NatGateway: &api.ZonedNatGatewayConfig{Enabled: true},
 					},
 					{
-						Name: 2,
+						Name:       2,
+						NatGateway: &api.ZonedNatGatewayConfig{Enabled: true},
+					},
+					{
+						Name:       3,
+						NatGateway: nil, // check that nil does not panic
 					},
 				},
 			}
-			// state.SubnetNames = []string{subnetName1, subnetName2}
 			state.Subnets = []terraformSubnet{
 				{
 					name: subnetName1,
@@ -762,14 +783,16 @@ var _ = Describe("Terraform", func() {
 					},
 					Subnets: []apiv1alpha1.Subnet{
 						{
-							Purpose: apiv1alpha1.PurposeNodes,
-							Name:    subnetName1,
-							Zone:    &zone1,
+							Purpose:    apiv1alpha1.PurposeNodes,
+							Name:       subnetName1,
+							Zone:       &zone1,
+							NatGateway: true,
 						},
 						{
-							Purpose: apiv1alpha1.PurposeNodes,
-							Name:    subnetName2,
-							Zone:    &zone2,
+							Purpose:    apiv1alpha1.PurposeNodes,
+							Name:       subnetName2,
+							Zone:       &zone2,
+							NatGateway: true,
 						},
 					},
 					Layout: apiv1alpha1.NetworkLayoutMultipleSubnet,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #293

**Special notes for your reviewer**:
Should merge https://github.com/gardener/gardener-extension-provider-azure/pull/583 before this

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
