### PR TITLE
simplify gardener version passing to webhooks

### DIFF
--- a/cmd/gardener-extension-provider-azure/app/app.go
+++ b/cmd/gardener-extension-provider-azure/app/app.go
@@ -19,21 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	azureinstall "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/install"
-	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
-	azurecmd "github.com/gardener/gardener-extension-provider-azure/pkg/cmd"
-	azurebackupbucket "github.com/gardener/gardener-extension-provider-azure/pkg/controller/backupbucket"
-	azurebackupentry "github.com/gardener/gardener-extension-provider-azure/pkg/controller/backupentry"
-	azurecontrolplane "github.com/gardener/gardener-extension-provider-azure/pkg/controller/controlplane"
-	azurecsimigration "github.com/gardener/gardener-extension-provider-azure/pkg/controller/csimigration"
-	azurednsrecord "github.com/gardener/gardener-extension-provider-azure/pkg/controller/dnsrecord"
-	"github.com/gardener/gardener-extension-provider-azure/pkg/controller/healthcheck"
-	azureinfrastructure "github.com/gardener/gardener-extension-provider-azure/pkg/controller/infrastructure"
-	azureworker "github.com/gardener/gardener-extension-provider-azure/pkg/controller/worker"
-	azurecontrolplaneexposure "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/controlplaneexposure"
-
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	azurebastion "github.com/gardener/gardener-extension-provider-azure/pkg/controller/bastion"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
@@ -52,6 +38,20 @@ import (
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	azureinstall "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/install"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+	azurecmd "github.com/gardener/gardener-extension-provider-azure/pkg/cmd"
+	azurebackupbucket "github.com/gardener/gardener-extension-provider-azure/pkg/controller/backupbucket"
+	azurebackupentry "github.com/gardener/gardener-extension-provider-azure/pkg/controller/backupentry"
+	azurebastion "github.com/gardener/gardener-extension-provider-azure/pkg/controller/bastion"
+	azurecontrolplane "github.com/gardener/gardener-extension-provider-azure/pkg/controller/controlplane"
+	azurecsimigration "github.com/gardener/gardener-extension-provider-azure/pkg/controller/csimigration"
+	azurednsrecord "github.com/gardener/gardener-extension-provider-azure/pkg/controller/dnsrecord"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/controller/healthcheck"
+	azureinfrastructure "github.com/gardener/gardener-extension-provider-azure/pkg/controller/infrastructure"
+	azureworker "github.com/gardener/gardener-extension-provider-azure/pkg/controller/worker"
+	azurecontrolplaneexposure "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/controlplaneexposure"
 )
 
 // NewControllerManagerCommand creates a new command for running a Azure provider controller.
@@ -133,9 +133,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			Namespace: os.Getenv("WEBHOOK_CONFIG_NAMESPACE"),
 		}
 
-		gardenerVersion    = new(string)
 		controllerSwitches = azurecmd.ControllerSwitchOptions()
-		webhookSwitches    = azurecmd.WebhookSwitchOptions(gardenerVersion)
+		webhookSwitches    = azurecmd.WebhookSwitchOptions()
 		webhookOptions     = webhookcmd.NewAddToManagerOptions(
 			azure.Name,
 			genericactuator.ShootWebhooksResourceName,
@@ -214,8 +213,6 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 			// add common meta types to schema for controller-runtime to use v1.ListOptions
 			metav1.AddToGroupVersion(scheme, machinev1alpha1.SchemeGroupVersion)
-
-			*gardenerVersion = generalOpts.Completed().GardenerVersion
 
 			configFileOpts.Completed().ApplyETCDStorage(&azurecontrolplaneexposure.DefaultAddOptions.ETCDStorage)
 			configFileOpts.Completed().ApplyHealthCheckConfig(&healthcheck.DefaultAddOptions.HealthCheckConfig)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -65,13 +65,13 @@ func ControllerSwitchOptions() *controllercmd.SwitchOptions {
 }
 
 // WebhookSwitchOptions are the webhookcmd.SwitchOptions for the provider webhooks.
-func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
+func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(extensionsnetworkwebhook.WebhookName, networkwebhook.AddToManager),
 		webhookcmd.Switch(infrastructurewebhook.WebhookName, infrastructurewebhook.AddToManager),
 		webhookcmd.Switch(extensionscontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		webhookcmd.Switch(extensionscontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
-		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager(gardenerVersion)),
+		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
 		webhookcmd.Switch(topology.WebhookName, topology.AddToManager),
 	)
 }

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -15,47 +15,31 @@
 package cloudprovider
 
 import (
-	"fmt"
-
-	"github.com/Masterminds/semver"
-	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 )
 
 var (
-	logger                           = log.Log.WithName("azure-cloudprovider-webhook")
-	versionConstraintGreaterEqual142 *semver.Constraints
+	logger = log.Log.WithName("azure-cloudprovider-webhook")
 )
 
 func init() {
 	var err error
-	versionConstraintGreaterEqual142, err = semver.NewConstraint(">= 1.42")
 	utilruntime.Must(err)
 }
 
 // AddToManager creates the cloudprovider webhook and adds it to the manager.
-func AddToManager(gardenerVersion *string) func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-		enable := false
-		if gardenerVersion != nil && len(*gardenerVersion) > 0 {
-			version, err := semver.NewVersion(*gardenerVersion)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse gardener version: %v", err)
-			}
-			if versionConstraintGreaterEqual142.Check(version) {
-				enable = true
-			}
-		}
-		logger.Info("adding webhook to manager")
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("adding webhook to manager")
 
-		return cloudprovider.New(mgr, cloudprovider.Args{
-			Provider:             azure.Type,
-			Mutator:              cloudprovider.NewMutator(logger, NewEnsurer(logger)),
-			EnableObjectSelector: enable,
-		})
-	}
+	return cloudprovider.New(mgr, cloudprovider.Args{
+		Provider:             azure.Type,
+		Mutator:              cloudprovider.NewMutator(logger, NewEnsurer(logger)),
+		EnableObjectSelector: true,
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Since we already have dependency on higher g/g versions (e.g. https://github.com/gardener/gardener-extension-provider-azure/pull/529), simplify gardener version passing to the cloudprovider webhook

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
