### PR TITLE
delete empty RGs on infra creation

### DIFF
--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -131,9 +131,7 @@ func InfrastructureStateFromRaw(raw *runtime.RawExtension) (*api.InfrastructureS
 func InfrastructureStatusFromInfrastructure(infra *extensionsv1alpha1.Infrastructure) (*api.InfrastructureStatus, error) {
 	status := &api.InfrastructureStatus{}
 	if infra.Status.ProviderStatus != nil && infra.Status.ProviderStatus.Raw != nil {
-		if _, _, err := lenientDecoder.Decode(infra.Status.ProviderStatus.Raw, nil, status); err != nil {
-			return nil, err
-		}
+		return InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
 	}
 	return status, nil
 }

--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -60,12 +60,12 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 // InfrastructureStatusFromRaw extracts the InfrastructureStatus from the
 // ProviderStatus section of the given Infrastructure.
 func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.InfrastructureStatus, error) {
-	config := &api.InfrastructureStatus{}
+	status := &api.InfrastructureStatus{}
 	if raw != nil && raw.Raw != nil {
-		if _, _, err := lenientDecoder.Decode(raw.Raw, nil, config); err != nil {
+		if _, _, err := lenientDecoder.Decode(raw.Raw, nil, status); err != nil {
 			return nil, err
 		}
-		return config, nil
+		return status, nil
 	}
 	return nil, fmt.Errorf("provider status is not set on the infrastructure resource")
 }
@@ -123,4 +123,17 @@ func InfrastructureStateFromRaw(raw *runtime.RawExtension) (*api.InfrastructureS
 	}
 
 	return state, nil
+}
+
+// InfrastructureStatusFromInfrastructure extracts the InfrastructureStatus from the
+// ProviderStatus section of the given Infrastructure.
+// If the providerConfig is missing from the status, it will return a zero-value InfrastructureStatus.
+func InfrastructureStatusFromInfrastructure(infra *extensionsv1alpha1.Infrastructure) (*api.InfrastructureStatus, error) {
+	status := &api.InfrastructureStatus{}
+	if infra.Status.ProviderStatus != nil && infra.Status.ProviderStatus.Raw != nil {
+		if _, _, err := lenientDecoder.Decode(infra.Status.ProviderStatus.Raw, nil, status); err != nil {
+			return nil, err
+		}
+	}
+	return status, nil
 }

--- a/pkg/azure/client/factory.go
+++ b/pkg/azure/client/factory.go
@@ -92,6 +92,11 @@ func (f azureFactory) Group() (ResourceGroup, error) {
 	return NewResourceGroupsClient(f.auth, f.tokenCredential, f.clientOpts)
 }
 
+// Resource returns an Azure resource client.
+func (f azureFactory) Resource() (Resource, error) {
+	return NewResourceClient(f.auth, f.tokenCredential, f.clientOpts)
+}
+
 // Vmss returns an Azure virtual machine scale set client.
 func (f azureFactory) Vmss() (Vmss, error) {
 	return NewVmssClient(*f.auth, f.tokenCredential, f.clientOpts)

--- a/pkg/azure/client/mock/mocks.go
+++ b/pkg/azure/client/mock/mocks.go
@@ -365,6 +365,21 @@ func (mr *MockFactoryMockRecorder) PublicIP() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicIP", reflect.TypeOf((*MockFactory)(nil).PublicIP))
 }
 
+// Resource mocks base method.
+func (m *MockFactory) Resource() (client.Resource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Resource")
+	ret0, _ := ret[0].(client.Resource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Resource indicates an expected call of Resource.
+func (mr *MockFactoryMockRecorder) Resource() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resource", reflect.TypeOf((*MockFactory)(nil).Resource))
+}
+
 // RouteTables mocks base method.
 func (m *MockFactory) RouteTables() (client.RouteTables, error) {
 	m.ctrl.T.Helper()

--- a/pkg/azure/client/resources.go
+++ b/pkg/azure/client/resources.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
+)
+
+var _ Resource = &ResourceClient{}
+
+// ResourceClient is a client for resource groups.
+type ResourceClient struct {
+	client *armresources.Client
+}
+
+// NewResourceClient creates a new ResourceClient
+func NewResourceClient(auth *internal.ClientAuth, tc azcore.TokenCredential, opts *arm.ClientOptions) (*ResourceClient, error) {
+	client, err := armresources.NewClient(auth.SubscriptionID, tc, opts)
+	return &ResourceClient{client: client}, err
+}
+
+// ListByResourceGroup fetches all resources of a resource group.
+func (c *ResourceClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]*armresources.GenericResourceExpanded, error) {
+	var res []*armresources.GenericResourceExpanded
+	pager := c.client.NewListByResourceGroupPager(resourceGroupName, &armresources.ClientListByResourceGroupOptions{})
+	for pager.More() {
+		nextResult, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, v := range nextResult.Value {
+			res = append(res, v)
+		}
+	}
+	return res, nil
+}

