### PR TITLE
always set vmtype

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -496,6 +496,7 @@ func appendMachineSetValues(values map[string]interface{}, infraStatus *apisazur
 		return values
 	}
 
+	values["vmType"] = "standard"
 	return values
 }
 
@@ -628,6 +629,8 @@ func getCSIControllerChartValues(
 
 	if azureapihelper.IsVmoRequired(infraStatus) {
 		values["vmType"] = "vmss"
+	} else {
+		values["vmType"] = "standard"
 	}
 
 	return values, nil

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -289,6 +289,7 @@ var _ = Describe("ValuesProvider", func() {
 					"routeTableName":    "route-table-name",
 					"securityGroupName": "security-group-name-workers",
 					"maxNodes":          maxNodes,
+					"vmType":            "standard",
 				}))
 			})
 
@@ -316,6 +317,7 @@ var _ = Describe("ValuesProvider", func() {
 					"securityGroupName":   "security-group-name-workers",
 					"acrIdentityClientId": identityName,
 					"maxNodes":            maxNodes,
+					"vmType":              "standard",
 				}))
 			})
 		})
@@ -427,6 +429,7 @@ var _ = Describe("ValuesProvider", func() {
 				}),
 				azure.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
 					"replicas": 1,
+					"vmType":   "standard",
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + azure.CloudProviderConfigName: checksums[azure.CloudProviderConfigName],
 					},
@@ -469,6 +472,7 @@ var _ = Describe("ValuesProvider", func() {
 				}),
 				azure.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
 					"replicas": 1,
+					"vmType":   "standard",
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + azure.CloudProviderConfigName: checksums[azure.CloudProviderConfigName],
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/platform azure

**What this PR does / why we need it**:

Azure CCM's make a change to the default value of vmType in k8s v1.28. Instead of "reverting the conditions" where we set `vmType` let's always set the proper value.

With this change we will also always set the vmtype and not only in v1.28

Ref to azure PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/4214

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Always set the `vmType` in cloud-provider configuration files.
```
