### PR TITLE
Add calico scheme to validator

### DIFF
--- a/cmd/gardener-extension-admission-azure/app/app.go
+++ b/cmd/gardener-extension-admission-azure/app/app.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	calicoinstall "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/install"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	"github.com/gardener/gardener/pkg/apis/core/install"
@@ -75,6 +76,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			if err := azureinstall.AddToScheme(mgr.GetScheme()); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
+			calicoinstall.Install(mgr.GetScheme())
 
 			log.Info("Setting up webhook server")
 			if err := webhookOptions.Completed().AddToManager(mgr); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
With https://github.com/gardener/gardener-extension-provider-azure/pull/669 the validator performs some checks specific to calico and as such needs to have the calico scheme registered to decode the networking config.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add calico scheme to azure-validator.
```
