### PR TITLE
calculate vnet name correctly in infra status

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -664,7 +664,7 @@ func (f *FlowContext) GetInfrastructureStatus(_ context.Context) (*v1alpha1.Infr
 		TypeMeta: infrastructure.StatusTypeMeta,
 		Networks: v1alpha1.NetworkStatus{
 			VNet: v1alpha1.VNetStatus{
-				Name: f.adapter.VirtualNetworkConfig().ResourceGroup,
+				Name: f.adapter.VirtualNetworkConfig().Name,
 			},
 			Layout: v1alpha1.NetworkLayoutSingleSubnet,
 		},

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -254,6 +254,8 @@ var _ = Describe("Infrastructure tests", func() {
 		It("should successfully create and delete AvailabilitySet cluster using existing vNet and existing identity", func() {
 			foreignName, err := generateName()
 			Expect(err).ToNot(HaveOccurred())
+			foreignNameVnet := foreignName + "-vnet"
+			foreignNameId := foreignName + "-id"
 
 			var cleanupHandle framework.CleanupActionHandle
 			cleanupHandle = framework.AddCleanupAction(func() {
@@ -262,15 +264,15 @@ var _ = Describe("Infrastructure tests", func() {
 			})
 
 			Expect(prepareNewResourceGroup(ctx, log, clientSet, foreignName, *region)).To(Succeed())
-			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignName, *region, VNetCIDR)).To(Succeed())
-			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignName, *region)).To(Succeed())
+			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignNameVnet, *region, VNetCIDR)).To(Succeed())
+			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignNameId, *region)).To(Succeed())
 
 			vnetConfig := &azurev1alpha1.VNet{
-				Name:          pointer.String(foreignName),
+				Name:          pointer.String(foreignNameVnet),
 				ResourceGroup: pointer.String(foreignName),
 			}
 			identityConfig := &azurev1alpha1.IdentityConfig{
-				Name:          foreignName,
+				Name:          foreignNameId,
 				ResourceGroup: foreignName,
 			}
 			providerConfig := newInfrastructureConfig(vnetConfig, nil, identityConfig, false)
@@ -300,6 +302,8 @@ var _ = Describe("Infrastructure tests", func() {
 		It("should successfully create and delete a zonal cluster with NatGateway using an existing vNet and identity", func() {
 			foreignName, err := generateName()
 			Expect(err).ToNot(HaveOccurred())
+			foreignNameVnet := foreignName + "-vnet"
+			foreignNameId := foreignName + "-id"
 
 			var cleanupHandle framework.CleanupActionHandle
 			cleanupHandle = framework.AddCleanupAction(func() {
@@ -308,15 +312,15 @@ var _ = Describe("Infrastructure tests", func() {
 			})
 
 			Expect(prepareNewResourceGroup(ctx, log, clientSet, foreignName, *region)).To(Succeed())
-			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignName, *region, VNetCIDR)).To(Succeed())
-			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignName, *region)).To(Succeed())
+			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignNameVnet, *region, VNetCIDR)).To(Succeed())
+			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignNameId, *region)).To(Succeed())
 
 			vnetConfig := &azurev1alpha1.VNet{
-				Name:          pointer.String(foreignName),
+				Name:          pointer.String(foreignNameVnet),
 				ResourceGroup: pointer.String(foreignName),
 			}
 			identityConfig := &azurev1alpha1.IdentityConfig{
-				Name:          foreignName,
+				Name:          foreignNameId,
 				ResourceGroup: foreignName,
 			}
 			natGatewayConfig := &azurev1alpha1.NatGatewayConfig{
@@ -437,6 +441,8 @@ var _ = Describe("Infrastructure tests", func() {
 		It("should successfully create and delete VMO cluster with NatGateway using an existing vNet and identity", func() {
 			foreignName, err := generateName()
 			Expect(err).ToNot(HaveOccurred())
+			foreignNameVnet := foreignName + "-vnet"
+			foreignNameId := foreignName + "-id"
 
 			var cleanupHandle framework.CleanupActionHandle
 			cleanupHandle = framework.AddCleanupAction(func() {
@@ -445,15 +451,15 @@ var _ = Describe("Infrastructure tests", func() {
 			})
 
 			Expect(prepareNewResourceGroup(ctx, log, clientSet, foreignName, *region)).To(Succeed())
-			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignName, *region, VNetCIDR)).To(Succeed())
-			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignName, *region)).To(Succeed())
+			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignNameVnet, *region, VNetCIDR)).To(Succeed())
+			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignNameId, *region)).To(Succeed())
 
 			vnetConfig := &azurev1alpha1.VNet{
-				Name:          pointer.String(foreignName),
+				Name:          pointer.String(foreignNameVnet),
 				ResourceGroup: pointer.String(foreignName),
 			}
 			identityConfig := &azurev1alpha1.IdentityConfig{
-				Name:          foreignName,
+				Name:          foreignNameId,
 				ResourceGroup: foreignName,
 			}
 			natGatewayConfig := &azurev1alpha1.NatGatewayConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where the vnet name was not correctly calculated in status
```
