### PR TITLE
Fix delete shoot with invalid credentials

### DIFF
--- a/pkg/azure/client/helper.go
+++ b/pkg/azure/client/helper.go
@@ -31,6 +31,7 @@ func IsAzureAPINotFoundError(err error) bool {
 	return false
 }
 
+// IsAzureAPIUnauthorized tries to determine if the API error is due to unauthorized access
 func IsAzureAPIUnauthorized(err error) bool {
 	switch e := err.(type) {
 	case autorest.DetailedError:

--- a/pkg/azure/client/helper.go
+++ b/pkg/azure/client/helper.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
-func IsAzureAPStatusError(err error,status int) bool {
+func isAzureAPStatusError(err error, status int) bool {
 	switch e := err.(type) {
 	case autorest.DetailedError:
 		if e.Response != nil && e.Response.StatusCode == status {
@@ -30,13 +30,12 @@ func IsAzureAPStatusError(err error,status int) bool {
 	return false
 }
 
-
 // IsAzureAPINotFoundError tries to determine if an error is a resource not found error.
 func IsAzureAPINotFoundError(err error) bool {
-	return IsAzureAPStatusError(err,http.StatusNotFound)
+	return isAzureAPStatusError(err, http.StatusNotFound)
 }
 
 // IsAzureAPIUnauthorized tries to determine if the API error is due to unauthorized access
 func IsAzureAPIUnauthorized(err error) bool {
-	return IsAzureAPStatusError(err,http.StatusUnauthorized)
+	return isAzureAPStatusError(err, http.StatusUnauthorized)
 }

--- a/pkg/azure/client/helper.go
+++ b/pkg/azure/client/helper.go
@@ -20,24 +20,23 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
-// IsAzureAPINotFoundError tries to determine if an error is a resource not found error.
-func IsAzureAPINotFoundError(err error) bool {
+func IsAzureAPStatusError(err error,status int) bool {
 	switch e := err.(type) {
 	case autorest.DetailedError:
-		if e.Response != nil && e.Response.StatusCode == http.StatusNotFound {
+		if e.Response != nil && e.Response.StatusCode == status {
 			return true
 		}
 	}
 	return false
 }
 
+
+// IsAzureAPINotFoundError tries to determine if an error is a resource not found error.
+func IsAzureAPINotFoundError(err error) bool {
+	return IsAzureAPStatusError(err,http.StatusNotFound)
+}
+
 // IsAzureAPIUnauthorized tries to determine if the API error is due to unauthorized access
 func IsAzureAPIUnauthorized(err error) bool {
-	switch e := err.(type) {
-	case autorest.DetailedError:
-		if e.Response.StatusCode == http.StatusUnauthorized {
-			return true
-		}
-	}
-	return false
+	return IsAzureAPStatusError(err,http.StatusUnauthorized)
 }

--- a/pkg/azure/client/helper.go
+++ b/pkg/azure/client/helper.go
@@ -30,3 +30,13 @@ func IsAzureAPINotFoundError(err error) bool {
 	}
 	return false
 }
+
+func IsAzureAPIUnauthorized(err error) bool {
+	switch e := err.(type) {
+	case autorest.DetailedError:
+		if e.Response.StatusCode == http.StatusUnauthorized {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/azure/client/helper_test.go
+++ b/pkg/azure/client/helper_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Helper", func() {
 		},
 		Entry("should return false as error is not a detailed azure error", false, false, 999, false),
 		Entry("should return false as error is not a NotFound", true, false, http.StatusInternalServerError, false),
-		Entry("should return true as error is a NotFound", true, true, http.StatusNotFound, true))
+		Entry("should return true as error if it is an NotFound error", true, true, http.StatusNotFound, true))
 	DescribeTable("#IsAzureAPIUnauthorized",
 		func(isDetailedError, hasResponse bool, statusCode int, expectIsUnauthorizedError bool) {
 			var err = errors.New("error")

--- a/pkg/azure/client/helper_test.go
+++ b/pkg/azure/client/helper_test.go
@@ -46,6 +46,29 @@ var _ = Describe("Helper", func() {
 		},
 		Entry("should return false as error is not a detailed azure error", false, false, 999, false),
 		Entry("should return false as error is not a NotFound", true, false, http.StatusInternalServerError, false),
-		Entry("should return true as error is a NotFound", true, true, http.StatusNotFound, true),
+		Entry("should return true as error is a NotFound", true, true, http.StatusNotFound, true))
+	DescribeTable("#IsAzureAPIUnauthorized",
+		func(isDetailedError, hasResponse bool, statusCode int, expectIsUnauthorizedError bool) {
+			var err = errors.New("error")
+			if !isDetailedError {
+				Expect(IsAzureAPIUnauthorized(err)).To(Equal(expectIsUnauthorizedError))
+				return
+			}
+
+			var detailedError = autorest.DetailedError{
+				Original:   err,
+				StatusCode: statusCode,
+			}
+			if hasResponse {
+				detailedError.Response = &http.Response{
+					StatusCode: statusCode,
+				}
+			}
+			Expect(IsAzureAPIUnauthorized(detailedError)).To(Equal(expectIsUnauthorizedError))
+		},
+		Entry("should return false as error if is not a detailed azure error", false, false, 999, false),
+		Entry("should return false as error if is not an Unauthorized error", true, false, http.StatusInternalServerError, false),
+		Entry("should return true as error if it is an Unauthorized error", true, true, http.StatusUnauthorized, true),
 	)
+
 })

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -59,7 +59,11 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 	azureClientFactory := NewAzureClientFactory(a.Client())
 	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, azureClientFactory, infra, config)
 	if err != nil {
-		return err
+		if azureclient.IsAzureAPIUnauthorized(err) {
+			log.Info("failed to check resource group availability due to invalid credentials", err)
+		} else {
+			return err
+		}
 	}
 
 	if !resourceGroupExists {

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -67,8 +67,10 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 	}
 
 	if !resourceGroupExists {
-		if err := infrastructure.DeleteNodeSubnetIfExists(ctx, azureClientFactory, infra, config); err != nil {
-			return err
+		if !azureclient.IsAzureAPIUnauthorized(err) {
+			if err := infrastructure.DeleteNodeSubnetIfExists(ctx, azureClientFactory, infra, config); err != nil {
+				return err
+			}
 		}
 
 		if err := tf.RemoveTerraformerFinalizerFromConfig(ctx); err != nil {

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -60,7 +60,7 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, azureClientFactory, infra, config)
 	if err != nil {
 		if azureclient.IsAzureAPIUnauthorized(err) {
-			log.Info("failed to check resource group availability due to invalid credentials", err)
+			log.Error(err, "Failed to check resource group availability due to invalid credentials")
 		} else {
 			return err
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
do not err when Azure client is unauthorized in resource group availability check, instead just log the result

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/574

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
