### PR TITLE
add rg deletion at end of tf.destroy

### DIFF
--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -212,10 +212,15 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 		return err
 	}
 
-	return tf.
+	if err = tf.
 		InitializeWith(ctx, terraformer.DefaultInitializer(r.Client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, terraformer.StateConfigMapInitializerFunc(NoOpStateInitializer))).
 		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef)...).
-		Destroy(ctx)
+		Destroy(ctx); err != nil {
+		return err
+	}
+
+	// make sure the
+	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg)
 }
 
 // NoOpStateInitializer is a no-op StateConfigMapInitializerFunc.

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -219,7 +219,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 		return err
 	}
 
-	// make sure the
+	// make sure the resource group for the shoot is properly cleaned up even if it is missing from terraform state.
 	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg)
 }
 

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -175,6 +175,13 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 	if err != nil {
 		return err
 	}
+	status := &azure.InfrastructureStatus{}
+	if infra.Status.ProviderStatus != nil {
+		status, err = helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
+		if err != nil {
+			return err
+		}
+	}
 
 	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, clientFactory, infra, cfg)
 	if err != nil {
@@ -220,7 +227,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 	}
 
 	// make sure the resource group for the shoot is properly cleaned up even if it is missing from terraform state.
-	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg)
+	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg, status)
 }
 
 // NoOpStateInitializer is a no-op StateConfigMapInitializerFunc.

--- a/pkg/controller/infrastructure/terraform_reconciler_test.go
+++ b/pkg/controller/infrastructure/terraform_reconciler_test.go
@@ -226,8 +226,9 @@ var _ = Describe("Actuator", func() {
 		})
 
 		It("should delete the Infrastructure", func() {
-			azureClientFactory.EXPECT().Group().Return(azureGroupClient, nil)
+			azureClientFactory.EXPECT().Group().Return(azureGroupClient, nil).Times(2)
 			azureGroupClient.EXPECT().Get(ctx, infra.Namespace).Return(&armresources.ResourceGroup{Name: &resourceGroupName}, nil)
+			azureGroupClient.EXPECT().Delete(ctx, infra.Namespace).Return(nil)
 
 			tf.EXPECT().EnsureCleanedUp(ctx)
 			tf.EXPECT().IsStateEmpty(ctx).Return(false)
@@ -238,6 +239,7 @@ var _ = Describe("Actuator", func() {
 			tf.EXPECT().Destroy(ctx)
 			err := a.Delete(ctx, log, infra, cluster)
 			Expect(err).NotTo(HaveOccurred())
+
 		})
 
 		It("should delete the Infrastructure with invalid credentials", func() {

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -112,3 +112,17 @@ func DeleteNodeSubnetIfExists(ctx context.Context, factory azureclient.Factory, 
 
 	return nil
 }
+
+// DeleteShootResourceGroupIfExists will delete the shoot's resource group if it exists.
+func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig) error {
+	if cfg.ResourceGroup != nil {
+		return nil
+	}
+
+	groupClient, err := factory.Group()
+	if err != nil {
+		return err
+	}
+
+	return groupClient.Delete(ctx, infra.Namespace)
+}

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -114,7 +114,7 @@ func DeleteNodeSubnetIfExists(ctx context.Context, factory azureclient.Factory, 
 }
 
 // DeleteShootResourceGroupIfExists will delete the shoot's resource group if it exists.
-func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig) error {
+func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig, status *api.InfrastructureStatus) error {
 	if cfg.ResourceGroup != nil {
 		return nil
 	}
@@ -124,5 +124,10 @@ func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.F
 		return err
 	}
 
-	return groupClient.Delete(ctx, infra.Namespace)
+	name := infra.Namespace
+	if status != nil && len(status.ResourceGroup.Name) > 0 {
+		name = status.ResourceGroup.Name
+	}
+
+	return groupClient.Delete(ctx, name)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug where the terraform-provider-azure would not properly delete shoot resource groups. The infrastructure-controller will issue an additional delete operation for the shoot's resource group.
```
