### PR TITLE
update namespace selector for topology webhook

### DIFF
--- a/pkg/webhook/topology/add.go
+++ b/pkg/webhook/topology/add.go
@@ -58,7 +58,7 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 					Values:   []string{v1beta1constants.GardenRoleExtension},
 				},
 				{
-					Key:      "kubernetes.io/metadata.name",
+					Key:      corev1.LabelMetadataName
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{metav1.NamespaceSystem, v1beta1constants.GardenNamespace},
 				},

--- a/pkg/webhook/topology/add.go
+++ b/pkg/webhook/topology/add.go
@@ -51,9 +51,17 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Types:    types,
 		Webhook:  &admission.Webhook{Handler: New(logger), RecoverPanic: true},
 		Selector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				v1beta1constants.LabelSeedProvider: azure.Type,
-				v1beta1constants.GardenRole:        v1beta1constants.GardenRoleShoot,
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      v1beta1constants.GardenRole,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{v1beta1constants.GardenRoleExtension},
+				},
+				{
+					Key:      "kubernetes.io/metadata.name",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{metav1.NamespaceSystem, v1beta1constants.GardenNamespace},
+				},
 			},
 		},
 	}, nil

--- a/pkg/webhook/topology/add.go
+++ b/pkg/webhook/topology/add.go
@@ -58,7 +58,7 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 					Values:   []string{v1beta1constants.GardenRoleExtension},
 				},
 				{
-					Key:      corev1.LabelMetadataName
+					Key:      corev1.LabelMetadataName,
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{metav1.NamespaceSystem, v1beta1constants.GardenNamespace},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

After https://github.com/gardener/gardener/pull/6997, handling only the shoot namespaces in the topology webhook is not enough. We should extend the applicable namespaces while excluding critical ones to prevent deadlocks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Update the azure topology webhook to watch all namespaces and not just shoot namespaces. The `kube-system`, `garden` and extension namespaces are except to prevent deadlocks.
```
