### PR TITLE
Mark  csi-driver-node-* and cloud-node-manager as node-critical component

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
@@ -44,6 +44,7 @@ metadata:
   name: cloud-node-manager
   namespace: {{ .Release.Namespace }}
   labels:
+    node.gardener.cloud/critical-component: "true"
     component: cloud-node-manager
 spec:
   selector:
@@ -52,6 +53,7 @@ spec:
   template:
     metadata:
       labels:
+        node.gardener.cloud/critical-component: "true"
         k8s-app: cloud-node-manager
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_daemonset.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_daemonset.tpl
@@ -20,6 +20,7 @@ metadata:
   name: csi-driver-node-{{ .role }}
   namespace: {{ .Release.Namespace }}
   labels:
+    node.gardener.cloud/critical-component: "true"
     app: csi
     role: driver-{{ .role }}
 spec:
@@ -34,6 +35,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
+        node.gardener.cloud/critical-component: "true"
         app: csi
         role: driver-{{ .role }}
     spec:


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `node.gardener.cloud/critical-component` label to `csi-driver-node-*` and `cloud-node-manager` DaemonSet introduced in https://github.com/gardener/gardener/pull/7406 

**Which issue(s) this PR fixes**:
Part of  https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:
https://github.com/gardener/gardener/pull/7406 is merged

**Release note**:
```feature user
`csi-driver-node-*` and `cloud-node-manager` are marked as a node-critical component. With this, workload pods are only scheduled to a `Node` if it runs a ready `csi-driver-node-*` and `cloud-node-manager` pods.
```