### PR TITLE
[release-v1.42] Automated cherry pick of #841: add rg deletion at end of tf.destroy

### DIFF
--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -150,6 +150,13 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 	if err != nil {
 		return err
 	}
+	status := &azure.InfrastructureStatus{}
+	if infra.Status.ProviderStatus != nil {
+		status, err = helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
+		if err != nil {
+			return err
+		}
+	}
 
 	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, azureClientFactory, infra, cfg)
 	if err != nil {
@@ -195,7 +202,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 	}
 
 	// make sure the resource group for the shoot is properly cleaned up even if it is missing from terraform state.
-	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg)
+	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg, status)
 }
 
 // NoOpStateInitializer is a no-op StateConfigMapInitializerFunc.

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -194,7 +194,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 		return err
 	}
 
-	// make sure the
+	// make sure the resource group for the shoot is properly cleaned up even if it is missing from terraform state.
 	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg)
 }
 

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
@@ -141,7 +142,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 		return err
 	}
 
-	azureClientFactory, err := NewAzureClientFactory(ctx, r.Client, infra.Spec.SecretRef)
+	clientFactory, err := NewAzureClientFactory(ctx, r.Client, infra.Spec.SecretRef)
 	if err != nil {
 		return err
 	}
@@ -158,7 +159,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 		}
 	}
 
-	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, azureClientFactory, infra, cfg)
+	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, clientFactory, infra, cfg)
 	if err != nil {
 		if azureclient.IsAzureAPIUnauthorized(err) {
 			r.Logger.Error(err, "Failed to check resource group availability due to invalid credentials")
@@ -169,7 +170,7 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 
 	if !resourceGroupExists {
 		if !azureclient.IsAzureAPIUnauthorized(err) {
-			if err := infrastructure.DeleteNodeSubnetIfExists(ctx, azureClientFactory, infra, cfg); err != nil {
+			if err := infrastructure.DeleteNodeSubnetIfExists(ctx, clientFactory, infra, cfg); err != nil {
 				return err
 			}
 		}

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -187,10 +187,15 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 		return err
 	}
 
-	return tf.
+	if err = tf.
 		InitializeWith(ctx, terraformer.DefaultInitializer(r.Client, terraformFiles.Main, terraformFiles.Variables, terraformFiles.TFVars, terraformer.StateConfigMapInitializerFunc(NoOpStateInitializer))).
 		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef)...).
-		Destroy(ctx)
+		Destroy(ctx); err != nil {
+		return err
+	}
+
+	// make sure the
+	return infrastructure.DeleteShootResourceGroupIfExists(ctx, clientFactory, infra, cfg)
 }
 
 // NoOpStateInitializer is a no-op StateConfigMapInitializerFunc.

--- a/pkg/controller/infrastructure/terraform_reconciler_test.go
+++ b/pkg/controller/infrastructure/terraform_reconciler_test.go
@@ -226,8 +226,9 @@ var _ = Describe("Actuator", func() {
 		})
 
 		It("should delete the Infrastructure", func() {
-			azureClientFactory.EXPECT().Group().Return(azureGroupClient, nil)
+			azureClientFactory.EXPECT().Group().Return(azureGroupClient, nil).Times(2)
 			azureGroupClient.EXPECT().Get(ctx, infra.Namespace).Return(&armresources.ResourceGroup{Name: &resourceGroupName}, nil)
+			azureGroupClient.EXPECT().Delete(ctx, infra.Namespace).Return(nil)
 
 			tf.EXPECT().EnsureCleanedUp(ctx)
 			tf.EXPECT().IsStateEmpty(ctx).Return(false)
@@ -238,6 +239,7 @@ var _ = Describe("Actuator", func() {
 			tf.EXPECT().Destroy(ctx)
 			err := a.Delete(ctx, log, infra, cluster)
 			Expect(err).NotTo(HaveOccurred())
+
 		})
 
 		It("should delete the Infrastructure with invalid credentials", func() {

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -112,3 +112,17 @@ func DeleteNodeSubnetIfExists(ctx context.Context, factory azureclient.Factory, 
 
 	return nil
 }
+
+// DeleteShootResourceGroupIfExists will delete the shoot's resource group if it exists.
+func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig) error {
+	if cfg.ResourceGroup != nil {
+		return nil
+	}
+
+	groupClient, err := factory.Group()
+	if err != nil {
+		return err
+	}
+
+	return groupClient.Delete(ctx, infra.Namespace)
+}

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -114,7 +114,7 @@ func DeleteNodeSubnetIfExists(ctx context.Context, factory azureclient.Factory, 
 }
 
 // DeleteShootResourceGroupIfExists will delete the shoot's resource group if it exists.
-func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig) error {
+func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig, status *api.InfrastructureStatus) error {
 	if cfg.ResourceGroup != nil {
 		return nil
 	}
@@ -124,5 +124,10 @@ func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.F
 		return err
 	}
 
-	return groupClient.Delete(ctx, infra.Namespace)
+	name := infra.Namespace
+	if status != nil && len(status.ResourceGroup.Name) > 0 {
+		name = status.ResourceGroup.Name
+	}
+
+	return groupClient.Delete(ctx, name)
 }


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #841 on release-v1.42.

#841: add rg deletion at end of tf.destroy

**Release Notes:**
```other operator
Fix a bug where the terraform-provider-azure would not properly delete shoot resource groups. The infrastructure-controller will issue an additional delete operation for the shoot's resource group.
```