### PR TITLE
refactor blob client

### DIFF
--- a/pkg/azure/client/mock/mocks.go
+++ b/pkg/azure/client/mock/mocks.go
@@ -15,7 +15,6 @@ import (
 	client "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 	internal "github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 	gomock "go.uber.org/mock/gomock"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockDNSZone is a mock of DNSZone interface.
@@ -389,21 +388,6 @@ func (m *MockFactory) RouteTables() (client.RouteTables, error) {
 func (mr *MockFactoryMockRecorder) RouteTables() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteTables", reflect.TypeOf((*MockFactory)(nil).RouteTables))
-}
-
-// Storage mocks base method.
-func (m *MockFactory) Storage(arg0 context.Context, arg1 v1.SecretReference) (client.Storage, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Storage", arg0, arg1)
-	ret0, _ := ret[0].(client.Storage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Storage indicates an expected call of Storage.
-func (mr *MockFactoryMockRecorder) Storage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Storage", reflect.TypeOf((*MockFactory)(nil).Storage), arg0, arg1)
 }
 
 // StorageAccount mocks base method.

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 )
@@ -31,7 +30,6 @@ import (
 type Factory interface {
 	Auth() *internal.ClientAuth
 
-	Storage(context.Context, corev1.SecretReference) (Storage, error)
 	StorageAccount() (StorageAccount, error)
 	Vmss() (Vmss, error)
 	DNSZone() (DNSZone, error)
@@ -145,13 +143,6 @@ type VirtualNetwork interface {
 	DeleteFunc[armnetwork.VirtualNetwork]
 }
 
-// Storage represents an Azure (blob) storage k8sClient.
-type Storage interface {
-	DeleteObjectsWithPrefix(context.Context, string, string) error
-	CreateContainerIfNotExists(context.Context, string) error
-	DeleteContainerIfExists(context.Context, string) error
-}
-
 // StorageAccount represents an Azure storage account k8sClient.
 type StorageAccount interface {
 	CreateStorageAccount(context.Context, string, string, string) error
@@ -172,4 +163,11 @@ type DNSRecordSet interface {
 // VirtualMachineImages represents an Azure Virtual Machine Image k8sClient.
 type VirtualMachineImages interface {
 	ListSkus(ctx context.Context, location string, publisherName string, offer string) (*compute.ListVirtualMachineImageResource, error)
+}
+
+// Storage represents an Azure (blob) storage k8sClient.
+type Storage interface {
+	DeleteObjectsWithPrefix(context.Context, string, string) error
+	CreateContainerIfNotExists(context.Context, string) error
+	DeleteContainerIfExists(context.Context, string) error
 }

--- a/pkg/controller/backupentry/actuator.go
+++ b/pkg/controller/backupentry/actuator.go
@@ -29,6 +29,11 @@ import (
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 )
 
+var (
+	// DefaultBlobStorageClient is the default function to get a backupbucket client. Can be overridden for tests.
+	DefaultBlobStorageClient = azureclient.NewBlobStorageClient
+)
+
 type actuator struct {
 	client client.Client
 }
@@ -44,11 +49,7 @@ func (a *actuator) GetETCDSecretData(_ context.Context, _ logr.Logger, _ *extens
 }
 
 func (a *actuator) Delete(ctx context.Context, _ logr.Logger, backupEntry *extensionsv1alpha1.BackupEntry) error {
-	factory, err := azureclient.NewAzureClientFactory(ctx, a.client, backupEntry.Spec.SecretRef)
-	if err != nil {
-		return util.DetermineError(err, helper.KnownCodes)
-	}
-	storageClient, err := factory.Storage(ctx, backupEntry.Spec.SecretRef)
+	storageClient, err := DefaultBlobStorageClient(ctx, a.client, backupEntry.Spec.SecretRef)
 	if err != nil {
 		return util.DetermineError(err, helper.KnownCodes)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener-extension-provider-azure/issues/793

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where backupentry secrets would not be deleted due to incorrect credential format error.
```
