### PR TITLE
Remove invalid CCM feature gate from the examples

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -5,7 +5,6 @@ podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}
 featureGates: {}
-  # RotateKubeletServerCertificate: false
 images:
   cloud-controller-manager: image-repository:image-tag
 resources:

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -305,8 +305,8 @@ An example `ControlPlaneConfig` for the Azure extension looks as follows:
 apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
 kind: ControlPlaneConfig
 cloudControllerManager:
-  featureGates:
-    RotateKubeletServerCertificate: true
+# featureGates:
+#   SomeKubernetesFeature: true
 ```
 
 The `cloudControllerManager.featureGates` contains a map of explicitly enabled or disabled feature gates.

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -59,12 +59,12 @@ spec:
   providerConfig:
     apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
     kind: ControlPlaneConfig
-    cloudControllerManager:
-      featureGates:
-        RotateKubeletServerCertificate: true
-#    storage:
-#      managedDefaultVolumeSnapshotClass: true
-#      managedDefaultStorageClass: true
+  # cloudControllerManager:
+  #   featureGates:
+  #     SomeKubernetesFeature: true
+  # storage:
+  #   managedDefaultVolumeSnapshotClass: true
+  #   managedDefaultStorageClass: true
   infrastructureProviderStatus:
     apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
     kind: InfrastructureStatus

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -102,7 +102,7 @@ var _ = Describe("ValuesProvider", func() {
 			},
 			CloudControllerManager: &v1alpha1.CloudControllerManagerConfig{
 				FeatureGates: map[string]bool{
-					"RotateKubeletServerCertificate": true,
+					"SomeKubernetesFeature": true,
 				},
 			},
 		}
@@ -313,7 +313,7 @@ var _ = Describe("ValuesProvider", func() {
 					"maintenance.gardener.cloud/restart": "true",
 				},
 				"featureGates": map[string]bool{
-					"RotateKubeletServerCertificate": true,
+					"SomeKubernetesFeature": true,
 				},
 				"tlsCipherSuites": []string{
 					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/955
cc @ialidzhikov

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
