### PR TITLE
Fix possible Nullpointer-deref

### DIFF
--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -135,8 +135,8 @@ func (ia *InfrastructureAdapter) virtualNetworkConfig() VirtualNetworkConfig {
 	if cidr := ia.config.Networks.VNet.CIDR; cidr != nil {
 		// copy string
 		vnc.CIDR = to.Ptr(*cidr)
-	} else {
-		vnc.CIDR = to.Ptr(*ia.config.Networks.Workers)
+	} else if cidr = ia.config.Networks.Workers; cidr != nil {
+		vnc.CIDR = to.Ptr(*cidr)
 	}
 
 	return vnc


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Fixes a possible nullpointer-deref for zoned clusters that also give an external vnet config

**Which issue(s) this PR fixes**:
Fixes # 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix panic that could occur when using zoned cluster and providing external vnet config
```
