### PR TITLE
[release-v1.35] Automated cherry pick of #671: allow rg deletion with other resources

### DIFF
--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -5,7 +5,11 @@ provider "azurerm" {
   client_secret   = var.CLIENT_SECRET
 
   skip_provider_registration = "true"
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 #===============================================


### PR DESCRIPTION
/area control-plane
/kind regression

Cherry pick of #671 on release-v1.35.

#671: allow rg deletion with other resources

**Release Notes:**
```other operator
Restore terraform behavior to delete the azure resource group even if it contains other resources.
```