### PR TITLE
simplify condition for picking terraform after trying to decode state

### DIFF
--- a/pkg/controller/infrastructure/actuator_helper.go
+++ b/pkg/controller/infrastructure/actuator_helper.go
@@ -17,7 +17,6 @@ package infrastructure
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
@@ -30,7 +29,6 @@ import (
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 	azuretypes "github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
-	infrainternal "github.com/gardener/gardener-extension-provider-azure/pkg/internal/infrastructure"
 )
 
 var (
@@ -90,16 +88,7 @@ func hasFlowState(status extensionsv1alpha1.InfrastructureStatus) (bool, error) 
 		return true, nil
 	}
 
-	infraState := &infrainternal.InfrastructureState{}
-	if err := json.Unmarshal(status.State.Raw, infraState); err != nil {
-		return false, err
-	}
-
-	if infraState.TerraformState != nil {
-		return false, nil
-	}
-
-	return false, fmt.Errorf("unknown infrastructure state format")
+	return false, nil
 }
 
 // HasFlowAnnotation returns true if the new flow reconciler should be used for the reconciliation.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

The overall previous stricter check was causing issues in shoots that had not been reconciled for a long time and contained no state. The additional check done by decoding the state into the previous format, did not provide much benefit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix an issue where an empty infrastructure state would cause issues when picking the proper reconciler.
```