--- a/pkg/azure/client/resources.go
+++ b/pkg/azure/client/resources.go
@@ -36,9 +36,7 @@ func (c *ResourceClient) ListByResourceGroup(ctx context.Context, resourceGroupN
 		if err != nil {
 			return nil, err
 		}
-		for _, v := range nextResult.Value {
-			res = append(res, v)
-		}
+		res = append(res, nextResult.Value...)
 	}
 	return res, nil
 }

--- a/pkg/azure/client/resources.go
+++ b/pkg/azure/client/resources.go
@@ -28,9 +28,9 @@ func NewResourceClient(auth *internal.ClientAuth, tc azcore.TokenCredential, opt
 }
 
 // ListByResourceGroup fetches all resources of a resource group.
-func (c *ResourceClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]*armresources.GenericResourceExpanded, error) {
+func (c *ResourceClient) ListByResourceGroup(ctx context.Context, resourceGroupName string, options *armresources.ClientListByResourceGroupOptions) ([]*armresources.GenericResourceExpanded, error) {
 	var res []*armresources.GenericResourceExpanded
-	pager := c.client.NewListByResourceGroupPager(resourceGroupName, &armresources.ClientListByResourceGroupOptions{})
+	pager := c.client.NewListByResourceGroupPager(resourceGroupName, options)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -160,5 +160,5 @@ type Storage interface {
 
 // Resource is an Azure resources client.
 type Resource interface {
-	ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]*armresources.GenericResourceExpanded, error)
+	ListByResourceGroup(ctx context.Context, resourceGroupName string, options *armresources.ClientListByResourceGroupOptions) ([]*armresources.GenericResourceExpanded, error)
 }

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -158,6 +158,7 @@ type Storage interface {
 	DeleteContainerIfExists(context.Context, string) error
 }
 
+// Resource is an Azure resources client.
 type Resource interface {
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]*armresources.GenericResourceExpanded, error)
 }

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -23,6 +23,7 @@ type Factory interface {
 	NetworkInterface() (NetworkInterface, error)
 	Disk() (Disk, error)
 	Group() (ResourceGroup, error)
+	Resource() (Resource, error)
 	NetworkSecurityGroup() (NetworkSecurityGroup, error)
 	Subnet() (Subnet, error)
 	PublicIP() (PublicIP, error)
@@ -155,4 +156,8 @@ type Storage interface {
 	DeleteObjectsWithPrefix(context.Context, string, string) error
 	CreateContainerIfNotExists(context.Context, string) error
 	DeleteContainerIfExists(context.Context, string) error
+}
+
+type Resource interface {
+	ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]*armresources.GenericResourceExpanded, error)
 }

--- a/pkg/controller/infrastructure/infraflow/flow_context.go
+++ b/pkg/controller/infrastructure/infraflow/flow_context.go
@@ -68,6 +68,12 @@ func NewFlowContext(factory client.Factory,
 		return nil, err
 	}
 
