### PR TITLE
[release-v1.39] Automated cherry pick of #749: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.11.0->v0.11.1]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -171,7 +171,7 @@ images:
 - name: machine-controller-manager-provider-azure
   sourceRepository: github.com/gardener/machine-controller-manager-provider-azure
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-azure
-  tag: "v0.11.0"
+  tag: "v0.11.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #749 on release-v1.39.

#749: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.11.0->v0.11.1]

**Release Notes:**
```other developer github.com/gardener/machine-controller-manager #820 @afritzler
Bump `k8s.io/*` deps to v0.27.2
```
```other operator github.com/gardener/machine-controller-manager #851 @rishabh-11
Added `errorCode` field in the `LastOperation` struct. This should be implemented only for the `CreateMachine` call in the `triggerCreationFlow`. This field will be utilized by Cluster autoscaler to do early backoff 
```
```bugfix operator github.com/gardener/machine-controller-manager #866 @gardener-robot-ci-2
Removes `node.machine.sapcloud.io/not-managed-by-mcm` annotation from nodes managed by the MCM.
```
```other operator github.com/gardener/machine-controller-manager #866 @gardener-robot-ci-2
The default `machine-safety-orphan-vms-period` has been reduced from 30m to 15m.
```
```other developer github.com/gardener/machine-controller-manager #845 @unmarshall
A new make target is introduced to add license headers.
```
```other operator github.com/gardener/machine-controller-manager #842 @unmarshall
New metrics introduced: 
- api_request_duration_seconds -> tracks time taken for successful invocation of provider APIs. This metric can be filtered by provider and service.
- driver_request_duration_seconds -> tracks total time taken to successfully complete driver method invocation. This metric can be filtered by provider and operation.
- driver_requests_failed_total -> records total number of failed driver API requests. This metric can be filtered by provider, operations and error_code.
```
```other operator github.com/gardener/machine-controller-manager #852 @unmarshall
Makefile targets have changed: Introduced gardener-setup, gardener-restore, gardener-local-mcm-up, non-gardener-setup, non-gardener-restore, non-gardener-local-mcm-up. Users can also directly use the scripts which are used by these makefile targets.
```
```other developer github.com/gardener/machine-controller-manager #842 @unmarshall
status.Status now captures underline cause, allowing consumers to introspect the error returned by the provider. WrapError() function could be used to wrap the provider error
```
```other developer github.com/gardener/machine-controller-manager #823 @himanshu-kun
Removed dead metrics code and refactored the remaining metrics code
```
```other operator github.com/gardener/machine-controller-manager #808 @jguipi
Added a new metric that will allow to get the number of stale (due to unhealthiness) machines that are getting terminated
```
```bugfix operator github.com/gardener/machine-controller-manager #814 @acumino
An issue causing nil pointer panic on scaleup of the machinedeployment along with trigger of rolling update, is fixed
```
```bugfix operator github.com/gardener/machine-controller-manager #839 @elankath
Force drain and delete volume attachments for nodes un-healthy due to `ReadOnlyFileSystem` and `NotReady` for too long
```
```other operator github.com/gardener/machine-controller-manager #827 @rishabh-11
Updated to go v1.20.5
```
```bugfix operator github.com/gardener/machine-controller-manager #833 @rishabh-11
Included `UnavailableReplicas` in determining if a machine deployment status update is needed
```
```bugfix user github.com/gardener/machine-controller-manager #821 @rishabh-11
An edge case where outdated DesiredReplicas annotation blocked a rolling update is fixed.
```