### PR TITLE
adapt cloudprovider bucket size based on nodes

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.tpl
@@ -25,9 +25,9 @@ cloudProviderBackoffDuration: 5
 cloudProviderBackoffJitter: 1.0
 cloudProviderRateLimit: true
 cloudProviderRateLimitQPS: {{ ( max .Values.maxNodes 10 ) }}
-cloudProviderRateLimitBucket: 100
+cloudProviderRateLimitBucket: {{ ( max .Values.maxNodes 100 ) }}
 cloudProviderRateLimitQPSWrite: {{ ( max .Values.maxNodes 10 ) }}
-cloudProviderRateLimitBucketWrite: 100
+cloudProviderRateLimitBucketWrite: {{ ( max .Values.maxNodes 100 ) }}
 {{- if semverCompare "< 1.18" .Values.kubernetesVersion }}
 cloudProviderBackoffMode: v2
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Adapt the client rate-limiter bucket based on the cluster size. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt the client rate-limiter bucket based on the cluster size. 
```
