### PR TITLE
rm meta-record deletion, update tests

### DIFF
--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -12,7 +12,6 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
 	"github.com/gardener/gardener/extensions/pkg/util"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
@@ -75,18 +74,6 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, dns *extensio
 		return &reconcilerutils.RequeueAfterError{
 			Cause:        fmt.Errorf("could not create or update DNS recordset in zone %s with name %s, type %s, and values %v: %+v", zone, dns.Spec.Name, dns.Spec.RecordType, dns.Spec.Values, err),
 			RequeueAfter: requeueAfterOnProviderError,
-		}
-	}
-
-	// Delete meta DNS recordset if exists
-	if dns.Status.LastOperation == nil || dns.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate {
-		name, recordType := dnsrecord.GetMetaRecordName(dns.Spec.Name), "TXT"
-		log.Info("Deleting meta DNS recordset", "zone", zone, "name", name, "type", recordType, "dnsrecord", kutil.ObjectName(dns))
-		if err := dnsRecordSetClient.Delete(ctx, zone, name, recordType); err != nil {
-			return &reconcilerutils.RequeueAfterError{
-				Cause:        fmt.Errorf("could not delete meta DNS recordset in zone %s with name %s and type %s: %+v", zone, name, recordType, err),
-				RequeueAfter: requeueAfterOnProviderError,
-			}
 		}
 	}
 

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -113,7 +113,6 @@ var _ = Describe("Actuator", func() {
 			azureClientFactory.EXPECT().DNSRecordSet().Return(azureDNSRecordSetClient, nil)
 			azureDNSZoneClient.EXPECT().List(ctx).Return(zones, nil)
 			azureDNSRecordSetClient.EXPECT().CreateOrUpdate(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).Return(nil)
-			azureDNSRecordSetClient.EXPECT().Delete(ctx, zone, "comment-"+domainName, "TXT").Return(nil)
 			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, obj *extensionsv1alpha1.DNSRecord, _ client.Patch, opts ...client.PatchOption) error {
 					Expect(obj.Status).To(Equal(extensionsv1alpha1.DNSRecordStatus{


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind cleanup
/platform azure

**What this PR does / why we need it**:
Removes old superfluous dns-metarecord deletion.