### PR TITLE
Add cluster-autoscaler options to machine deployment

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -16,6 +16,7 @@ import (
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -260,6 +261,8 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					"operatingSystemVersion": pool.MachineImage.Version,
 				}
 			}
+
+			machineDeployment.ClusterAutoscalerAnnotations = extensionsv1alpha1helper.GetMachineDeploymentClusterAutoscalerAnnotations(pool.ClusterAutoscaler)
 
 			return machineDeployment, machineClassSpec
 		}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -709,6 +709,43 @@ var _ = Describe("Machines", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(result).To(Equal(machineDeployments))
 					})
+
+					It("should set expected cluster-autoscaler annotations on the machine deployment", func() {
+						w.Spec.Pools[0].ClusterAutoscaler = &extensionsv1alpha1.ClusterAutoscalerOptions{
+							MaxNodeProvisionTime:             ptr.To(metav1.Duration{Duration: time.Minute}),
+							ScaleDownGpuUtilizationThreshold: ptr.To("0.4"),
+							ScaleDownUnneededTime:            ptr.To(metav1.Duration{Duration: 2 * time.Minute}),
+							ScaleDownUnreadyTime:             ptr.To(metav1.Duration{Duration: 3 * time.Minute}),
+							ScaleDownUtilizationThreshold:    ptr.To("0.5"),
+						}
+
+						w.Spec.Pools = append(w.Spec.Pools, pool2)
+						w.Spec.Pools[1].Zones = []string{zone1, zone2}
+
+						workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+						result, err := workerDelegate.GenerateMachineDeployments(ctx)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).NotTo(BeNil())
+
+						Expect(result[0].ClusterAutoscalerAnnotations).NotTo(BeNil())
+						Expect(result[1].ClusterAutoscalerAnnotations).NotTo(BeNil())
+						Expect(result[2].ClusterAutoscalerAnnotations).To(BeNil())
+						Expect(result[3].ClusterAutoscalerAnnotations).To(BeNil())
+
+						Expect(result[0].ClusterAutoscalerAnnotations[extensionsv1alpha1.MaxNodeProvisionTimeAnnotation]).To(Equal("1m0s"))
+						Expect(result[0].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation]).To(Equal("0.4"))
+						Expect(result[0].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnneededTimeAnnotation]).To(Equal("2m0s"))
+						Expect(result[0].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation]).To(Equal("3m0s"))
+						Expect(result[0].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
+
+						Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.MaxNodeProvisionTimeAnnotation]).To(Equal("1m0s"))
+						Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation]).To(Equal("0.4"))
+						Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnneededTimeAnnotation]).To(Equal("2m0s"))
+						Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation]).To(Equal("3m0s"))
+						Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
+					})
 				})
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR adds cluster-autoscaler options for worker groups from workers to machine deployments. These options allow users to specify some cluster-autoscaler specific for worker groups

**Which issue(s) this PR fixes**:
Fixes partially gardener/autoscaler#240

**Special notes for your reviewer**:
- `Autoscaler` will read these values from annotations in the `machineDeployment` (ref: https://github.com/gardener/autoscaler/pull/257)
- These values are specified in the shoot via `spec.provider.workers.clusterAutoscaler` and are added to the worker (ref: https://github.com/gardener/gardener/pull/9245)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NodeGroupAutoscalingOptions can now be specified per worker group via the worker through the field `worker.spec.pools.clusterAutoscaler`
```
