### PR TITLE
Fix flow deletion foreign subnet

### DIFF
--- a/pkg/azure/client/factory.go
+++ b/pkg/azure/client/factory.go
@@ -137,6 +137,11 @@ func (f azureFactory) Subnet() (Subnet, error) {
 	return NewSubnetsClient(*f.auth, f.tokenCredential, f.clientOpts)
 }
 
+// LoadBalancer returns an Azure LoadBalancer client.
+func (f azureFactory) LoadBalancer() (LoadBalancer, error) {
+	return NewLoadBalancersClient(*f.auth, f.tokenCredential, f.clientOpts)
+}
+
 // RouteTables returns an Azure RouteTables client.
 func (f azureFactory) RouteTables() (RouteTables, error) {
 	return NewRouteTablesClient(*f.auth, f.tokenCredential, f.clientOpts)

--- a/pkg/azure/client/loadbalancers.go
+++ b/pkg/azure/client/loadbalancers.go
@@ -14,8 +14,6 @@ import (
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
 )
 
-var _ Subnet = &SubnetsClient{}
-
 // LoadBalancersClient implements the interface for the LoadBalancers client.
 type LoadBalancersClient struct {
 	client *armnetwork.LoadBalancersClient

--- a/pkg/azure/client/loadbalancers.go
+++ b/pkg/azure/client/loadbalancers.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/internal"
+)
+
+var _ Subnet = &SubnetsClient{}
+
+// LoadBalancersClient implements the interface for the LoadBalancers client.
+type LoadBalancersClient struct {
+	client *armnetwork.LoadBalancersClient
+}
+
+// NewLoadBalancersClient creates a new client for the LoadBalancers API.
+func NewLoadBalancersClient(auth internal.ClientAuth, tc azcore.TokenCredential, opts *arm.ClientOptions) (*LoadBalancersClient, error) {
+	client, err := armnetwork.NewLoadBalancersClient(auth.SubscriptionID, tc, opts)
+	return &LoadBalancersClient{client}, err
+}
+
+// List lists all subnets of a given virtual network.
+func (c *LoadBalancersClient) List(ctx context.Context, resourceGroupName string) ([]*armnetwork.LoadBalancer, error) {
+	pager := c.client.NewListPager(resourceGroupName, nil)
+	var loadBalancers []*armnetwork.LoadBalancer
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		loadBalancers = append(loadBalancers, page.Value...)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return loadBalancers, nil
+}
+
+// Delete deletes a subnet in a given virtual network.
+func (c *LoadBalancersClient) Delete(ctx context.Context, resourceGroupName, loadBalancerName string) error {
+	poller, err := c.client.BeginDelete(ctx, resourceGroupName, loadBalancerName, nil)
+	if err != nil {
+		return FilterNotFoundError(err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	return err
+}

--- a/pkg/azure/client/mock/mocks.go
+++ b/pkg/azure/client/mock/mocks.go
@@ -290,6 +290,21 @@ func (mr *MockFactoryMockRecorder) Group() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockFactory)(nil).Group))
 }
 
