### PR TITLE
Add object selector to the shoot webhook

### DIFF
--- a/pkg/webhook/acceleratednetwork/add.go
+++ b/pkg/webhook/acceleratednetwork/add.go
@@ -8,6 +8,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -27,5 +28,10 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			{Obj: &appsv1.DaemonSet{}},
 		},
 		Mutator: NewMutator(mgr, logger),
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"k8s-app": "calico-node",
+			},
+		},
 	})
 }

--- a/pkg/webhook/acceleratednetwork/mutate.go
+++ b/pkg/webhook/acceleratednetwork/mutate.go
@@ -13,16 +13,13 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
-	// daemonSetName is the name of the calico daemon set to mutate.
-	daemonSetName = "calico-node"
 	// containerName is the name of the calico container to mutate.
-	containerName = daemonSetName
+	containerName = "calico-node"
 	// bpfEnvVariableName is the name of the environment variable indicating whether calico's ebpf dataplane is active or not.
 	bpfEnvVariableName = "FELIX_BPFENABLED"
 	// bpfDataIfacePatternEnvVariableName is the name of the environment variable to be set during the mutation.
@@ -62,19 +59,14 @@ func (m *mutator) Mutate(_ context.Context, new, old client.Object) error {
 
 	newDaemonSet, ok = new.(*appsv1.DaemonSet)
 	if !ok {
-		return fmt.Errorf("could not mutate, object is not of type \"DaemonSet\"")
+		return fmt.Errorf("wrong object type %T", new)
 	}
 
 	if old != nil {
 		oldDaemonSet, ok = old.(*appsv1.DaemonSet)
 		if !ok {
-			return fmt.Errorf("could not cast old object to appsv1.DaemonSet")
+			return fmt.Errorf("wrong object type %T", old)
 		}
-	}
-
-	// Only mutate calico-node daemon set in kube-system namespace
-	if newDaemonSet.Namespace != metav1.NamespaceSystem || newDaemonSet.Name != daemonSetName {
-		return nil
 	}
 
 	// Only mutate if calico-node's ebpf mode is active


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/988

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9864

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The shoot-webhook that mutates the `calico-node` DaemonSet does now specify object selector. The webhook will now intercept only requests for the `calico-node` DaemonSet.
```
