### PR TITLE
Skip backupbucket container deletion if generated secret is not existing

### DIFF
--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -71,13 +71,19 @@ func (a *actuator) Delete(ctx context.Context, _ logr.Logger, backupBucket *exte
 
 	var factory = azureclient.NewAzureClientFactory(a.client)
 
-	// Get a storage account client to delete the backup container in the storage account.
-	storageClient, err := factory.Storage(ctx, *backupBucket.Status.GeneratedSecretRef)
+	secret, err := a.getBackupBucketGeneratedSecret(ctx, backupBucket)
 	if err != nil {
 		return err
 	}
-	if err := storageClient.DeleteContainerIfExists(ctx, backupBucket.Name); err != nil {
-		return err
+	if secret != nil {
+		// Get a storage account client to delete the backup container in the storage account.
+		storageClient, err := factory.Storage(ctx, *backupBucket.Status.GeneratedSecretRef)
+		if err != nil {
+			return err
+		}
+		if err := storageClient.DeleteContainerIfExists(ctx, backupBucket.Name); err != nil {
+			return err
+		}
 	}
 
 	// Get resource group client and delete the resource group which contains the backup storage account.

--- a/pkg/controller/backupbucket/secret.go
+++ b/pkg/controller/backupbucket/secret.go
@@ -21,10 +21,10 @@ import (
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -59,11 +59,17 @@ func (a *actuator) deleteBackupBucketGeneratedSecret(ctx context.Context, backup
 	if backupBucket.Status.GeneratedSecretRef == nil {
 		return nil
 	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      backupBucket.Status.GeneratedSecretRef.Name,
-			Namespace: backupBucket.Status.GeneratedSecretRef.Namespace,
-		},
+	return kutil.DeleteSecretByReference(ctx, a.client, backupBucket.Status.GeneratedSecretRef)
+}
+
+// getBackupBucketGeneratedSecret get generated secret referred by core BackupBucket resource in garden.
+func (a *actuator) getBackupBucketGeneratedSecret(ctx context.Context, backupBucket *extensionsv1alpha1.BackupBucket) (*corev1.Secret, error) {
+	if backupBucket.Status.GeneratedSecretRef == nil {
+		return nil, nil
 	}
-	return k8sclient.IgnoreNotFound(a.client.Delete(ctx, secret))
+	secret, err := kutil.GetSecretByReference(ctx, a.client, backupBucket.Status.GeneratedSecretRef)
+	if err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return secret, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Skip backup bucket deletion if generated secret is not existing anymore.

**Which issue(s) this PR fixes**:
Fixes #624

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Skip backupbucket container deletion if generated secret is not existing anymore
```
