### PR TITLE
[release-v1.34] Automated cherry pick of #664: Do not delete `csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the wrong cluster (Seed cluster) when deleting Shoot

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -167,8 +167,6 @@ var (
 					{Type: &appsv1.Deployment{}, Name: azure.CSISnapshotValidationName},
 					{Type: &corev1.Service{}, Name: azure.CSISnapshotValidationName},
 					{Type: &networkingv1.NetworkPolicy{}, Name: "allow-kube-apiserver-to-csi-snapshot-validation"},
-					{Type: &rbacv1.ClusterRole{}, Name: azure.UsernamePrefix + azure.CSISnapshotValidationName},
-					{Type: &rbacv1.ClusterRoleBinding{}, Name: azure.UsernamePrefix + azure.CSISnapshotValidationName},
 				},
 			},
 			{
@@ -258,6 +256,8 @@ var (
 					{Type: &rbacv1.RoleBinding{}, Name: azure.UsernamePrefix + azure.CSIResizerName},
 					// csi-snapshot-validation-webhook
 					{Type: &admissionregistrationv1.ValidatingWebhookConfiguration{}, Name: azure.CSISnapshotValidationName},
+					{Type: &rbacv1.ClusterRole{}, Name: azure.UsernamePrefix + azure.CSISnapshotValidationName},
+					{Type: &rbacv1.ClusterRoleBinding{}, Name: azure.UsernamePrefix + azure.CSISnapshotValidationName},
 				},
 			},
 			{


### PR DESCRIPTION
/area quality
/kind bug
/kind regression

Cherry pick of #664 on release-v1.34.

#664: Do not delete `csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the wrong cluster (Seed cluster) when deleting Shoot

**Release Notes:**
```bugfix operator
An issue causing provider-azure to wrongly delete the `extensions.gardener.cloud:provider-azure:csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the Seed cluster on every Shoot deletion is now fixed.
```