### PR TITLE
webhook for seed namespaces

### DIFF
--- a/cmd/gardener-extension-provider-azure/app/app.go
+++ b/cmd/gardener-extension-provider-azure/app/app.go
@@ -51,6 +51,7 @@ import (
 	azureinfrastructure "github.com/gardener/gardener-extension-provider-azure/pkg/controller/infrastructure"
 	azureworker "github.com/gardener/gardener-extension-provider-azure/pkg/controller/worker"
 	azurecontrolplaneexposure "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/controlplaneexposure"
+	haNamespace "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/highavailability/namespace"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/webhook/topology"
 )
 
@@ -234,6 +235,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 			topology.SeedRegion = seedOptions.Completed().Region
 			topology.SeedProvider = seedOptions.Completed().Provider
+			haNamespace.SeedRegion = seedOptions.Completed().Region
+			haNamespace.SeedProvider = seedOptions.Completed().Provider
 
 			shootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil)
 			if err != nil {

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -42,6 +42,7 @@ import (
 	cloudproviderwebhook "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/cloudprovider"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/controlplane"
 	controlplaneexposurewebhook "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/controlplaneexposure"
+	haNamespace "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/highavailability/namespace"
 	infrastructurewebhook "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/infrastructure"
 	networkwebhook "github.com/gardener/gardener-extension-provider-azure/pkg/webhook/network"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/webhook/topology"
@@ -72,5 +73,6 @@ func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 		webhookcmd.Switch(extensionscontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
 		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
 		webhookcmd.Switch(topology.WebhookName, topology.AddToManager),
+		webhookcmd.Switch(haNamespace.WebhookName, haNamespace.AddToManager),
 	)
 }

--- a/pkg/webhook/highavailability/namespace/add.go
+++ b/pkg/webhook/highavailability/namespace/add.go
@@ -1,0 +1,89 @@
+//  Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package namespace
+
+import (
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+)
+
+const (
+	// WebhookName the name of the topology webhook.
+	WebhookName = "high-availability-namespace"
+	webhookPath = "high-availability/namespace"
+)
+
+var (
+	logger = log.Log.WithName("high-availability-namespace-webhook")
+	// SeedRegion is the region where the seed is located.
+	SeedRegion = ""
+	// SeedProvider is the provider type of the seed.
+	SeedProvider = ""
+)
+
+// AddOptions contains the configuration options for the topology webhook.
+type AddOptions struct {
+	// SeedRegion is the region where the seed is located.
+	SeedRegion string
+	// SeedProvider is the provider type of the seed.
+	SeedProvider string
+}
+
+// AddToManager adds the webhook to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return AddToManagerWithOpts(mgr, AddOptions{
+		SeedRegion:   SeedRegion,
+		SeedProvider: SeedProvider,
+	})
+}
+
+// AddToManagerWithOpts creates the webhook with the given opts and adds that to the manager.
+func AddToManagerWithOpts(mgr manager.Manager, options AddOptions) (*extensionswebhook.Webhook, error) {
+	logger.Info("Adding webhook to manager")
+	types := []extensionswebhook.Type{
+		{Obj: &corev1.Namespace{}},
+	}
+
+	logger.Info("Creating webhook")
+	return &extensionswebhook.Webhook{
+		Name:     WebhookName,
+		Provider: azure.Type,
+		Path:     webhookPath,
+		Target:   extensionswebhook.TargetSeed,
+		Types:    types,
+		Webhook:  &admission.Webhook{Handler: New(admission.NewDecoder(mgr.GetScheme()), logger, options), RecoverPanic: true},
+		Selector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      v1beta1constants.GardenRole,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{v1beta1constants.GardenRoleShoot},
+				},
+				{
+					Key:      v1alpha1.HighAvailabilityConfigConsider,
+					Operator: metav1.LabelSelectorOpExists,
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/webhook/highavailability/namespace/mutator.go
+++ b/pkg/webhook/highavailability/namespace/mutator.go
@@ -1,0 +1,133 @@
+//  Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+)
+
+// handler can mutate namespaces having the "high-availability-config.resources.gardener.cloud/zones" annotation. Because gardener uses azure zones differently that Azure controllers,
+// there are installations where the zones in the seed and shoot spec are inconsistent ("zone" vs "region-zone" format). This webhook handler translates the latter format to the first to make it
+// consistent between the different gardener resources.
+type handler struct {
+	log      logr.Logger
+	region   string
+	provider string
+	decoder  *admission.Decoder
+}
+
+// New initializes a new namespace handler.
+// The LabelTopologyZone label that Azure CCM adds to nodes does not contain only the zone as it appears in Azure API
+// calls but also the region like "$region-$zone". When only "$zone" is present for the LabelTopologyZone selector key
+// this handler will adapt it to match the format that is used by the CCM labels.
+func New(decoder *admission.Decoder, log logr.Logger, opts AddOptions) *handler {
+	return &handler{
+		decoder:  decoder,
+		log:      log,
+		region:   opts.SeedRegion,
+		provider: opts.SeedProvider,
+	}
+}
+
+func (h *handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ar := req.AdmissionRequest
+	logger = h.log
+
+	// Decode object
+	var (
+		newNamespace corev1.Namespace
+		obj          client.Object = &newNamespace
+	)
+
+	err := h.decoder.DecodeRaw(req.Object, &newNamespace)
+	if err != nil {
+		logger.Error(err, "Could not decode request", "request", ar)
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("could not decode request %v: %w", ar, err))
+	}
+
+	// // skip mutation if the seed's region has not been provided
+	if len(h.region) == 0 {
+		return admission.ValidationResponse(true, "")
+	}
+	// This webhook is only useful if our seed is running on azure. Therefore, skip mutation if the seed's provider is
+	// not of type Azure.
+	if !strings.EqualFold(h.provider, azure.Type) {
+		return admission.ValidationResponse(true, "")
+	}
+
+	// Process the resource
+	newObj := newNamespace.DeepCopyObject().(client.Object)
+	if err = h.Mutate(ctx, newObj, nil); err != nil {
+		logger.Error(fmt.Errorf("could not process: %w", err), "Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
+		return admission.Errored(http.StatusUnprocessableEntity, err)
+	}
+
+	// Return a patch response if the resource should be changed
+	if !equality.Semantic.DeepEqual(obj, newObj) {
+		oldObjMarshaled, err := json.Marshal(obj)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		newObjMarshaled, err := json.Marshal(newObj)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
+		return admission.PatchResponseFromRaw(oldObjMarshaled, newObjMarshaled)
+	}
+
+	// Return a validation response if the resource should not be changed
+	return admission.ValidationResponse(true, "")
+}
+
+func (h *handler) Mutate(_ context.Context, new, _ client.Object) error {
+	// do not try to mutate if deletion timestamp is present.
+	if new.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
+	annotations := new.GetAnnotations()
+	var zonesRaw []string
+	if zoneAnnotation, ok := annotations[v1alpha1.HighAvailabilityConfigZones]; !ok {
+		return nil
+	} else {
+		zonesRaw = strings.Split(zoneAnnotation, ",")
+	}
+
+	for i := range zonesRaw {
+		zonesRaw[i], _ = strings.CutPrefix(zonesRaw[i], fmt.Sprintf("%s-", h.region))
+	}
+	zoneSet := sets.New(zonesRaw...).UnsortedList()
+	sort.Strings(zoneSet)
+	annotations[v1alpha1.HighAvailabilityConfigZones] = strings.Join(zoneSet, ",")
+	new.SetAnnotations(annotations)
+
+	return nil
+}

--- a/pkg/webhook/highavailability/namespace/mutator_test.go
+++ b/pkg/webhook/highavailability/namespace/mutator_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Topology Webhook Suite")
+}
+
+var _ = Describe("Topology", func() {
+	var (
+		ctrl *gomock.Controller
+
+		ctx     context.Context
+		ns      *corev1.Namespace
+		mutator *handler
+		region  = "westeurope"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		ctx = context.Background()
+
+		mutator = New(&admission.Decoder{}, logr.Discard(), AddOptions{
+			SeedRegion:   region,
+			SeedProvider: azure.Type,
+		})
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Annotations: map[string]string{
+					v1alpha1.HighAvailabilityConfigZones: "2,westeurope-1,3",
+				},
+			},
+		}
+
+		var err error
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("#Webhook", func() {
+		Describe("#Mutate", func() {
+			It("it should correctly mutate required", func() {
+				err := mutator.Mutate(ctx, ns, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ns.Annotations[v1alpha1.HighAvailabilityConfigZones]).To(Equal("1,2,3"))
+			})
+
+			It("it should not mutate if the zone annotation is missing", func() {
+				ns.Annotations[v1alpha1.HighAvailabilityConfigZones] = ""
+				nsOld := ns.DeepCopy()
+				err := mutator.Mutate(ctx, ns, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nsOld).To(Equal(ns))
+			})
+
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/platform azure

**What this PR does / why we need it**:
Adds a webhook to normalize the usage of zones in the HA annotations on Azure due to Azure's peculiarities with the format of the zone's names.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
