### PR TITLE
Fix empty `vmType`

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -486,6 +486,7 @@ func getConfigChartValues(infraStatus *apisazure.InfrastructureStatus, cp *exten
 }
 
 func appendMachineSetValues(values map[string]interface{}, infraStatus *apisazure.InfrastructureStatus) map[string]interface{} {
+	values["vmType"] = "standard"
 	if azureapihelper.IsVmoRequired(infraStatus) {
 		values["vmType"] = "vmss"
 		return values
@@ -493,10 +494,8 @@ func appendMachineSetValues(values map[string]interface{}, infraStatus *apisazur
 
 	if primaryAvailabilitySet, err := azureapihelper.FindAvailabilitySetByPurpose(infraStatus.AvailabilitySets, apisazure.PurposeNodes); err == nil {
 		values["availabilitySetName"] = primaryAvailabilitySet.Name
-		return values
 	}
 
-	values["vmType"] = "standard"
 	return values
 }
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -244,6 +244,7 @@ var _ = Describe("ValuesProvider", func() {
 					"routeTableName":      "route-table-name",
 					"securityGroupName":   "security-group-name-workers",
 					"maxNodes":            maxNodes,
+					"vmType":              "standard",
 				}))
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR fixes a bug which caused an empty `vmType`. Empty `vmType`s prevent load balancers from being deleted on Kubernetes v1.28 shoots.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which caused an empty `vmType` under certain conditions has been fixed. Empty `vmType`s prevent load balancers from being deleted on Kubernetes v1.28 shoots.
```
