### PR TITLE
Support for Kubernetes v1.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.30 | 1.30.0+     | N/A |
 | Kubernetes 1.29 | 1.29.0+     | [![Gardener v1.29 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.29%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.29%20Azure) |
 | Kubernetes 1.28 | 1.28.0+     | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20Azure) |
 | Kubernetes 1.27 | 1.27.0+     | [![Gardener v1.27 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.27%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.27%20Azure) |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.26.21"
+  tag: "v1.26.22"
   targetVersion: "1.26.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -44,7 +44,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.27.14"
+  tag: "v1.27.17"
   targetVersion: "1.27.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -58,7 +58,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.28.6"
+  tag: "v1.28.9"
   targetVersion: "1.28.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -72,8 +72,22 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.29.1"
-  targetVersion: ">= 1.29"
+  tag: "v1.29.5"
+  targetVersion: "1.29.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  tag: "v1.30.1"
+  targetVersion: ">= 1.30"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -101,7 +115,7 @@ images:
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.26.21"
+  tag: "v1.26.22"
   targetVersion: "1.26.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -115,7 +129,7 @@ images:
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.27.14"
+  tag: "v1.27.17"
   targetVersion: "1.27.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -129,7 +143,7 @@ images:
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.28.6"
+  tag: "v1.28.9"
   targetVersion: "1.28.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -143,8 +157,22 @@ images:
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.29.1"
-  targetVersion: ">= 1.29"
+  tag: "v1.29.5"
+  targetVersion: "1.29.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: cloud-node-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
+  tag: "v1.30.1"
+  targetVersion: ">= 1.30"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -195,8 +195,10 @@ func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, k8sVersion *semver.
 			"CSIMigrationAzureDisk=true", ",")
 	}
 
-	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
-		"CSIMigrationAzureFile=true", ",")
+	if version.ConstraintK8sLess130.Check(k8sVersion) {
+		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+			"CSIMigrationAzureFile=true", ",")
+	}
 
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 		"InTreePluginAzureDiskUnregister=true", ",")
@@ -220,9 +222,10 @@ func ensureKubeControllerManagerCommandLineArgs(c *corev1.Container, k8sVersion 
 			"CSIMigrationAzureDisk=true", ",")
 	}
 
-	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
-		"CSIMigrationAzureFile=true", ",")
-
+	if version.ConstraintK8sLess130.Check(k8sVersion) {
+		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+			"CSIMigrationAzureFile=true", ",")
+	}
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 		"InTreePluginAzureDiskUnregister=true", ",")
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
@@ -239,9 +242,10 @@ func ensureKubeSchedulerCommandLineArgs(c *corev1.Container, k8sVersion *semver.
 			"CSIMigrationAzureDisk=true", ",")
 	}
 
-	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
-		"CSIMigrationAzureFile=true", ",")
-
+	if version.ConstraintK8sLess130.Check(k8sVersion) {
+		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+			"CSIMigrationAzureFile=true", ",")
+	}
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 		"InTreePluginAzureDiskUnregister=true", ",")
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
@@ -256,9 +260,10 @@ func ensureClusterAutoscalerCommandLineArgs(c *corev1.Container, k8sVersion *sem
 			"CSIMigrationAzureDisk=true", ",")
 	}
 
-	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
-		"CSIMigrationAzureFile=true", ",")
-
+	if version.ConstraintK8sLess130.Check(k8sVersion) {
+		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+			"CSIMigrationAzureFile=true", ",")
+	}
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 		"InTreePluginAzureDiskUnregister=true", ",")
 	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
@@ -380,7 +385,9 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ gcontext.Garde
 		new.FeatureGates["CSIMigrationAzureDisk"] = true
 	}
 
-	new.FeatureGates["CSIMigrationAzureFile"] = true
+	if version.ConstraintK8sLess130.Check(kubeletVersion) {
+		new.FeatureGates["CSIMigrationAzureFile"] = true
+	}
 	// kubelets of new worker nodes can directly be started with the `InTreePluginAzure<*>Unregister` feature gates
 	new.FeatureGates["InTreePluginAzureDiskUnregister"] = true
 	new.FeatureGates["InTreePluginAzureFileUnregister"] = true

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -88,6 +88,20 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
+		eContextK8s130 = gcontext.NewInternalGardenContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.30.1",
+						},
+					},
+					Status: gardencorev1beta1.ShootStatus{
+						TechnicalID: namespace,
+					},
+				},
+			},
+		)
 	)
 
 	BeforeEach(func() {
@@ -129,14 +143,21 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, true)
+			checkKubeAPIServerDeployment(dep, true, true)
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.27)", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.27, < 1.30)", func() {
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s127, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, false)
+			checkKubeAPIServerDeployment(dep, false, true)
+		})
+
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.30)", func() {
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s130, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkKubeAPIServerDeployment(dep, false, false)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -168,7 +189,7 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			Expect(ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, true)
+			checkKubeAPIServerDeployment(dep, true, true)
 		})
 	})
 
