### PR TITLE
Configure CCM to keep setting deprecated labes on the nodes

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -69,6 +69,9 @@ spec:
         - --tls-cipher-suites={{ .Values.tlsCipherSuites | join "," }}
         - --use-service-account-credentials
         - --v=2
+        {{- if semverCompare ">= 1.26.0-0, < 1.28.0-0" .Values.kubernetesVersion }}
+        - --deprecated-apply-beta-topology-labels=true
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness storage
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Configure CCM to keep setting deprecated labes on the nodes for k8s clusters `>= 1.26, <1.28`. 

https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2653 stopped maintaining the deprecated labels on the nodes, however some PVs are using these deprecated labels for node affinities and in the same time the PV node affinities field is immutable, hence once a shoot is upgraded to 1.26 it might happen that pods using exising PVs to not be scheduled on any node in the cluster.  


https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3685 added the option the CCM to keep maintaining these labels, so let's make use of it. 
In the same time, k8s relaxed a bit the immutability the PV spec with https://github.com/kubernetes/kubernetes/pull/115391, but as of now this is available only in `>= 1.27` (there are opened cherry-picks to bring it also in 1.25 and 1.26). 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The cloud-controller-manager is now set to keep setting deprecated node labels for k8s clusters of version `>=1.26.0, <1.28.0` to ensure pods using persistent volumes with node affinities are scheduled in the cluster.
```
