### PR TITLE
only apply HA-ns webhook on HA type zone

### DIFF
--- a/pkg/webhook/highavailability/namespace/mutator.go
+++ b/pkg/webhook/highavailability/namespace/mutator.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -104,6 +105,10 @@ func (h *handler) Mutate(_ context.Context, new, _ client.Object) error {
 	}
 
 	annotations := new.GetAnnotations()
+	if v, ok := annotations[v1alpha1.HighAvailabilityConfigFailureToleranceType]; !ok || v != string(v1beta1.FailureToleranceTypeZone) {
+		return nil
+	}
+
 	var zonesRaw []string
 	if zoneAnnotation, ok := annotations[v1alpha1.HighAvailabilityConfigZones]; !ok {
 		return nil

--- a/pkg/webhook/highavailability/namespace/mutator_test.go
+++ b/pkg/webhook/highavailability/namespace/mutator_test.go
@@ -48,7 +48,8 @@ var _ = Describe("Topology", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Annotations: map[string]string{
-					v1alpha1.HighAvailabilityConfigZones: "2,westeurope-1,3",
+					v1alpha1.HighAvailabilityConfigZones:                "2,westeurope-1,3",
+					v1alpha1.HighAvailabilityConfigFailureToleranceType: "zone",
 				},
 			},
 		}
@@ -77,6 +78,13 @@ var _ = Describe("Topology", func() {
 				Expect(nsOld).To(Equal(ns))
 			})
 
+			It("it should not mutate if the HA type is not zone", func() {
+				ns.Annotations[v1alpha1.HighAvailabilityConfigFailureToleranceType] = ""
+				nsOld := ns.DeepCopy()
+				err := mutator.Mutate(ctx, ns, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nsOld).To(Equal(ns))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Fix an issue where the webhook was applied to namespaces other than those with HA type "zone"


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
