### PR TITLE
[release-v1.42] Automated cherry pick of #811: increase period of deprecated node labels until k8s v1.29

### DIFF
--- a/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/cloud-controller-manager/templates/cloud-node-manager.yaml
@@ -83,7 +83,7 @@ spec:
         - cloud-node-manager
         - --node-name=$(NODE_NAME)
         - --wait-routes=true   # only set to true when --configure-cloud-routes=true in cloud-controller-manager.
-        {{- if semverCompare ">= 1.26.0-0, < 1.28.0-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">= 1.26.0-0, < 1.30.0-0" .Capabilities.KubeVersion.Version }}
         - --enable-deprecated-beta-topology-labels=true
         {{- end }}
         env:


### PR DESCRIPTION
/area control-plane
/kind bug
/kind regression

Cherry pick of #811 on release-v1.42.

#811: increase period of deprecated node labels until k8s v1.29

**Release Notes:**
```breaking user
Extend the user of deprecated topology labels until `<=v1.29`. Azure clusters upgrading to v1.30 should make sure to have migrated away from the deprecated [topology labels](failure-domain.beta.kubernetes.io/zone). See https://github.com/kubernetes-sigs/cloud-provider-azure/issues/2453 for more details.
```