### PR TITLE
Add wait-for-csi-node annotation to csi-driver-node Pods

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_daemonset.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/_daemonset.tpl
@@ -30,8 +30,9 @@ spec:
       role: driver-{{ .role }}
   template:
     metadata:
-{{- if .Values.podAnnotations }}
       annotations:
+        node.gardener.cloud/wait-for-csi-node-azure: {{ include (print "csi-driver-node.provisioner-" .role) . }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/platform azure

**What this PR does / why we need it**:

This PR adds the `wait-for-csi-node` annotation to `csi-driver-node` introduced in gardener/gardener#7621

**Which issue(s) this PR fixes**:
Parts of gardener/gardener#7117

**Special notes for your reviewer**:
/hold
until gardener/gardener#7621 is merged

**Release note**:

```feature operator
`csi-driver-node` is annotated with the `wait-for-csi-node` annotation. Gardener uses this to only schedule workload pods to a `Node` once the driver has been successfully registered with the `CSINode` object.
```
