### PR TITLE
[release-v1.36] Automated cherry pick of #696: Add calico scheme to validator

### DIFF
--- a/cmd/gardener-extension-admission-azure/app/app.go
+++ b/cmd/gardener-extension-admission-azure/app/app.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	calicoinstall "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/install"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	"github.com/gardener/gardener/pkg/apis/core/install"
@@ -75,6 +76,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			if err := azureinstall.AddToScheme(mgr.GetScheme()); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
+			calicoinstall.Install(mgr.GetScheme())
 
 			log.Info("Setting up webhook server")
 			if err := webhookOptions.Completed().AddToManager(mgr); err != nil {


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #696 on release-v1.36.

#696: Add calico scheme to validator

**Release Notes:**
```other operator
Add calico scheme to azure-validator.
```