### PR TITLE
Update default storage account SKU to StandardZRS

### DIFF
--- a/pkg/azure/client/storageaccount.go
+++ b/pkg/azure/client/storageaccount.go
@@ -35,7 +35,7 @@ func (c *StorageAccountClient) CreateStorageAccount(ctx context.Context, resourc
 		Kind:     storage.BlobStorage,
 		Location: &region,
 		Sku: &storage.Sku{
-			Name: storage.StandardLRS,
+			Name: storage.StandardZRS,
 		},
 		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
 			AccessTier:             storage.Cool,

--- a/pkg/azure/client/storageaccount.go
+++ b/pkg/azure/client/storageaccount.go
@@ -32,7 +32,7 @@ type StorageAccountClient struct {
 // CreateStorageAccount creates a storage account.
 func (c *StorageAccountClient) CreateStorageAccount(ctx context.Context, resourceGroupName, storageAccountName, region string) error {
 	future, err := c.client.Create(ctx, resourceGroupName, storageAccountName, storage.AccountCreateParameters{
-		Kind:     storage.BlobStorage,
+		Kind:     storage.StorageV2,
 		Location: &region,
 		Sku: &storage.Sku{
 			Name: storage.StandardZRS,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area storage
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR updates the default storage account SKU and Kind in the Azure extension. The changes are as follows:
- SKU: StandardLRS to StandardZRS
- Kind: BlobStorage to StorageV2

The change enhances data durability and availability by leveraging Zone Redundant Storage (ZRS), which replicates data across multiple availability zones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Updated the default storage account SKU from StandardLRS to StandardZRS to enhance data durability and availability.
```