+// LoadBalancer mocks base method.
+func (m *MockFactory) LoadBalancer() (client.LoadBalancer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadBalancer")
+	ret0, _ := ret[0].(client.LoadBalancer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadBalancer indicates an expected call of LoadBalancer.
+func (mr *MockFactoryMockRecorder) LoadBalancer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancer", reflect.TypeOf((*MockFactory)(nil).LoadBalancer))
+}
+
 // ManagedUserIdentity mocks base method.
 func (m *MockFactory) ManagedUserIdentity() (client.ManagedUserIdentity, error) {
 	m.ctrl.T.Helper()

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -26,6 +26,7 @@ type Factory interface {
 	Resource() (Resource, error)
 	NetworkSecurityGroup() (NetworkSecurityGroup, error)
 	Subnet() (Subnet, error)
+	LoadBalancer() (LoadBalancer, error)
 	PublicIP() (PublicIP, error)
 	Vnet() (VirtualNetwork, error)
 	RouteTables() (RouteTables, error)
@@ -120,6 +121,12 @@ type Subnet interface {
 	SubResourceGetWithExpandFunc[armnetwork.Subnet, *string]
 	SubResourceListFunc[armnetwork.Subnet]
 	SubResourceDeleteFunc[armnetwork.Subnet]
+}
+
+// LoadBalancer represents an Azure LoadBalancer k8sClient.
+type LoadBalancer interface {
+	ListFunc[armnetwork.LoadBalancer]
+	DeleteFunc[armnetwork.LoadBalancer]
 }
 
 // VirtualNetwork represents an Azure Virtual Network k8sClient.

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -755,23 +755,6 @@ func (fctx *FlowContext) DeleteResourceGroup(ctx context.Context) error {
 
 // DeleteSubnetsInForeignGroup deletes all managed subnets in a foreign resource group
 func (fctx *FlowContext) DeleteSubnetsInForeignGroup(ctx context.Context) error {
-	if fctx.adapter.VirtualNetworkConfig().Managed {
-		return nil
-	}
-
-	// This is a prerequisite for the deletion of the subnets in foreign resource group because
-	// internal load balancers might have a Frontend IP configuration referencing the
-	// foreign subnet which therefore can not be deleted. Since the Frontend IP configuration
-	// by its own can not be deleted, we remove the whole (all) load balancers.
-	err := fctx.deleteLoadBalancers(ctx)
-	if err != nil {
-		return err
-	}
-
-	return fctx.deleteForeignSubnets(ctx)
-}
-
-func (fctx *FlowContext) deleteForeignSubnets(ctx context.Context) error {
 	vnetCfg := fctx.adapter.VirtualNetworkConfig()
 	vnetRgroup := vnetCfg.ResourceGroup
 	vnetName := vnetCfg.Name
@@ -800,8 +783,12 @@ func (fctx *FlowContext) deleteForeignSubnets(ctx context.Context) error {
 	return joinErr
 }
 
-// deleteLoadBalancers deletes all load balancers in shoots resource group
-func (fctx *FlowContext) deleteLoadBalancers(ctx context.Context) error {
+// DeleteLoadBalancers deletes all load balancers in shoots resource group
+// This is a prerequisite for the deletion of the subnets in foreign resource group because
+// internal load balancers might have a Frontend IP configuration referencing the
+// foreign subnet which therefore can not be deleted. Since the Frontend IP configuration
+// by its own can not be deleted, we remove the whole (all) load balancers.
+func (fctx *FlowContext) DeleteLoadBalancers(ctx context.Context) error {
 	c, err := fctx.factory.LoadBalancer()
 	if err != nil {
 		return err

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -755,11 +755,24 @@ func (fctx *FlowContext) DeleteResourceGroup(ctx context.Context) error {
 
 // DeleteSubnetsInForeignGroup deletes all managed subnets in a foreign resource group
 func (fctx *FlowContext) DeleteSubnetsInForeignGroup(ctx context.Context) error {
-	vnetCfg := fctx.adapter.VirtualNetworkConfig()
-	if vnetCfg.Managed {
+	if fctx.adapter.VirtualNetworkConfig().Managed {
 		return nil
 	}
 
+	// This is a prerequisite for the deletion of the subnets in foreign resource group because
+	// internal load balancers might have a Frontend IP configuration referencing the
+	// foreign subnet which therefore can not be deleted. Since the Frontend IP configuration
+	// by its own can not be deleted, we remove the whole (all) load balancers.
+	err := fctx.deleteLoadBalancers(ctx)
+	if err != nil {
+		return err
+	}
+
+	return fctx.deleteForeignSubnets(ctx)
+}
+
+func (fctx *FlowContext) deleteForeignSubnets(ctx context.Context) error {
+	vnetCfg := fctx.adapter.VirtualNetworkConfig()
 	vnetRgroup := vnetCfg.ResourceGroup
 	vnetName := vnetCfg.Name
 
@@ -782,7 +795,30 @@ func (fctx *FlowContext) DeleteSubnetsInForeignGroup(ctx context.Context) error 
 		err := c.Delete(ctx, vnetRgroup, vnetName, *s.Name)
 		if err != nil {
 			joinErr = errors.Join(joinErr, err)
-			continue
+		}
+	}
+	return joinErr
+}
+
+// deleteLoadBalancers deletes all load balancers in shoots resource group
+func (fctx *FlowContext) deleteLoadBalancers(ctx context.Context) error {
+	c, err := fctx.factory.LoadBalancer()
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := fctx.adapter.ResourceGroupName()
+
+	loadBalancers, err := c.List(ctx, resourceGroup)
+	if err != nil {
+		return err
+	}
+
+	var joinErr error
+	for _, lb := range loadBalancers {
+		err := c.Delete(ctx, resourceGroup, *lb.Name)
+		if err != nil {
+			joinErr = errors.Join(joinErr, err)
 		}
 	}
 	return joinErr


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform azure

**What this PR does / why we need it**:
If users bring their own vnet and deploy a load balancer with IP configuration in the shoot cluster referencing the subnet in the foreign resource group, the deletion of this subnet currently fails.
To fix this issue we will first try to delete all load balancers in the shoots resource group, before deleting the subnet in the foreign resource group.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve flow shoot deletion with custom vnet
```
