### PR TITLE
Fix restoration of infra with migrated network layout

### DIFF
--- a/pkg/apis/azure/helper/scheme.go
+++ b/pkg/apis/azure/helper/scheme.go
@@ -5,6 +5,7 @@
 package helper
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
@@ -100,6 +101,30 @@ func BackupConfigFromBackupBucket(backupBucket *extensionsv1alpha1.BackupBucket)
 		}
 	}
 	return backupConfig, nil
+}
+
+// HasFlowState returns true if the group version of the State field in the provided
+// `extensionsv1alpha1.InfrastructureStatus` is azure.provider.extensions.gardener.cloud/v1alpha1.
+func HasFlowState(status extensionsv1alpha1.InfrastructureStatus) (bool, error) {
+	if status.State == nil {
+		return false, nil
+	}
+
+	flowState := runtime.TypeMeta{}
+	stateJson, err := status.State.MarshalJSON()
+	if err != nil {
+		return false, err
+	}
+
+	if err := json.Unmarshal(stateJson, &flowState); err != nil {
+		return false, err
+	}
+
+	if flowState.GroupVersionKind().GroupVersion() == apiv1alpha1.SchemeGroupVersion {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // InfrastructureStateFromRaw extracts the state from the Infrastructure. If no state was available, it returns a "zero" value InfrastructureState object.

--- a/pkg/apis/azure/helper/scheme_test.go
+++ b/pkg/apis/azure/helper/scheme_test.go
@@ -5,11 +5,11 @@
 package helper_test
 
 import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 var _ = Describe("Scheme", func() {

--- a/pkg/apis/azure/helper/scheme_test.go
+++ b/pkg/apis/azure/helper/scheme_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+var _ = Describe("Scheme", func() {
+	DescribeTable("#HasFlowState",
+		func(state *runtime.RawExtension, expectedHasFlowState, expectedErr bool) {
+			infraStatus := extensionsv1alpha1.InfrastructureStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					State: state,
+				},
+			}
+			hasFlowState, err := HasFlowState(infraStatus)
+			expectResults(hasFlowState, expectedHasFlowState, err, expectedErr)
+		},
+		Entry("when state is nil", nil, false, false),
+		Entry("when state is invalid json", &runtime.RawExtension{Raw: []byte(`foo`)}, false, true),
+		Entry("when state is not in 'azure.provider.extensions.gardener.cloud/v1alpha1' group version", &runtime.RawExtension{Raw: []byte(`{"apiVersion":"foo.bar/v1alpha1","kind":"InfrastructureState"}`)}, false, false),
+		Entry("when state is in 'azure.provider.extensions.gardener.cloud/v1alpha1' group version", &runtime.RawExtension{Raw: []byte(`{"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1","kind":"InfrastructureState"}`)}, true, false),
+	)
+})

--- a/pkg/controller/infrastructure/actuator_helper.go
+++ b/pkg/controller/infrastructure/actuator_helper.go
@@ -6,15 +6,11 @@ package infrastructure
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 	azuretypes "github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 )
 
@@ -27,28 +23,6 @@ func CleanupTerraformerResources(ctx context.Context, tf terraformer.Terraformer
 		return err
 	}
 	return tf.RemoveTerraformerFinalizerFromConfig(ctx)
-}
-
-func hasFlowState(status extensionsv1alpha1.InfrastructureStatus) (bool, error) {
-	if status.State == nil {
-		return false, nil
-	}
-
-	flowState := runtime.TypeMeta{}
-	stateJson, err := status.State.MarshalJSON()
-	if err != nil {
-		return false, err
-	}
-
-	if err := json.Unmarshal(stateJson, &flowState); err != nil {
-		return false, err
-	}
-
-	if flowState.GroupVersionKind().GroupVersion() == v1alpha1.SchemeGroupVersion {
-		return true, nil
-	}
-
-	return false, nil
 }
 
 // GetFlowAnnotationValue returns the boolean value of the expected flow annotation. Returns false if the annotation was not found, if it couldn't be converted to bool,

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -46,7 +46,7 @@ func (f *FlowReconciler) Reconcile(ctx context.Context, infra *extensionsv1alpha
 		infraState *azure.InfrastructureState
 		err        error
 	)
-	fsOk, err := hasFlowState(infra.Status)
+	fsOk, err := helper.HasFlowState(infra.Status)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -934,17 +934,6 @@ func (fctx *FlowContext) GetEgressIpCidrs() []string {
 	return nil
 }
 
-func (fctx *FlowContext) enrichStatusWithIdentity(_ context.Context, status *v1alpha1.InfrastructureStatus) error {
-	if identity := fctx.cfg.Identity; identity != nil {
-		status.Identity = &v1alpha1.IdentityStatus{
-			ID:        *fctx.whiteboard.Get(KeyManagedIdentityId),
-			ClientID:  *fctx.whiteboard.Get(KeyManagedIdentityClientId),
-			ACRAccess: identity.ACRAccess != nil && *identity.ACRAccess,
-		}
-	}
-	return nil
-}
-
 // DeleteResourceGroup deletes the shoot's resource group.
 func (fctx *FlowContext) DeleteResourceGroup(ctx context.Context) error {
 	c, err := fctx.factory.Group()

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -906,6 +906,13 @@ func (fctx *FlowContext) GetInfrastructureState() *runtime.RawExtension {
 		Data:         fctx.whiteboard.ExportAsFlatMap(),
 	}
 
+	if migratedZone, ok := fctx.infra.Annotations[azure.NetworkLayoutZoneMigrationAnnotation]; ok {
+		if state.Data == nil {
+			state.Data = make(map[string]string)
+		}
+		state.Data[azure.NetworkLayoutZoneMigrationAnnotation] = migratedZone
+	}
+
 	return &runtime.RawExtension{
 		Object: state,
 	}

--- a/pkg/controller/infrastructure/strategyselector.go
+++ b/pkg/controller/infrastructure/strategyselector.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 )
 
 // Reconciler is an interface for the infrastructure reconciliation.

--- a/pkg/controller/infrastructure/strategyselector.go
+++ b/pkg/controller/infrastructure/strategyselector.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
@@ -60,7 +61,7 @@ type SelectorFunc func(*extensionsv1alpha1.Infrastructure, *extensions.Cluster) 
 
 // OnReconcile returns true if the operation should use the Flow for the given cluster.
 func OnReconcile(infra *extensionsv1alpha1.Infrastructure, _ *extensions.Cluster) (bool, error) {
-	hasState, err := hasFlowState(infra.Status)
+	hasState, err := helper.HasFlowState(infra.Status)
 	if err != nil {
 		return false, err
 	}
@@ -69,7 +70,7 @@ func OnReconcile(infra *extensionsv1alpha1.Infrastructure, _ *extensions.Cluster
 
 // OnDelete returns true if the operation should use the Flow deletion for the given cluster.
 func OnDelete(infra *extensionsv1alpha1.Infrastructure, _ *extensions.Cluster) (bool, error) {
-	return hasFlowState(infra.Status)
+	return helper.HasFlowState(infra.Status)
 }
 
 // OnRestore decides the reconciler used on migration.

--- a/pkg/webhook/infrastructure/layout_test.go
+++ b/pkg/webhook/infrastructure/layout_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Mutate", func() {
 				Expect(ok).To(BeTrue())
 				Expect(v).To(Equal("2"))
 			})
-			It("should mutate the resource if the current 'gardener.cloud/operation' annotation is restore and has terraform state", func() {
+			It("should mutate the resource if the current 'gardener.cloud/operation' annotation is 'restore' and has terraform state", func() {
 				newInfra := generateInfrastructureWithProviderConfig(zonesConfig, nil)
 				newInfra.Annotations = map[string]string{
 					"gardener.cloud/operation": "restore",

--- a/pkg/webhook/infrastructure/layout_test.go
+++ b/pkg/webhook/infrastructure/layout_test.go
@@ -18,8 +18,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
+	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azurev1alpha1 "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/internal/infrastructure"
 )
 
 const (
@@ -116,6 +118,72 @@ var _ = Describe("Mutate", func() {
 				Expect(err).To(BeNil())
 				_, ok := getLayoutMigrationAnnotation(newInfra)
 				Expect(ok).To(BeFalse())
+			})
+			It("should mutate the resource if the current 'gardener.cloud/operation' annotation is 'restore' and has flow state", func() {
+				newInfra := generateInfrastructureWithProviderConfig(zonesConfig, nil)
+				newInfra.Annotations = map[string]string{
+					"gardener.cloud/operation": "restore",
+				}
+
+				state := &azurev1alpha1.InfrastructureState{
+					TypeMeta: helper.InfrastructureStateTypeMeta,
+					Data: map[string]string{
+						azure.NetworkLayoutZoneMigrationAnnotation: "2",
+					},
+				}
+				marshalled, err := json.Marshal(state)
+				Expect(err).To(BeNil())
+				newInfra.Status.State = &runtime.RawExtension{Raw: marshalled}
+
+				err = mutator.Mutate(context.TODO(), newInfra, newInfra)
+				Expect(err).To(BeNil())
+				v, ok := getLayoutMigrationAnnotation(newInfra)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal("2"))
+			})
+			It("should mutate the resource if the current 'gardener.cloud/operation' annotation is restore and has terraform state", func() {
+				newInfra := generateInfrastructureWithProviderConfig(zonesConfig, nil)
+				newInfra.Annotations = map[string]string{
+					"gardener.cloud/operation": "restore",
+				}
+
+				status := &azurev1alpha1.InfrastructureStatus{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: azurev1alpha1.SchemeGroupVersion.String(),
+						Kind:       "InfrastructureStatus",
+					},
+					Networks: azurev1alpha1.NetworkStatus{
+						Subnets: []azurev1alpha1.Subnet{
+							{
+								Name:     "subnet-zone1",
+								Zone:     ptr.To("1"),
+								Migrated: false,
+							},
+							{
+								Name:     "subnet",
+								Zone:     ptr.To("2"),
+								Migrated: true,
+							},
+						},
+					},
+				}
+				marshalled, err := json.Marshal(status)
+				Expect(err).To(BeNil())
+
+				state := &infrastructure.InfrastructureState{
+					SavedProviderStatus: &runtime.RawExtension{
+						Raw: marshalled,
+					},
+				}
+				marshalledState, err := json.Marshal(state)
+				Expect(err).To(BeNil())
+				newInfra.Status.State = &runtime.RawExtension{Raw: marshalledState}
+
+				err = mutator.Mutate(context.TODO(), newInfra, newInfra)
+				Expect(err).To(BeNil())
+				v, ok := getLayoutMigrationAnnotation(newInfra)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal("2"))
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR modifies the layout mutator which adds the `migration.azure.provider.extensions.gardener.cloud/zone` annotation on the `Infrastructure` resource so that the annotation is also added during the `restore` phase of control plane migration in the following cases:
1. If the `.status.state` field is defined and is in the `azure.provider.extensions.gardener.cloud/v1alpha1` group version, then
    - If its `.data` field contains an entry for  `migration.azure.provider.extensions.gardener.cloud/zone`, then this entry is added as an annotation to the `Infrastructure` resource
2. If the `.status.state` field is defined and its type is [`InfrastructureState`](https://github.com/gardener/gardener-extension-provider-azure/blob/3b5becbae7761889d7bf7f476ede0eb6d5e4fd98/pkg/internal/infrastructure/state.go#L15-L22), then
    - If this `.state` field contains a `.savedProviderStatus` field and its `.networks.subnets` array contains a subnet for which the  `.migrated` field is true and the `.zone` field is not nil

Additionally, during reconciliation, if the new flow reconciler is used and the `migration.azure.provider.extensions.gardener.cloud/zone` annotation is present on the `Infrastructure` resource, then it is persisted in the `.status.state.data` map.


**Which issue(s) this PR fixes**:
Fixes #827

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that prevented the `Infrastructure` resource to be correctly restored during control plane migration, if the `Infrastructure` was previously migrated from a single subnet network layout to a multiple subnet network layout.
```
