### PR TITLE
Handle user related error code at missing place in infra deletion flow

### DIFF
--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -63,14 +63,14 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 		if azureclient.IsAzureAPIUnauthorized(err) {
 			log.Error(err, "Failed to check resource group availability due to invalid credentials")
 		} else {
-			return err
+			return util.DetermineError(err, helper.KnownCodes)
 		}
 	}
 
 	if !resourceGroupExists {
 		if !azureclient.IsAzureAPIUnauthorized(err) {
 			if err := infrastructure.DeleteNodeSubnetIfExists(ctx, azureClientFactory, infra, config); err != nil {
-				return err
+				return util.DetermineError(err, helper.KnownCodes)
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind regression
/platform azure

**What this PR does / why we need it**:
Check motivation for this PR -> https://github.com/gardener/gardener-extension-provider-azure/issues/660

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/issues/660

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing Azure-related errors not getting categorized properly is now fixed.
```
