### PR TITLE
Replace occurrences of + in operating system labels for MachineClasses with _

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -263,7 +263,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			if pool.MachineImage.Name != "" && pool.MachineImage.Version != "" {
 				machineClassSpec["operatingSystem"] = map[string]interface{}{
 					"operatingSystemName":    pool.MachineImage.Name,
-					"operatingSystemVersion": pool.MachineImage.Version,
+					"operatingSystemVersion": strings.Replace(pool.MachineImage.Version, "+", "_", -1),
 				}
 			}
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Machines", func() {
 
 			BeforeEach(func() {
 				machineImageName = "my-os"
-				machineImageVersion = "1"
+				machineImageVersion = "123.4.5-foo+bar"
 				machineImageVersionID = "2"
 				machineImageVersionCommunityID = "3"
 				machineImageVersionSharedID = "4"
@@ -532,19 +532,19 @@ var _ = Describe("Machines", func() {
 
 					machineClassPool1["operatingSystem"] = map[string]interface{}{
 						"operatingSystemName":    machineImageName,
-						"operatingSystemVersion": machineImageVersion,
+						"operatingSystemVersion": strings.Replace(machineImageVersion, "+", "_", -1),
 					}
 					machineClassPool2["operatingSystem"] = map[string]interface{}{
 						"operatingSystemName":    machineImageName,
-						"operatingSystemVersion": machineImageVersionID,
+						"operatingSystemVersion": strings.Replace(machineImageVersionID, "+", "_", -1),
 					}
 					machineClassPool3["operatingSystem"] = map[string]interface{}{
 						"operatingSystemName":    machineImageName,
-						"operatingSystemVersion": machineImageVersionCommunityID,
+						"operatingSystemVersion": strings.Replace(machineImageVersionCommunityID, "+", "_", -1),
 					}
 					machineClassPool4["operatingSystem"] = map[string]interface{}{
 						"operatingSystemName":    machineImageName,
-						"operatingSystemVersion": machineImageVersionSharedID,
+						"operatingSystemVersion": strings.Replace(machineImageVersionSharedID, "+", "_", -1),
 					}
 
 					machineClasses = map[string]interface{}{"machineClasses": []map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

**What this PR does / why we need it**:
This is the change of https://github.com/gardener/gardener-extension-provider-aws/pull/983 for provider-AZ.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A problem with deploying MachineClasses that reference an operating system image whose version contains a `+` character was fixed. 
```
