### PR TITLE
Detect Cloud Instance by Region as Fallback

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -34,6 +34,10 @@ nodeTemplate:
   zone: {{ $machineClass.nodeTemplate.zone }}
 {{- end }}
 providerSpec:
+  {{- if hasKey $machineClass "cloudConfiguration" }}
+  cloudConfiguration:
+{{ toYaml $machineClass.cloudConfiguration | indent 4 }}
+  {{- end }}
   location: {{ $machineClass.region }}
   properties:
     {{- if $machineClass.securityProfile }}

--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -6,7 +6,6 @@ package helper
 
 import (
 	"fmt"
-	"strings"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"k8s.io/utils/ptr"
@@ -146,25 +145,4 @@ func InfrastructureZoneToString(zone int32) string {
 // IsUsingSingleSubnetLayout returns true if the infrastructure configuration is using a network setup with a single subnet.
 func IsUsingSingleSubnetLayout(config *api.InfrastructureConfig) bool {
 	return len(config.Networks.Zones) == 0
-}
-
-// CloudInstanceNameFromRegion returns the canonical cloud instance name for the instance the region is hosted in.
-func CloudInstanceNameFromRegion(region string) string {
-	if hasAnyPrefix(region, api.AzureGovRegionPrefixes...) {
-		return api.AzureGovCloudName
-	} else if hasAnyPrefix(region, api.AzureChinaRegionPrefixes...) {
-		return api.AzureChinaCloudName
-	} else {
-		return api.AzurePublicCloudName
-	}
-}
-
-func hasAnyPrefix(s string, prefixes ...string) bool {
-	lString := strings.ToLower(s)
-	for _, p := range prefixes {
-		if strings.HasPrefix(lString, strings.ToLower(p)) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -6,6 +6,7 @@ package helper
 
 import (
 	"fmt"
+	"strings"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"k8s.io/utils/ptr"
@@ -145,4 +146,25 @@ func InfrastructureZoneToString(zone int32) string {
 // IsUsingSingleSubnetLayout returns true if the infrastructure configuration is using a network setup with a single subnet.
 func IsUsingSingleSubnetLayout(config *api.InfrastructureConfig) bool {
 	return len(config.Networks.Zones) == 0
+}
+
+// CloudInstanceNameFromRegion returns the canonical cloud instance name for the instance the region is hosted in.
+func CloudInstanceNameFromRegion(region string) string {
+	if hasAnyPrefix(region, api.AzureGovRegionPrefixes...) {
+		return api.AzureGovCloudName
+	} else if hasAnyPrefix(region, api.AzureChinaRegionPrefixes...) {
+		return api.AzureChinaCloudName
+	} else {
+		return api.AzurePublicCloudName
+	}
+}
+
+func hasAnyPrefix(s string, prefixes ...string) bool {
+	lString := strings.ToLower(s)
+	for _, p := range prefixes {
+		if strings.HasPrefix(lString, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/apis/azure/types_cloudprofile.go
+++ b/pkg/apis/azure/types_cloudprofile.go
@@ -87,6 +87,6 @@ const (
 
 // The known prefixes in of region names for the various instances.
 var (
-	AzureGovRegionPrefixes   = []string{"usgov-", "dod-"}
-	AzureChinaRegionPrefixes = []string{"cn-"}
+	AzureGovRegionPrefixes   = []string{"usgov", "usdod", "ussec"}
+	AzureChinaRegionPrefixes = []string{"china"}
 )

--- a/pkg/apis/azure/types_cloudprofile.go
+++ b/pkg/apis/azure/types_cloudprofile.go
@@ -84,3 +84,10 @@ const (
 	AzureGovCloudName    string = "AzureGovernment"
 	AzurePublicCloudName string = "AzurePublic"
 )
+
+// The known prefixes in of region names for the various instances.
+// TODO doublecheck
+var (
+	AzureGovRegionPrefixes   = []string{"usgov-", "dod-"}
+	AzureChinaRegionPrefixes = []string{"cn-"}
+)

--- a/pkg/apis/azure/types_cloudprofile.go
+++ b/pkg/apis/azure/types_cloudprofile.go
@@ -86,7 +86,6 @@ const (
 )
 
 // The known prefixes in of region names for the various instances.
-// TODO doublecheck
 var (
 	AzureGovRegionPrefixes   = []string{"usgov-", "dod-"}
 	AzureChinaRegionPrefixes = []string{"cn-"}

--- a/pkg/apis/azure/types_cloudprofile.go
+++ b/pkg/apis/azure/types_cloudprofile.go
@@ -77,3 +77,10 @@ type MachineType struct {
 	// AcceleratedNetworking is an indicator if the machine type supports Azure accelerated networking.
 	AcceleratedNetworking *bool
 }
+
+// The (currently) supported values for the names of clouds to use in the CloudConfiguration.
+const (
+	AzureChinaCloudName  string = "AzureChina"
+	AzureGovCloudName    string = "AzureGovernment"
+	AzurePublicCloudName string = "AzurePublic"
+)

--- a/pkg/azure/client/client_opts.go
+++ b/pkg/azure/client/client_opts.go
@@ -84,11 +84,11 @@ func AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration *azure.Clo
 
 	cloudConfigurationName := cloudConfiguration.Name
 	switch {
-	case strings.EqualFold(cloudConfigurationName, "AzurePublic"):
+	case strings.EqualFold(cloudConfigurationName, azure.AzurePublicCloudName):
 		return cloud.AzurePublic, nil
-	case strings.EqualFold(cloudConfigurationName, "AzureGovernment"):
+	case strings.EqualFold(cloudConfigurationName, azure.AzureGovCloudName):
 		return cloud.AzureGovernment, nil
-	case strings.EqualFold(cloudConfigurationName, "AzureChina"):
+	case strings.EqualFold(cloudConfigurationName, azure.AzureChinaCloudName):
 		return cloud.AzureChina, nil
 
 	default:

--- a/pkg/azure/client/client_opts.go
+++ b/pkg/azure/client/client_opts.go
@@ -6,19 +6,15 @@ package client
 
 import (
 	"crypto/tls"
-	"fmt"
 	"math"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 )
 
 const (
@@ -73,45 +69,6 @@ func getAzureClientOpts() *arm.ClientOptions {
 			},
 			Cloud: cloud.AzurePublic,
 		},
-	}
-}
-
-// AzureCloudConfigurationFromCloudConfiguration returns the cloud.Configuration corresponding to the given cloud configuration name (as part of our CloudConfiguration)
-func AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration *azure.CloudConfiguration) (cloud.Configuration, error) {
-	if cloudConfiguration == nil {
-		return cloud.AzurePublic, nil
-	}
-
-	cloudConfigurationName := cloudConfiguration.Name
-	switch {
-	case strings.EqualFold(cloudConfigurationName, azure.AzurePublicCloudName):
-		return cloud.AzurePublic, nil
-	case strings.EqualFold(cloudConfigurationName, azure.AzureGovCloudName):
-		return cloud.AzureGovernment, nil
-	case strings.EqualFold(cloudConfigurationName, azure.AzureChinaCloudName):
-		return cloud.AzureChina, nil
-
-	default:
-		return cloud.Configuration{}, fmt.Errorf("unknown cloud configuration name '%s'", cloudConfigurationName)
-	}
-}
-
-// CloudEnvVarNameFromCloudConfiguration returns the names of env-vars used by the upstream-controllers corresponding to the given cloud configuration name (as part of our CloudConfiguration)
-func CloudEnvVarNameFromCloudConfiguration(cloudConfiguration *azure.CloudConfiguration) (string, error) {
-	if cloudConfiguration == nil {
-		return "AZUREPUBLICCLOUD", nil
-	}
-
-	cloudConfigurationName := cloudConfiguration.Name
-	switch {
-	case strings.EqualFold(cloudConfigurationName, "AzurePublic"):
-		return "AZUREPUBLICCLOUD", nil
-	case strings.EqualFold(cloudConfigurationName, "AzureGovernment"):
-		return "AZUREUSGOVERNMENT", nil
-	case strings.EqualFold(cloudConfigurationName, "AzureChina"):
-		return "AZURECHINACLOUD", nil
-	default:
-		return "", fmt.Errorf("unknown cloud configuration name '%s'", cloudConfigurationName)
 	}
 }
 

--- a/pkg/azure/client/helper.go
+++ b/pkg/azure/client/helper.go
@@ -6,12 +6,17 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest"
 	azerrors "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 )
 
 // FilterNotFoundError returns nil for NotFound errors.
@@ -61,4 +66,99 @@ func IsAzureAPIUnauthorized(err error) bool {
 
 	inErr := &azidentity.AuthenticationFailedError{}
 	return errors.As(err, &inErr)
+}
+
+// CloudConfiguration returns a CloudConfiguration for the given input, prioritising the given CloudConfiguration if both inputs are not nil. In essence
+// this function unifies both ways to configure the instance to connect to into a single type - our CloudConfiguration.
+func CloudConfiguration(cloudConfiguration *azure.CloudConfiguration, region *string) (*azure.CloudConfiguration, error) {
+	if cloudConfiguration != nil {
+		return cloudConfiguration, nil
+	} else if region != nil {
+		return cloudConfigurationFromRegion(*region), nil
+	}
+	return nil, fmt.Errorf("either CloudConfiguration or region must not be nil to determine Azure Cloud configuration")
+}
+
+// AzureCloudConfiguration is a convenience function to get the corresponding Azure Cloud configuration (from the Azure SDK) to the given input,
+// preferring the cloudConfiguration if both values are not nil.
+func AzureCloudConfiguration(cloudConfiguration *azure.CloudConfiguration, region *string) (cloud.Configuration, error) {
+	cloudConf, err := CloudConfiguration(cloudConfiguration, region)
+	if err != nil {
+		return cloud.Configuration{}, err
+	}
+	return AzureCloudConfigurationFromCloudConfiguration(cloudConf)
+}
+
+// cloudConfigurationFromRegion returns a matching cloudConfiguration corresponding to a well known cloud instance for the given region
+func cloudConfigurationFromRegion(region string) *azure.CloudConfiguration {
+	switch {
+	case hasAnyPrefix(region, azure.AzureGovRegionPrefixes...):
+		return &azure.CloudConfiguration{Name: azure.AzureGovCloudName}
+	case hasAnyPrefix(region, azure.AzureChinaRegionPrefixes...):
+		return &azure.CloudConfiguration{Name: azure.AzureChinaCloudName}
+	default:
+		return &azure.CloudConfiguration{Name: azure.AzurePublicCloudName}
+	}
+}
+
+// AzureCloudConfigurationFromCloudConfiguration returns the cloud.Configuration corresponding to the given cloud configuration name (as part of our CloudConfiguration).
+func AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration *azure.CloudConfiguration) (cloud.Configuration, error) {
+	if cloudConfiguration == nil {
+		return cloud.AzurePublic, nil
+	}
+
+	cloudConfigurationName := cloudConfiguration.Name
+	switch {
+	case strings.EqualFold(cloudConfigurationName, azure.AzurePublicCloudName):
+		return cloud.AzurePublic, nil
+	case strings.EqualFold(cloudConfigurationName, azure.AzureGovCloudName):
+		return cloud.AzureGovernment, nil
+	case strings.EqualFold(cloudConfigurationName, azure.AzureChinaCloudName):
+		return cloud.AzureChina, nil
+
+	default:
+		return cloud.Configuration{}, fmt.Errorf("unknown cloud configuration name '%s'", cloudConfigurationName)
+	}
+}
+
+// AzureCloudEnvVarName is a convenience function to get the correct env-var name to use in terraform for the given input,
+// preferring the cloudConfiguration if both values are not nil.
+func AzureCloudEnvVarName(cloudConfiguration *azure.CloudConfiguration, region *string) (string, error) {
+	if cloudConfiguration != nil {
+		return cloudEnvVarNameFromCloudConfiguration(cloudConfiguration)
+	} else if region != nil {
+		cloudConfiguration := cloudConfigurationFromRegion(*region)
+		return cloudEnvVarNameFromCloudConfiguration(cloudConfiguration)
+	}
+
+	return "", fmt.Errorf("either CloudConfiguration or region must not be nil to determine correct env var name")
+}
+
+// CloudEnvVarNameFromCloudConfiguration returns the names of env-vars used by the upstream-controllers corresponding to the given cloud configuration name (as part of our CloudConfiguration).
+func cloudEnvVarNameFromCloudConfiguration(cloudConfiguration *azure.CloudConfiguration) (string, error) {
+	if cloudConfiguration == nil {
+		return "AZUREPUBLICCLOUD", nil
+	}
+
+	cloudConfigurationName := cloudConfiguration.Name
+	switch {
+	case strings.EqualFold(cloudConfigurationName, "AzurePublic"):
+		return "AZUREPUBLICCLOUD", nil
+	case strings.EqualFold(cloudConfigurationName, "AzureGovernment"):
+		return "AZUREUSGOVERNMENT", nil
+	case strings.EqualFold(cloudConfigurationName, "AzureChina"):
+		return "AZURECHINACLOUD", nil
+	default:
+		return "", fmt.Errorf("unknown cloud configuration name '%s'", cloudConfigurationName)
+	}
+}
+
+func hasAnyPrefix(s string, prefixes ...string) bool {
+	lString := strings.ToLower(s)
+	for _, p := range prefixes {
+		if strings.HasPrefix(lString, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/azure/client/helper.go
+++ b/pkg/azure/client/helper.go
@@ -121,38 +121,6 @@ func AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration *azure.Clo
 	}
 }
 
-// AzureCloudEnvVarName is a convenience function to get the correct env-var name to use in terraform for the given input,
-// preferring the cloudConfiguration if both values are not nil.
-func AzureCloudEnvVarName(cloudConfiguration *azure.CloudConfiguration, region *string) (string, error) {
-	if cloudConfiguration != nil {
-		return cloudEnvVarNameFromCloudConfiguration(cloudConfiguration)
-	} else if region != nil {
-		cloudConfiguration := cloudConfigurationFromRegion(*region)
-		return cloudEnvVarNameFromCloudConfiguration(cloudConfiguration)
-	}
-
-	return "", fmt.Errorf("either CloudConfiguration or region must not be nil to determine correct env var name")
-}
-
-// CloudEnvVarNameFromCloudConfiguration returns the names of env-vars used by the upstream-controllers corresponding to the given cloud configuration name (as part of our CloudConfiguration).
-func cloudEnvVarNameFromCloudConfiguration(cloudConfiguration *azure.CloudConfiguration) (string, error) {
-	if cloudConfiguration == nil {
-		return "AZUREPUBLICCLOUD", nil
-	}
-
-	cloudConfigurationName := cloudConfiguration.Name
-	switch {
-	case strings.EqualFold(cloudConfigurationName, "AzurePublic"):
-		return "AZUREPUBLICCLOUD", nil
-	case strings.EqualFold(cloudConfigurationName, "AzureGovernment"):
-		return "AZUREUSGOVERNMENT", nil
-	case strings.EqualFold(cloudConfigurationName, "AzureChina"):
-		return "AZURECHINACLOUD", nil
-	default:
-		return "", fmt.Errorf("unknown cloud configuration name '%s'", cloudConfigurationName)
-	}
-}
-
 func hasAnyPrefix(s string, prefixes ...string) bool {
 	lString := strings.ToLower(s)
 	for _, p := range prefixes {

--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -41,7 +41,13 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, backupBucket *e
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(backupConfig.CloudConfiguration)
+	cloudConfiguration := backupConfig.CloudConfiguration
+
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(backupBucket.Spec.Region)}
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}
@@ -101,6 +107,9 @@ func (a *actuator) delete(ctx context.Context, _ logr.Logger, backupBucket *exte
 	var cloudConfiguration *azure.CloudConfiguration
 	if backupBucket != nil {
 		cloudConfiguration = backupBucketConfig.CloudConfiguration
+	}
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(backupBucket.Spec.Region)}
 	}
 
 	if secret != nil {

--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -41,13 +41,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, backupBucket *e
 		return err
 	}
 
-	cloudConfiguration := backupConfig.CloudConfiguration
-
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(backupBucket.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(backupConfig.CloudConfiguration, &backupBucket.Spec.Region)
 	if err != nil {
 		return err
 	}
@@ -104,12 +98,19 @@ func (a *actuator) delete(ctx context.Context, _ logr.Logger, backupBucket *exte
 		return err
 	}
 
-	var cloudConfiguration *azure.CloudConfiguration
+	var (
+		cloudConfiguration *azure.CloudConfiguration
+		region             *string
+	)
+
 	if backupBucket != nil {
 		cloudConfiguration = backupBucketConfig.CloudConfiguration
+		region = &backupBucket.Spec.Region
 	}
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(backupBucket.Spec.Region)}
+
+	cloudConfiguration, err = azureclient.CloudConfiguration(cloudConfiguration, region)
+	if err != nil {
+		return err
 	}
 
 	if secret != nil {

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -17,6 +17,7 @@ import (
 	ctrlerror "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/go-logr/logr"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 )
@@ -38,7 +39,12 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensi
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudProfile.CloudConfiguration, &cluster.Shoot.Spec.Region)
+	var cloudConfiguration *azure.CloudConfiguration
+	if cloudProfile != nil {
+		cloudConfiguration = cloudProfile.CloudConfiguration
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &cluster.Shoot.Spec.Region)
 
 	if err != nil {
 		return err

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -17,7 +17,6 @@ import (
 	ctrlerror "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/go-logr/logr"
 
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 )
@@ -39,16 +38,8 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensi
 		return err
 	}
 
-	var cloudConfiguration *azure.CloudConfiguration
-	if cloudProfile != nil {
-		cloudConfiguration = cloudProfile.CloudConfiguration
-	}
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudProfile.CloudConfiguration, &cluster.Shoot.Spec.Region)
 
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -44,6 +44,10 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensi
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
+
 	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -71,6 +71,10 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
+
 	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -66,7 +66,12 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudProfile.CloudConfiguration, &cluster.Shoot.Spec.Region)
+	var cloudConfiguration *azure.CloudConfiguration
+	if cloudProfile != nil {
+		cloudConfiguration = cloudProfile.CloudConfiguration
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &opt.Location)
 	if err != nil {
 		return err
 	}
@@ -146,7 +151,7 @@ func getInfrastructureStatus(ctx context.Context, a *actuator, cluster *extensio
 		return nil, err
 	}
 
-	if worker == nil || worker.Spec.InfrastructureProviderStatus == nil {
+	if worker.Spec.InfrastructureProviderStatus == nil {
 		return nil, errors.New("infrastructure provider status must be not empty for worker")
 	}
 

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -66,16 +66,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return err
 	}
 
-	var cloudConfiguration *azure.CloudConfiguration
-	if cloudProfile != nil {
-		cloudConfiguration = cloudProfile.CloudConfiguration
-	}
-
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudProfile.CloudConfiguration, &cluster.Shoot.Spec.Region)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -39,10 +39,8 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-azure/charts"
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azureapihelper "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
-	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/features"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 )
@@ -462,29 +460,8 @@ func getConfigChartValues(infraStatus *apisazure.InfrastructureStatus, cp *exten
 		maxNodes = maxNodes + worker.Maximum
 	}
 
-	cloudProfile, err := helper.CloudProfileConfigFromCluster(cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	var region *string
-	if cluster != nil && cluster.Shoot != nil {
-		region = &cluster.Shoot.Spec.Region
-	}
-
-	var cloudConfiguration *apisazure.CloudConfiguration
-	if cloudProfile != nil {
-		cloudConfiguration = cloudProfile.CloudConfiguration
-	}
-
-	azureCloudEnvVarName, err := azureclient.AzureCloudEnvVarName(cloudConfiguration, region)
-	if err != nil {
-		return nil, err
-	}
-
 	// Collect config chart values.
 	values := map[string]interface{}{
-		"cloud":             azureCloudEnvVarName,
 		"tenantId":          ca.TenantID,
 		"subscriptionId":    ca.SubscriptionID,
 		"aadClientId":       ca.ClientID,

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -467,15 +467,17 @@ func getConfigChartValues(infraStatus *apisazure.InfrastructureStatus, cp *exten
 		return nil, err
 	}
 
+	var region *string
+	if cluster != nil && cluster.Shoot != nil {
+		region = &cluster.Shoot.Spec.Region
+	}
+
 	var cloudConfiguration *apisazure.CloudConfiguration
 	if cloudProfile != nil {
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
-	if cloudConfiguration == nil {
-		cloudConfiguration = &apisazure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
 
-	azureCloudEnvVarName, err := azureclient.CloudEnvVarNameFromCloudConfiguration(cloudConfiguration)
+	azureCloudEnvVarName, err := azureclient.AzureCloudEnvVarName(cloudConfiguration, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -471,6 +471,9 @@ func getConfigChartValues(infraStatus *apisazure.InfrastructureStatus, cp *exten
 	if cloudProfile != nil {
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
+	if cloudConfiguration == nil {
+		cloudConfiguration = &apisazure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
 
 	azureCloudEnvVarName, err := azureclient.CloudEnvVarNameFromCloudConfiguration(cloudConfiguration)
 	if err != nil {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -774,6 +774,7 @@ func generateCluster(cidr, k8sVersion string, vpaEnabled bool, shootAnnotations 
 					},
 				},
 			},
+			Region: "eu-west-1a",
 			Networking: &gardencorev1beta1.Networking{
 				Pods: &cidr,
 			},

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -155,7 +155,6 @@ var _ = Describe("ValuesProvider", func() {
 		cluster = generateCluster(cidr, k8sVersion, false, nil, nil, nil)
 
 		ControlPlaneChartValues = map[string]interface{}{
-			"cloud":             "AZUREPUBLICCLOUD",
 			"tenantId":          "TenantID",
 			"subscriptionId":    "SubscriptionID",
 			"aadClientId":       "ClientID",

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 )
@@ -53,12 +52,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, dns *extensio
 		return err
 	}
 
-	cloudConfiguration := dnsRecordConfig.CloudConfiguration
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(*dns.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(dnsRecordConfig.CloudConfiguration, dns.Spec.Region)
 	if err != nil {
 		return err
 	}
@@ -112,12 +106,8 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, dns *extensionsv
 		return err
 	}
 
-	cloudConfiguration := dnsRecordConfig.CloudConfiguration
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(*dns.Spec.Region)}
-	}
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(dnsRecordConfig.CloudConfiguration, dns.Spec.Region)
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 )
@@ -52,7 +53,12 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, dns *extensio
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(dnsRecordConfig.CloudConfiguration)
+	cloudConfiguration := dnsRecordConfig.CloudConfiguration
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(*dns.Spec.Region)}
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}
@@ -106,7 +112,12 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, dns *extensionsv
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(dnsRecordConfig.CloudConfiguration)
+	cloudConfiguration := dnsRecordConfig.CloudConfiguration
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(*dns.Spec.Region)}
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Actuator", func() {
 				Name:       domainName,
 				RecordType: extensionsv1alpha1.DNSRecordTypeA,
 				Values:     []string{address},
+				Region:     ptr.To("Foobar"),
 			},
 		}
 

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -79,11 +79,7 @@ func (f *FlowReconciler) Reconcile(ctx context.Context, infra *extensionsv1alpha
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &cluster.Shoot.Spec.Region)
 	if err != nil {
 		return err
 	}
@@ -127,11 +123,7 @@ func (f *FlowReconciler) Delete(ctx context.Context, infra *extensionsv1alpha1.I
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &cluster.Shoot.Spec.Region)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -74,7 +74,16 @@ func (f *FlowReconciler) Reconcile(ctx context.Context, infra *extensionsv1alpha
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudProfile.CloudConfiguration)
+	var cloudConfiguration *azure.CloudConfiguration
+	if cloudProfile != nil {
+		cloudConfiguration = cloudProfile.CloudConfiguration
+	}
+
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}
@@ -113,7 +122,16 @@ func (f *FlowReconciler) Delete(ctx context.Context, infra *extensionsv1alpha1.I
 		return err
 	}
 
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudProfile.CloudConfiguration)
+	var cloudConfiguration *azure.CloudConfiguration
+	if cloudProfile != nil {
+		cloudConfiguration = cloudProfile.CloudConfiguration
+	}
+
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
+
+	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -246,28 +246,12 @@ func NoOpStateInitializer(_ context.Context, _ client.Client, _, _ string, _ *me
 	return nil
 }
 
-func (r *TerraformReconciler) getClientFactory(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *controller.Cluster) (azureclient.Factory, error) {
-	cloudProfile, err := helper.CloudProfileConfigFromCluster(cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	var cloudConfiguration *azure.CloudConfiguration
-	if cloudProfile != nil {
-		cloudConfiguration = cloudProfile.CloudConfiguration
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &cluster.Shoot.Spec.Region)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *TerraformReconciler) getClientFactory(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, _ *controller.Cluster) (azureclient.Factory, error) {
 	return DefaultAzureClientFactoryFunc(
 		ctx,
 		r.Client,
 		infra.Spec.SecretRef,
 		false,
-		azureclient.WithCloudConfiguration(azCloudConfiguration),
 	)
 }
 

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -257,11 +257,7 @@ func (r *TerraformReconciler) getClientFactory(ctx context.Context, infra *exten
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &cluster.Shoot.Spec.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/infrastructure/terraform_reconciler.go
+++ b/pkg/controller/infrastructure/terraform_reconciler.go
@@ -257,6 +257,10 @@ func (r *TerraformReconciler) getClientFactory(ctx context.Context, infra *exten
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
+
 	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -82,6 +82,10 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
+	if cloudConfiguration == nil {
+		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
+	}
+
 	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -82,11 +82,7 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		cloudConfiguration = cloudProfile.CloudConfiguration
 	}
 
-	if cloudConfiguration == nil {
-		cloudConfiguration = &azure.CloudConfiguration{Name: helper.CloudInstanceNameFromRegion(cluster.Shoot.Spec.Region)}
-	}
-
-	azCloudConfiguration, err := azureclient.AzureCloudConfigurationFromCloudConfiguration(cloudConfiguration)
+	azCloudConfiguration, err := azureclient.AzureCloudConfiguration(cloudConfiguration, &cluster.Shoot.Spec.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -28,6 +28,7 @@ import (
 	azureapi "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	azureapihelper "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+	azureclient "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 )
 
 const azureCSIDiskDriverTopologyKey = "topology.disk.csi.azure.com/zone"
@@ -194,6 +195,14 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"vnet":   infrastructureStatus.Networks.VNet.Name,
 				"subnet": subnetName,
 			}
+
+			cloudConfiguration, err := azureclient.CloudConfiguration(nil, &w.worker.Spec.Region)
+			if err == nil {
+				machineClassSpec["cloudConfiguration"] = map[string]interface{}{
+					"name": cloudConfiguration.Name,
+				}
+			}
+
 			if infrastructureStatus.Networks.VNet.ResourceGroup != nil {
 				networkConfig["vnetResourceGroup"] = *infrastructureStatus.Networks.VNet.ResourceGroup
 			}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-azure/charts"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 	. "github.com/gardener/gardener-extension-provider-azure/pkg/controller/worker"
@@ -473,6 +474,9 @@ var _ = Describe("Machines", func() {
 						},
 						"sshPublicKey": sshKey,
 						"identityID":   identityID,
+						"cloudConfiguration": map[string]interface{}{
+							"name": azure.AzurePublicCloudName,
+						},
 					}
 
 					urnMachineClass = copyMachineClass(defaultMachineClass)


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind enhancement
/platform azure

**What this PR does / why we need it**:
With the changes in this PR, the extension will look at the name of the region configured in the shoot to determine the correct cloud instance to connect to iff there is no explicit CloudConfiguration provided.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
When no CloudConfiguration is given, the Azure Cloud instance to connect to will be inferred from the region configured for the shoot
```
