### PR TITLE
enable cleanup of snapshots

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,7 +21,8 @@ gardener-extension-provider-azure:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          retention_policy: 'clean-snapshots'
         draft_release: ~
         options:
           public_build_logs: true


### PR DESCRIPTION
/area dev-productivity
/kind cleanup
/platform azure

**What this PR does / why we need it**:
Enable cleanup of snapshots

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
