### PR TITLE
Pass the `--enable-deprecated-beta-topology-labels` flag to cloud-node-manager, not cloud-controller-manager

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -69,9 +69,6 @@ spec:
         - --tls-cipher-suites={{ .Values.tlsCipherSuites | join "," }}
         - --use-service-account-credentials
         - --v=2
-        {{- if semverCompare ">= 1.26.0-0, < 1.28.0-0" .Values.kubernetesVersion }}
-        - --deprecated-apply-beta-topology-labels=true
-        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
@@ -85,6 +85,9 @@ spec:
         - cloud-node-manager
         - --node-name=$(NODE_NAME)
         - --wait-routes=true   # only set to true when --configure-cloud-routes=true in cloud-controller-manager.
+        {{- if semverCompare ">= 1.26.0-0, < 1.28.0-0" .Capabilities.KubeVersion.GitVersion }}
+        - --enable-deprecated-beta-topology-labels=true
+        {{- end }}
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/kind bug
/platform azure

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-azure/pull/716 added the flag to cloud-controller-manager. This fails with:
```
Error: unknown flag: --deprecated-apply-beta-topology-labels
```

The flag is supported for cloud-node-manager. See https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3685.

Additionally, the flag name is `--enable-deprecated-beta-topology-labels`, not `--deprecated-apply-beta-topology-labels`.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-azure/pull/716

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
