### PR TITLE
Fix failing validation when overlay config is empty.

### DIFF
--- a/pkg/apis/azure/validation/shoot.go
+++ b/pkg/apis/azure/validation/shoot.go
@@ -50,8 +50,6 @@ func ValidateNetworking(networking *core.Networking, fldPath *field.Path) field.
 			if overlay["enabled"].(bool) {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("providerConfig").Child("overlay").Child("enabled"), "Calico overlay network is not supported on azure"))
 			}
-		} else {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("providerConfig").Child("overlay"), networkConfig["overlay"], "error decoding networking provider config"))
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform azure

**What this PR does / why we need it**:
Cherry-pick from https://github.com/gardener/gardener-extension-provider-azure/pull/752
Since https://github.com/gardener/gardener-extension-provider-azure/pull/735
shoots with no overlay config can't be deleted as the missing config is considered as an error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix failing validation  when overlay config is empty.
```
