### PR TITLE
increase period of deprecated node labels until k8s v1.29

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
@@ -83,7 +83,7 @@ spec:
         - cloud-node-manager
         - --node-name=$(NODE_NAME)
         - --wait-routes=true   # only set to true when --configure-cloud-routes=true in cloud-controller-manager.
-        {{- if semverCompare ">= 1.26.0-0, < 1.28.0-0" .Capabilities.KubeVersion.Version }}
+        {{- if semverCompare ">= 1.26.0-0, < 1.30.0-0" .Capabilities.KubeVersion.Version }}
         - --enable-deprecated-beta-topology-labels=true
         {{- end }}
         env:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/platform azure

**What this PR does / why we need it**:
With https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2653 the old node topology labels were deprecated and with https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3685 an opt-in flag to re-enable them was introduced. In provider-azure we were already using this flag with https://github.com/gardener/gardener-extension-provider-azure/pull/717 but not all users were aware of the need to migrate. We will extend this until k8s <= v1.29 and allow users to migrate PVs or other resources that are using the old topology labels.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Extend the user of deprecated topology labels until `<=v1.29`. Azure clusters upgrading to v1.30 should make sure to have migrated away from the deprecated [topology labels](failure-domain.beta.kubernetes.io/zone). See https://github.com/kubernetes-sigs/cloud-provider-azure/issues/2453 for more details.
```
