### PR TITLE
Add validation for vnet name and resource group

### DIFF
--- a/pkg/apis/azure/validation/infrastructure.go
+++ b/pkg/apis/azure/validation/infrastructure.go
@@ -203,6 +203,12 @@ func validateVnetConfig(networkConfig *apisazure.NetworkConfig, resourceGroupCon
 	}
 
 	if isExternalVnetUsed(&networkConfig.VNet) {
+		if *networkConfig.VNet.Name == "" {
+			allErrs = append(allErrs, field.Required(vNetPath.Child("name"), "the vnet name must not be empty"))
+		}
+		if *networkConfig.VNet.ResourceGroup == "" {
+			allErrs = append(allErrs, field.Required(vNetPath.Child("resourceGroup"), "the vnet resource group must not be empty"))
+		}
 		if networkConfig.VNet.CIDR != nil {
 			allErrs = append(allErrs, field.Invalid(vNetPath.Child("cidr"), vnetConfig, "specifying a cidr for an existing vnet is not possible"))
 		}

--- a/pkg/apis/azure/validation/infrastructure_test.go
+++ b/pkg/apis/azure/validation/infrastructure_test.go
@@ -105,6 +105,26 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					}))
 			})
 
+			It("should forbid specifying a vnet resource group with empty name or resource group", func() {
+				infrastructureConfig.Networks.VNet = apisazure.VNet{
+					Name:          pointer.String(""),
+					ResourceGroup: pointer.String(""),
+				}
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services, hasVmoAlphaAnnotation, providerPath)
+
+				Expect(errorList).To(ConsistOfFields(
+					Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("networks.vnet.name"),
+						"Detail": Equal("the vnet name must not be empty"),
+					},
+					Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("networks.vnet.resourceGroup"),
+						"Detail": Equal("the vnet resource group must not be empty"),
+					}))
+			})
+
 			It("should forbid specifying existing vnet plus a vnet cidr", func() {
 				name := "existing-vnet"
 				vnetGroup := "existing-vnet-rg"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Add validation for infrastructure vnet name and resource group to forbid empty vnet references.

**Which issue(s) this PR fixes**:
Fixes #623 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add validation for infrastructure vnet name and resource group to forbid empty vnet references.
```
