### PR TITLE
[release-v1.39] Automated cherry pick of #754: Fix empty `vmType`

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -486,6 +486,7 @@ func getConfigChartValues(infraStatus *apisazure.InfrastructureStatus, cp *exten
 }
 
 func appendMachineSetValues(values map[string]interface{}, infraStatus *apisazure.InfrastructureStatus) map[string]interface{} {
+	values["vmType"] = "standard"
 	if azureapihelper.IsVmoRequired(infraStatus) {
 		values["vmType"] = "vmss"
 		return values
@@ -493,10 +494,8 @@ func appendMachineSetValues(values map[string]interface{}, infraStatus *apisazur
 
 	if primaryAvailabilitySet, err := azureapihelper.FindAvailabilitySetByPurpose(infraStatus.AvailabilitySets, apisazure.PurposeNodes); err == nil {
 		values["availabilitySetName"] = primaryAvailabilitySet.Name
-		return values
 	}
 
-	values["vmType"] = "standard"
 	return values
 }
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -244,6 +244,7 @@ var _ = Describe("ValuesProvider", func() {
 					"routeTableName":      "route-table-name",
 					"securityGroupName":   "security-group-name-workers",
 					"maxNodes":            maxNodes,
+					"vmType":              "standard",
 				}))
 			})
 


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #754 on release-v1.39.

#754: Fix empty `vmType`

**Release Notes:**
```bugfix operator
A bug which caused an empty `vmType` under certain conditions has been fixed. Empty `vmType`s prevent load balancers from being deleted on Kubernetes v1.28 shoots.
```