### PR TITLE
fix a case where a successful test would fail during cleanup

### DIFF
--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -670,8 +670,14 @@ func verifyDeletion(ctx context.Context, az *azureClientSet, options *bastionctr
 func checkSecurityRuleDoesNotExist(ctx context.Context, az *azureClientSet, options *bastionctrl.Options, securityRuleName string) {
 	// does not have authorization to performsecurityRules get due to global rule. use security group to check it.
 	sg, err := az.securityGroups.Get(ctx, options.ResourceGroupName, securityRuleName, "")
-	Expect(len(*sg.SecurityRules)).To(Equal(0))
+	if IsNotFound(err) {
+		return
+	}
+
 	Expect(ignoreAzureNotFoundError(err)).To(Succeed())
+	if sg.SecurityGroupPropertiesFormat != nil && sg.SecurityGroupPropertiesFormat.SecurityRules != nil {
+		Expect(len(*sg.SecurityGroupPropertiesFormat.SecurityRules)).To(Equal(0))
+	}
 }
 
 func verifyCreation(ctx context.Context, az *azureClientSet, options *bastionctrl.Options) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/platform azure

**What this PR does / why we need it**:
Fix an 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue with the bastion integration testing panicking on cleanup due to the security group having being deleted.
```
