### PR TITLE
add delete-on-invalid-update on CSIDriver objects

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csidriver-disk.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csidriver-disk.yaml
@@ -3,6 +3,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: disk.csi.azure.com
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 spec:
   attachRequired: true
   podInfoOnMount: false

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csidriver-file.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csidriver-file.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: file.csi.azure.com
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 spec:
   attachRequired: false
   podInfoOnMount: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
We updated the csidrivers to their proper upstream values but since certain fields are immutable, the whole csidriver needs to be recreated.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
