### PR TITLE
Provide Egress CIDRs in Infra Status

### DIFF
--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -184,5 +184,5 @@ func (f *FlowReconciler) migrateFromTerraform(ctx context.Context, infra *extens
 	// we will use a specific "marker" to make the reconciler aware of existing resources. This will prevent the reconciler from skipping the deletion flow.
 	state.Data[infraflow.CreatedResourcesExistKey] = "true"
 
-	return state, infrainternal.PatchProviderStatusAndState(ctx, f.client, infra, nil, &runtime.RawExtension{Object: state})
+	return state, infrainternal.PatchProviderStatusAndState(ctx, f.client, infra, nil, &runtime.RawExtension{Object: state}, nil)
 }

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -437,8 +437,7 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 
 // EnsureNatGateways reconciles all the NAT Gateways for the shoot.
 func (fctx *FlowContext) EnsureNatGateways(ctx context.Context) error {
-	err := fctx.ensureNatGateways(ctx)
-	return err
+	return fctx.ensureNatGateways(ctx)
 }
 
 // EnsureNatGateways creates or updates NAT Gateways. It also deletes old NATGateways.
@@ -500,9 +499,6 @@ func (fctx *FlowContext) ensureNatGateways(ctx context.Context) error {
 			toDelete[name] = *current.ID
 			continue
 		}
-	}
-	if joinError != nil {
-		return joinError
 	}
 
 	for natName, nat := range toDelete {

--- a/pkg/controller/infrastructure/infraflow/flow_context.go
+++ b/pkg/controller/infrastructure/infraflow/flow_context.go
@@ -130,10 +130,11 @@ func (fctx *FlowContext) Reconcile(ctx context.Context) error {
 
 	status, err := fctx.GetInfrastructureStatus(ctx)
 	state := fctx.GetInfrastructureState()
+	egressCidrs := fctx.GetEgressIpCidrs()
 	if err != nil {
 		return err
 	}
-	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, status, state)
+	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, status, state, egressCidrs)
 }
 
 func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
@@ -196,5 +197,5 @@ func (fctx *FlowContext) Delete(ctx context.Context) error {
 }
 
 func (fctx *FlowContext) persistState(ctx context.Context) error {
-	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, nil, fctx.GetInfrastructureState())
+	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, nil, fctx.GetInfrastructureState(), fctx.GetEgressIpCidrs())
 }

--- a/pkg/controller/infrastructure/infraflow/provider_utils.go
+++ b/pkg/controller/infrastructure/infraflow/provider_utils.go
@@ -38,6 +38,11 @@ const (
 )
 
 const (
+	// KeyPublicIPAddresses is the key used to store public IP addresses in the FlowContext's whiteboard.
+	KeyPublicIPAddresses = "PublicIpAddresses"
+)
+
+const (
 	// TemplateAvailabilitySet the template for the ID of an availability set.
 	TemplateAvailabilitySet = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s"
 	// TemplateNatGateway the template for the id of a NAT Gateway.

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state.go
@@ -37,6 +37,36 @@ type TFOutput struct {
 	Type  string `json:"type"`
 }
 
+// UnmarshalJSON is a custom unmarshal function to be able to handle all actually possible values for the value of a TFOutput.
+func (t *TFOutput) UnmarshalJSON(data []byte) error {
+	var (
+		v        map[string]interface{}
+		valueKey = "value"
+		typeKey  = "type"
+	)
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	rawValue := v[valueKey]
+	if value, ok := rawValue.(string); ok {
+		t.Value = value
+	} else if value, ok := rawValue.(int); ok {
+		t.Value = fmt.Sprint(value)
+	} else if value, ok := rawValue.(float64); ok {
+		t.Value = fmt.Sprint(int(value))
+	} else {
+		return fmt.Errorf("unable to parse value of field '%v' as string, float, or integer: %v", valueKey, v[valueKey])
+	}
+
+	if typeValue, ok := v[typeKey].(string); ok {
+		t.Type = typeValue
+	} else {
+		return fmt.Errorf("unable to parse value of field '%v' as string", typeKey)
+	}
+	return nil
+}
+
 // TFResource holds the attributes of a terraformer state resource.
 type TFResource struct {
 	Mode      string `json:"mode"`

--- a/pkg/internal/infrastructure/helper.go
+++ b/pkg/internal/infrastructure/helper.go
@@ -149,10 +149,14 @@ func PatchProviderStatusAndState(
 	infra *extensionsv1alpha1.Infrastructure,
 	status *apiv1alpha1.InfrastructureStatus,
 	state *runtime.RawExtension,
+	egressCidrs []string,
 ) error {
 	patch := client.MergeFrom(infra.DeepCopy())
 	if status != nil {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
+		if egressCidrs != nil {
+			infra.Status.EgressCIDRs = egressCidrs
+		}
 	}
 	if state != nil {
 		infra.Status.State = state


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/platform azure

**What this PR does / why we need it**:
With this PR the CIDR-Ranges used for cluster-egress will be provided in the shoot's infrastructure resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The CIDR blocks used for shoot egress will now be provided via the status of the shoot's infrastructure-resource
```
