### PR TITLE
Disable remedy-controller after deployment

### DIFF
--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -112,8 +112,9 @@ var _ = Describe("ValuesProvider", func() {
 		k8sVersionLessThan121    = "1.17.1"
 		k8sVersionHigherEqual121 = "1.21.4"
 
-		enabledTrue  = map[string]interface{}{"enabled": true}
-		enabledFalse = map[string]interface{}{"enabled": false}
+		enabledTrue    = map[string]interface{}{"enabled": true}
+		enabledFalse   = map[string]interface{}{"enabled": false}
+		remedyDisabled = map[string]interface{}{"enabled": false, "replicas": 0}
 
 		// Azure Container Registry
 		azureContainerRegistryConfigMap = &corev1.ConfigMap{
@@ -671,12 +672,13 @@ var _ = Describe("ValuesProvider", func() {
 
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, fakeSecretsManager, checksums)
 				Expect(err).NotTo(HaveOccurred())
+
 				Expect(values).To(Equal(map[string]interface{}{
 					"global":                         globalVpaDisabled,
 					azure.AllowEgressName:            enabledTrue,
 					azure.CloudControllerManagerName: cloudControllerManager,
 					azure.CSINodeName:                csiNode,
-					azure.RemedyControllerName:       enabledFalse,
+					azure.RemedyControllerName:       remedyDisabled,
 				}))
 			})
 
@@ -699,7 +701,7 @@ var _ = Describe("ValuesProvider", func() {
 					azure.AllowEgressName:            enabledFalse,
 					azure.CloudControllerManagerName: cloudControllerManager,
 					azure.CSINodeName:                csiNode,
-					azure.RemedyControllerName:       enabledFalse,
+					azure.RemedyControllerName:       remedyDisabled,
 				}))
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
similar to https://github.com/gardener/gardener-extension-provider-aws/pull/617 we set `replicas=0` to scale down an existing deployment

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/218

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
