### PR TITLE
alwasy using latest os version for bastion vm

### DIFF
--- a/pkg/azure/client/factory.go
+++ b/pkg/azure/client/factory.go
@@ -200,3 +200,17 @@ func (f AzureFactory) Subnet(ctx context.Context, secretRef corev1.SecretReferen
 		client: subnetsClient,
 	}, nil
 }
+
+// VirtualMachineImage reads the secret from the passed reference and return an Azure Virtual Machine Image client.
+func (f AzureFactory) VirtualMachineImage(ctx context.Context, secretRef corev1.SecretReference) (VirtualMachineImage, error) {
+	authorizer, subscriptionID, err := internal.GetAuthorizerAndSubscriptionID(ctx, f.client, secretRef, false)
+	if err != nil {
+		return nil, err
+	}
+	virtualMachineImageClient := azurecompute.NewVirtualMachineImagesClient(subscriptionID)
+	virtualMachineImageClient.Authorizer = authorizer
+
+	return VirtualMachineImageClient{
+		client: virtualMachineImageClient,
+	}, nil
+}

--- a/pkg/azure/client/mock/mocks.go
+++ b/pkg/azure/client/mock/mocks.go
@@ -425,6 +425,21 @@ func (mr *MockFactoryMockRecorder) VirtualMachine(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualMachine", reflect.TypeOf((*MockFactory)(nil).VirtualMachine), arg0, arg1)
 }
 
