### PR TITLE
Update azure-csi images

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -185,7 +185,7 @@ images:
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver
   repository: mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi
-  tag: "v1.29.1"
+  tag: "v1.29.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -198,7 +198,7 @@ images:
 - name: csi-driver-file
   sourceRepository: github.com/kubernetes-sigs/azurefile-csi-driver
   repository: mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi
-  tag: "v1.29.2"
+  tag: "v1.29.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
Update disk driver from v1.29.1 to v1.29.3 and file driver from v1.29.2 to v1.29.3

**Special notes for your reviewer**:
Possible breaking changes in the file-driver:
```
cleanup: remove getClientID func by @andyzhangx in https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/1652
cleanup: remove csi-attacher config by @andyzhangx in https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/1664
```