### PR TITLE
Disable remedy-controller after deployment

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -633,9 +633,8 @@ func getRemedyControllerChartValues(
 ) (map[string]interface{}, error) {
 	disableRemedyController := cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] == "true"
 	if disableRemedyController {
-		return map[string]interface{}{"enabled": false}, nil
+		return map[string]interface{}{"enabled": false, "replicas": 0}, nil
 	}
-
 	return map[string]interface{}{
 		"enabled":  true,
 		"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -633,7 +633,7 @@ func getRemedyControllerChartValues(
 ) (map[string]interface{}, error) {
 	disableRemedyController := cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] == "true"
 	if disableRemedyController {
-		return map[string]interface{}{"enabled": false, "replicas": 0}, nil
+		return map[string]interface{}{"enabled": true, "replicas": 0}, nil
 	}
 	return map[string]interface{}{
 		"enabled":  true,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -114,7 +114,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		enabledTrue    = map[string]interface{}{"enabled": true}
 		enabledFalse   = map[string]interface{}{"enabled": false}
-		remedyDisabled = map[string]interface{}{"enabled": false, "replicas": 0}
+		remedyDisabled = map[string]interface{}{"enabled": true, "replicas": 0}
 
 		// Azure Container Registry
 		azureContainerRegistryConfigMap = &corev1.ConfigMap{

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -112,8 +112,9 @@ var _ = Describe("ValuesProvider", func() {
 		k8sVersionLessThan121    = "1.17.1"
 		k8sVersionHigherEqual121 = "1.21.4"
 
-		enabledTrue  = map[string]interface{}{"enabled": true}
-		enabledFalse = map[string]interface{}{"enabled": false}
+		enabledTrue    = map[string]interface{}{"enabled": true}
+		enabledFalse   = map[string]interface{}{"enabled": false}
+		remedyDisabled = map[string]interface{}{"enabled": false, "replicas": 0}
 
 		// Azure Container Registry
 		azureContainerRegistryConfigMap = &corev1.ConfigMap{
@@ -479,7 +480,7 @@ var _ = Describe("ValuesProvider", func() {
 					"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 				}),
 				azure.CSIControllerName:    enabledFalse,
-				azure.RemedyControllerName: enabledFalse,
+				azure.RemedyControllerName: remedyDisabled,
 			}))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
similar to https://github.com/gardener/gardener-extension-provider-aws/pull/617 we set `replicas=0` to scale down an existing deployment

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/218

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
