### PR TITLE
Switch to the non-deprecated funcs of the WorkerDelegate

### DIFF
--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -20,7 +20,20 @@ import (
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 )
 
-func (w *workerDelegate) DeployMachineDependencies(ctx context.Context) error {
+// DeployMachineDependencies implements genericactuator.WorkerDelegate.
+// Deprecated: Do not use this func. It is deprecated in genericactuator.WorkerDelegate.
+func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error {
+	return nil
+}
+
+// CleanupMachineDependencies implements genericactuator.WorkerDelegate.
+// Deprecated: Do not use this func. It is deprecated in genericactuator.WorkerDelegate.
+func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error {
+	return nil
+}
+
+// PreReconcileHook implements genericactuator.WorkerDelegate.
+func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
 	infrastructureStatus, err := w.decodeAzureInfrastructureStatus()
 	if err != nil {
 		return err
@@ -42,7 +55,29 @@ func (w *workerDelegate) DeployMachineDependencies(ctx context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) CleanupMachineDependencies(ctx context.Context) error {
+// PostReconcileHook implements genericactuator.WorkerDelegate.
+func (w *workerDelegate) PostReconcileHook(ctx context.Context) error {
+	return w.cleanupMachineDependencies(ctx)
+}
+
+// PreDeleteHook implements genericactuator.WorkerDelegate.
+func (w *workerDelegate) PreDeleteHook(_ context.Context) error {
+	return nil
+}
+
+// PostDeleteHook implements genericactuator.WorkerDelegate.
+func (w *workerDelegate) PostDeleteHook(ctx context.Context) error {
+	return w.cleanupMachineDependencies(ctx)
+}
+
+// cleanupMachineDependencies cleans up machine dependencies.
+//
+// TODO(dkistner, kon-angelo): Currently both PostReconcileHook and PostDeleteHook funcs call cleanupMachineDependencies.
+// cleanupMachineDependencies calls cleanupVmoDependencies. cleanupVmoDependencies handles the cases when the Worker is being
+// deleted (logic applicable for PostDeleteHook) and is not being deleted (logic applicable for PostReconcileHook).
+// Refactor this so that PostDeleteHook executes only the handling for Worker being deleted and PostReconcileHook executes only
+// the handling for Worker reconciled (not being deleted).
+func (w *workerDelegate) cleanupMachineDependencies(ctx context.Context) error {
 	infrastructureStatus, err := w.decodeAzureInfrastructureStatus()
 	if err != nil {
 		return err
@@ -61,25 +96,5 @@ func (w *workerDelegate) CleanupMachineDependencies(ctx context.Context) error {
 		return w.updateWorkerProviderStatus(ctx, workerProviderStatus)
 	}
 
-	return nil
-}
-
-// PreReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PreReconcileHook(_ context.Context) error {
-	return nil
-}
-
-// PostReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostReconcileHook(_ context.Context) error {
-	return nil
-}
-
-// PreDeleteHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PreDeleteHook(_ context.Context) error {
-	return nil
-}
-
-// PostDeleteHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostDeleteHook(_ context.Context) error {
 	return nil
 }


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform azure

**What this PR does / why we need it**:
The `DeployMachineDependencies` and `CleanupMachineDependencies` funcs were deprecated with https://github.com/gardener/gardener/pull/6290.
https://github.com/gardener/gardener/pull/7600 is about to remove these deprecates funcs.
This PR is minimal adaptation to non-deprecated variants. A TODO describing the further adaptation is being added.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