+	status := &azure.InfrastructureStatus{}
+	status, err = helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
+	if err != nil {
+		return nil, err
+	}
+
 	profile, err := helper.CloudProfileConfigFromCluster(cluster)
 	if err != nil {
 		return nil, err
@@ -83,6 +89,7 @@ func NewFlowContext(factory client.Factory,
 	adapter, err := NewInfrastructureAdapter(
 		infra,
 		cfg,
+		status,
 		profile,
 		cluster,
 	)

--- a/pkg/controller/infrastructure/infraflow/flow_context.go
+++ b/pkg/controller/infrastructure/infraflow/flow_context.go
@@ -68,8 +68,7 @@ func NewFlowContext(factory client.Factory,
 		return nil, err
 	}
 
-	status := &azure.InfrastructureStatus{}
-	status, err = helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
+	status, err := helper.InfrastructureStatusFromInfrastructure(infra)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -26,6 +26,7 @@ import (
 type InfrastructureAdapter struct {
 	infra          *extensionsv1alpha1.Infrastructure
 	config         *azure.InfrastructureConfig
+	status         *azure.InfrastructureStatus
 	profile        *azure.CloudProfileConfig
 	cluster        *extensionscontroller.Cluster
 	subscriptionID string
@@ -40,6 +41,7 @@ type InfrastructureAdapter struct {
 func NewInfrastructureAdapter(
 	infra *extensionsv1alpha1.Infrastructure,
 	config *azure.InfrastructureConfig,
+	status *azure.InfrastructureStatus,
 	profile *azure.CloudProfileConfig,
 	cluster *extensionscontroller.Cluster,
 ) (*InfrastructureAdapter, error) {
@@ -62,7 +64,7 @@ func NewInfrastructureAdapter(
 
 // TechnicalName the cluster's "base" name. Used as a name or as a prefix by other resources.
 func (ia *InfrastructureAdapter) TechnicalName() string {
-	return ia.infra.Namespace
+	return infrastructure.ShootResourceGroupName(ia.infra, ia.config, ia.status)
 }
 
 // ResourceGroupConfig contains the configuration for a resource group.

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -50,6 +50,7 @@ func NewInfrastructureAdapter(
 		config:  config,
 		profile: profile,
 		cluster: cluster,
+		status:  status,
 	}
 	ia.vnetConfig = ia.virtualNetworkConfig()
 	avset, err := ia.availabilitySetConfig()

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -160,12 +160,9 @@ func (r *TerraformReconciler) Delete(ctx context.Context, infra *extensionsv1alp
 	if err != nil {
 		return err
 	}
-	status := &azure.InfrastructureStatus{}
-	if infra.Status.ProviderStatus != nil {
-		status, err = helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
-		if err != nil {
-			return err
-		}
+	status, err := helper.InfrastructureStatusFromInfrastructure(infra)
+	if err != nil {
+		return err
 	}
 
 	resourceGroupExists, err := infrastructure.IsShootResourceGroupAvailable(ctx, clientFactory, infra, cfg)
@@ -252,17 +249,15 @@ func (r *TerraformReconciler) cleanResourceGroupIfNeeded(ctx context.Context, in
 		return nil
 	}
 	// skip operations if we are not creating the resource group for the first time.
-	if infra.Status.LastOperation.Type != gardencorev1beta1.LastOperationTypeCreate {
+	if lastOp := infra.Status.LastOperation; lastOp == nil || lastOp.Type != gardencorev1beta1.LastOperationTypeCreate {
 		return nil
 	}
 
-	status := &azure.InfrastructureStatus{}
-	if infra.Status.ProviderStatus != nil {
-		status, err = helper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
-		if err != nil {
-			return err
-		}
+	status, err := helper.InfrastructureStatusFromInfrastructure(infra)
+	if err != nil {
+		return err
 	}
+
 	rgName := infrastructure.ShootResourceGroupName(infra, cfg, status)
 
 	clientFactory, err := r.getClientFactory(ctx, infra, cluster)

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -109,7 +109,7 @@ func (r *TerraformReconciler) reconcile(ctx context.Context, infra *extensionsv1
 			return err
 		}
 		r.Logger.Info(
-			"terraform application failed with infrastructure dependencies error. Will attempt to cleanup the resource group if empty",
+			"Terraform application failed with infrastructure dependencies error. Will attempt to cleanup the resource group if it is empty",
 			"error", err)
 
 		ok, inErr := r.cleanResourceGroupIfNeeded(ctx, infra, cluster, cfg)
@@ -118,7 +118,7 @@ func (r *TerraformReconciler) reconcile(ctx context.Context, infra *extensionsv1
 			return gardencorev1beta1helper.NewErrorWithCodes(fmt.Errorf("retry after resource group cleanup"), gardencorev1beta1.ErrorRetryableInfraDependencies)
 		}
 		if inErr != nil {
-			r.Logger.Error(inErr, "checking and cleaning up the resource group after a failed TF apply failed")
+			r.Logger.Error(inErr, "Checking and cleaning up the resource group after an unsuccessful terraform apply failed")
 		}
 
 		return fmt.Errorf("failed to apply the terraform config: %w", err)

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -128,6 +128,7 @@ func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.F
 	return groupClient.Delete(ctx, ShootResourceGroupName(infra, cfg, status))
 }
 
+// ShootResourceGroupName returns the expected name of the resource group.
 func ShootResourceGroupName(infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig, status *api.InfrastructureStatus) string {
 	if cfg.ResourceGroup != nil {
 		return cfg.ResourceGroup.Name

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -115,6 +115,7 @@ func DeleteNodeSubnetIfExists(ctx context.Context, factory azureclient.Factory, 
 
 // DeleteShootResourceGroupIfExists will delete the shoot's resource group if it exists.
 func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.Factory, infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig, status *api.InfrastructureStatus) error {
+	// skip if using user resource group.
 	if cfg.ResourceGroup != nil {
 		return nil
 	}
@@ -124,10 +125,17 @@ func DeleteShootResourceGroupIfExists(ctx context.Context, factory azureclient.F
 		return err
 	}
 
-	name := infra.Namespace
-	if status != nil && len(status.ResourceGroup.Name) > 0 {
-		name = status.ResourceGroup.Name
+	return groupClient.Delete(ctx, ShootResourceGroupName(infra, cfg, status))
+}
+
+func ShootResourceGroupName(infra *extensionsv1alpha1.Infrastructure, cfg *api.InfrastructureConfig, status *api.InfrastructureStatus) string {
+	if cfg.ResourceGroup != nil {
+		return cfg.ResourceGroup.Name
 	}
 
-	return groupClient.Delete(ctx, name)
+	if status != nil && len(status.ResourceGroup.Name) > 0 {
+		return status.ResourceGroup.Name
+	}
+
+	return infra.Namespace
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Due to the Terraform/Azure interaction, there may be resource groups that are created but not in the TF state, thus blocking infra creation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Delete empty resource groups on infrastructure creation. 
```