@@ -196,14 +217,21 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, true)
+			checkKubeControllerManagerDeployment(dep, true, true)
 		})
 
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.27)", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.27, < 1.30)", func() {
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s127, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, false)
+			checkKubeControllerManagerDeployment(dep, false, true)
+		})
+
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.30)", func() {
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s130, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkKubeControllerManagerDeployment(dep, false, false)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
@@ -229,7 +257,7 @@ var _ = Describe("Ensurer", func() {
 
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, true)
+			checkKubeControllerManagerDeployment(dep, true, true)
 		})
 	})
 
@@ -257,14 +285,21 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, true)
+			checkKubeSchedulerDeployment(dep, true, true)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s >= 1.27)", func() {
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.27, < 1.30)", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s127, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, false)
+			checkKubeSchedulerDeployment(dep, false, true)
+		})
+
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.30)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s130, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkKubeSchedulerDeployment(dep, false, false)
 		})
 	})
 
@@ -292,14 +327,21 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, true)
+			checkClusterAutoscalerDeployment(dep, true, true)
 		})
 
-		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.27)", func() {
+		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.27, < 1.30)", func() {
 			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s127, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, false)
+			checkClusterAutoscalerDeployment(dep, false, true)
+		})
+
+		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.30)", func() {
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s130, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkClusterAutoscalerDeployment(dep, false, false)
 		})
 	})
 
@@ -375,7 +417,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		DescribeTable("should modify existing elements of kubelet configuration",
-			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, withCSIFeatureGates bool) {
+			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, withCSIFeatureGates, k8sless130 bool) {
 				newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 					FeatureGates: map[string]bool{
 						"Foo": true,
@@ -384,7 +426,9 @@ var _ = Describe("Ensurer", func() {
 				}
 				kubeletConfig := *oldKubeletConfig
 
-				newKubeletConfig.FeatureGates["CSIMigrationAzureFile"] = true
+				if k8sless130 {
+					newKubeletConfig.FeatureGates["CSIMigrationAzureFile"] = true
+				}
 				newKubeletConfig.FeatureGates["InTreePluginAzureDiskUnregister"] = true
 				newKubeletConfig.FeatureGates["InTreePluginAzureFileUnregister"] = true
 				if withCSIFeatureGates {
@@ -397,8 +441,9 @@ var _ = Describe("Ensurer", func() {
 				Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 			},
 
-			Entry("kubelet k8s < 1.27", eContextK8s126, semver.MustParse("1.26.0"), true),
-			Entry("kubelet k8s >= 1.27", eContextK8s127, semver.MustParse("1.27.0"), false),
+			Entry("kubelet k8s < 1.27", eContextK8s126, semver.MustParse("1.26.0"), true, true),
+			Entry("kubelet k8s >=1.27, < 1.30", eContextK8s127, semver.MustParse("1.27.0"), false, true),
+			Entry("kubelet k8s >= 1.30", eContextK8s127, semver.MustParse("1.30.0"), false, false),
 		)
 	})
 
@@ -545,7 +590,7 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sLess127 bool) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sLess127, k8sLess130 bool) {
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
@@ -553,8 +598,10 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sLess127 bool) {
 
 	if k8sLess127 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
-	} else {
+	} else if k8sLess130 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
+	} else {
+		Expect(c.Command).To(ContainElement("--feature-gates=InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
 	}
 
 	Expect(c.Command).NotTo(ContainElement("--cloud-provider=azure"))
@@ -568,7 +615,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sLess127 bool) {
 
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sLess127 bool) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sLess127, k8sLess130 bool) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-controller-manager")
@@ -578,8 +625,10 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sLess127 boo
 
 	if k8sLess127 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
-	} else {
+	} else if k8sLess130 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
+	} else {
+		Expect(c.Command).To(ContainElement("--feature-gates=InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
 	}
 
 	Expect(c.Command).NotTo(ContainElement("--cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf"))
@@ -594,27 +643,31 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sLess127 boo
 	Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(usrShareCaCertsVolume))
 }
 
-func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sLess127 bool) {
+func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sLess127, k8sLess130 bool) {
 	// Check that the kube-scheduler container still exists and contains all needed command line args.
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-scheduler")
 	Expect(c).To(Not(BeNil()))
 
 	if k8sLess127 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
-	} else {
+	} else if k8sLess130 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
+	} else {
+		Expect(c.Command).To(ContainElement("--feature-gates=InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
 	}
 }
 
-func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sLess127 bool) {
+func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sLess127, k8sLess130 bool) {
 	// Check that the cluster-autoscaler container still exists and contains all needed command line args.
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "cluster-autoscaler")
 	Expect(c).To(Not(BeNil()))
 
 	if k8sLess127 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
-	} else {
+	} else if k8sLess130 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigrationAzureFile=true,InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
+	} else {
+		Expect(c.Command).To(ContainElement("--feature-gates=InTreePluginAzureDiskUnregister=true,InTreePluginAzureFileUnregister=true"))
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform azure
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.30 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9508

**Special notes for your reviewer**:
* I have successfully validated the functionality as follows:
  * [x] Create new clusters with versions < 1.30
  * [x] Create new clusters with version  = 1.30
  * [x] Upgrade old clusters from version 1.29 to version 1.30
  * [x] Delete clusters with versions < 1.30
  * [x] Delete clusters with version  = 1.30

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-azure extension does now support shoot clusters with Kubernetes version 1.30. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md) before upgrading to 1.30. 
```