+// VirtualMachineImage mocks base method.
+func (m *MockFactory) VirtualMachineImage(arg0 context.Context, arg1 v1.SecretReference) (client.VirtualMachineImage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VirtualMachineImage", arg0, arg1)
+	ret0, _ := ret[0].(client.VirtualMachineImage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VirtualMachineImage indicates an expected call of VirtualMachineImage.
+func (mr *MockFactoryMockRecorder) VirtualMachineImage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualMachineImage", reflect.TypeOf((*MockFactory)(nil).VirtualMachineImage), arg0, arg1)
+}
+
 // Vmss mocks base method.
 func (m *MockFactory) Vmss(arg0 context.Context, arg1 v1.SecretReference) (client.Vmss, error) {
 	m.ctrl.T.Helper()

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -41,6 +41,7 @@ type Factory interface {
 	NetworkInterface(ctx context.Context, secretRef corev1.SecretReference) (NetworkInterface, error)
 	Disk(ctx context.Context, secretRef corev1.SecretReference) (Disk, error)
 	Subnet(ctx context.Context, secretRef corev1.SecretReference) (Subnet, error)
+	VirtualMachineImage(ctx context.Context, secretRef corev1.SecretReference) (VirtualMachineImage, error)
 }
 
 // Group represents an Azure group client.
@@ -123,6 +124,11 @@ type Subnet interface {
 	Delete(context.Context, string, string, string) error
 }
 
+// VirtualMachineImage represents an Azure Virtual Machine Image client.
+type VirtualMachineImage interface {
+	ListSkus(ctx context.Context, location string, publisherName string, offer string) (*compute.ListVirtualMachineImageResource, error)
+}
+
 // AzureFactory is an implementation of Factory to produce clients for various Azure services.
 type AzureFactory struct {
 	client client.Client
@@ -191,4 +197,9 @@ type DisksClient struct {
 // SubnetsClient is an implementation of Subnet for a Subnet client.
 type SubnetsClient struct {
 	client network.SubnetsClient
+}
+
+// VirtualMachineImageClient is an implementation of Virtual Machine Image for a Virtual Machine Image client.
+type VirtualMachineImageClient struct {
+	client compute.VirtualMachineImagesClient
 }

--- a/pkg/azure/client/vmImage.go
+++ b/pkg/azure/client/vmImage.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+)
+
+// ListSkus will a list of virtual machine image SKUs for the specified location, publisher, and offer.
+func (c VirtualMachineImageClient) ListSkus(ctx context.Context, location string, publisherName string, offer string) (*compute.ListVirtualMachineImageResource, error) {
+	skus, err := c.client.ListSkus(ctx, location, publisherName, offer)
+	if err != nil {
+		return nil, err
+	}
+	return &skus, nil
+}

--- a/pkg/controller/bastion/resourcesdefine.go
+++ b/pkg/controller/bastion/resourcesdefine.go
@@ -60,7 +60,7 @@ func publicIPAddressDefine(opt *Options) *network.PublicIPAddress {
 	}
 }
 
-func computeInstanceDefine(opt *Options, sku string, bastion *extensionsv1alpha1.Bastion, publickey string) *compute.VirtualMachine {
+func computeInstanceDefine(opt *Options, sku *compute.ImageReference, bastion *extensionsv1alpha1.Bastion, publickey string) *compute.VirtualMachine {
 	return &compute.VirtualMachine{
 		Location: &opt.Location,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
@@ -68,7 +68,7 @@ func computeInstanceDefine(opt *Options, sku string, bastion *extensionsv1alpha1
 				VMSize: compute.VirtualMachineSizeTypesStandardB1s,
 			},
 			StorageProfile: &compute.StorageProfile{
-				ImageReference: vmImage(sku),
+				ImageReference: sku,
 				OsDisk: &compute.OSDisk{
 					CreateOption: compute.DiskCreateOptionTypesFromImage,
 					DiskSizeGB:   to.Int32Ptr(32),
@@ -156,14 +156,5 @@ func nsgEgressAllowSSHToWorkerIPv4(opt *Options) network.SecurityRule {
 			Priority:                   to.Int32Ptr(401),
 			Description:                to.StringPtr("Allow Bastion egress to Shoot workers ipv4"),
 		},
-	}
-}
-
-func vmImage(sku string) *compute.ImageReference {
-	return &compute.ImageReference{
-		Publisher: to.StringPtr("Canonical"),
-		Offer:     to.StringPtr("UbuntuServer"),
-		Sku:       to.StringPtr(sku),
-		Version:   to.StringPtr("latest"),
 	}
 }

--- a/pkg/controller/bastion/resourcesdefine.go
+++ b/pkg/controller/bastion/resourcesdefine.go
@@ -60,7 +60,7 @@ func publicIPAddressDefine(opt *Options) *network.PublicIPAddress {
 	}
 }
 
-func computeInstanceDefine(opt *Options, bastion *extensionsv1alpha1.Bastion, publickey string) *compute.VirtualMachine {
+func computeInstanceDefine(opt *Options, sku string, bastion *extensionsv1alpha1.Bastion, publickey string) *compute.VirtualMachine {
 	return &compute.VirtualMachine{
 		Location: &opt.Location,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
@@ -68,12 +68,7 @@ func computeInstanceDefine(opt *Options, bastion *extensionsv1alpha1.Bastion, pu
 				VMSize: compute.VirtualMachineSizeTypesStandardB1s,
 			},
 			StorageProfile: &compute.StorageProfile{
-				ImageReference: &compute.ImageReference{
-					Publisher: to.StringPtr("Canonical"),
-					Offer:     to.StringPtr("UbuntuServer"),
-					Sku:       to.StringPtr("18.04-LTS"),
-					Version:   to.StringPtr("latest"),
-				},
+				ImageReference: vmImage(sku),
 				OsDisk: &compute.OSDisk{
 					CreateOption: compute.DiskCreateOptionTypesFromImage,
 					DiskSizeGB:   to.Int32Ptr(32),
@@ -161,5 +156,14 @@ func nsgEgressAllowSSHToWorkerIPv4(opt *Options) network.SecurityRule {
 			Priority:                   to.Int32Ptr(401),
 			Description:                to.StringPtr("Allow Bastion egress to Shoot workers ipv4"),
 		},
+	}
+}
+
+func vmImage(sku string) *compute.ImageReference {
+	return &compute.ImageReference{
+		Publisher: to.StringPtr("Canonical"),
+		Offer:     to.StringPtr("UbuntuServer"),
+		Sku:       to.StringPtr(sku),
+		Version:   to.StringPtr("latest"),
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform Azure

**What this PR does / why we need it**:
It is similar to https://github.com/gardener/gardener-extension-provider-aws/issues/713, always search latest os version to build up the bastion instance instead of the hard code version.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
always search latest os version to build up the Bastion instance
```
