### PR TITLE
Fix infra mutator

### DIFF
--- a/pkg/webhook/infrastructure/add.go
+++ b/pkg/webhook/infrastructure/add.go
@@ -33,8 +33,10 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	}
 
 	handler, err := extensionswebhook.NewBuilder(mgr, logger).
-		WithMutator(NewLayoutMutator(logger), types...).
-		WithMutator(NewFlowMutator(mgr, logger), types...).
+		WithMutator(NewInfraMutator([]extensionswebhook.Mutator{
+			newLayoutMutator(logger),
+			newFlowMutator(mgr, logger),
+		}), types...).
 		Build()
 	if err != nil {
 		return nil, err

--- a/pkg/webhook/infrastructure/add.go
+++ b/pkg/webhook/infrastructure/add.go
@@ -32,6 +32,8 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		{Obj: &extensionsv1alpha1.Infrastructure{}},
 	}
 
+	// WithMutator can only add one mutator for the same type so
+	// we created a general infraMutator that just calls all Mutate funcs
 	handler, err := extensionswebhook.NewBuilder(mgr, logger).
 		WithMutator(NewInfraMutator([]extensionswebhook.Mutator{
 			newLayoutMutator(logger),

--- a/pkg/webhook/infrastructure/add.go
+++ b/pkg/webhook/infrastructure/add.go
@@ -33,7 +33,7 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	}
 
 	handler, err := extensionswebhook.NewBuilder(mgr, logger).
-		WithMutator(NewLayoutMutator(logger, NetworkLayoutMigrationMutate), types...).
+		WithMutator(NewLayoutMutator(logger), types...).
 		WithMutator(NewFlowMutator(mgr, logger), types...).
 		Build()
 	if err != nil {

--- a/pkg/webhook/infrastructure/add.go
+++ b/pkg/webhook/infrastructure/add.go
@@ -32,7 +32,7 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		{Obj: &extensionsv1alpha1.Infrastructure{}},
 	}
 
-	// WithMutator can only add one mutator for the same type so
+	// WithMutator can only add one mutator for the same type, so
 	// we created a general infraMutator that just calls all Mutate funcs
 	handler, err := extensionswebhook.NewBuilder(mgr, logger).
 		WithMutator(NewInfraMutator([]extensionswebhook.Mutator{

--- a/pkg/webhook/infrastructure/flow.go
+++ b/pkg/webhook/infrastructure/flow.go
@@ -27,7 +27,7 @@ type flowMutator struct {
 }
 
 // NewFlowMutator returns a new Infrastructure flowMutator that uses mutateFunc to perform the mutation.
-func NewFlowMutator(mgr manager.Manager, logger logr.Logger) extensionswebhook.Mutator {
+func newFlowMutator(mgr manager.Manager, logger logr.Logger) extensionswebhook.Mutator {
 	return &flowMutator{
 		client: mgr.GetClient(),
 		logger: logger,

--- a/pkg/webhook/infrastructure/flow_test.go
+++ b/pkg/webhook/infrastructure/flow_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Mutate", func() {
 		)
 
 		BeforeEach(func() {
-			mutator = NewFlowMutator(mgr, logger)
+			mutator = newFlowMutator(mgr, logger)
 			ctx = context.TODO()
 
 			c.EXPECT().Get(ctx, client.ObjectKey{Name: shootNamespace}, gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).

--- a/pkg/webhook/infrastructure/infrastructure.go
+++ b/pkg/webhook/infrastructure/infrastructure.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type infraMutator struct {
+	mutators []extensionswebhook.Mutator
+}
+
+// NewInfraMutator returns a new Infrastructure infraMutator that calls the
+// Mutate func of all passed mutators
+func NewInfraMutator(mutators []extensionswebhook.Mutator) extensionswebhook.Mutator {
+	return &infraMutator{
+		mutators: mutators,
+	}
+}
+
+// Mutate mutates the given object using the mutateFunc
+func (m *infraMutator) Mutate(ctx context.Context, new, old client.Object) error {
+	for _, mutator := range m.mutators {
+		err := mutator.Mutate(ctx, new, old)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/infrastructure/layout.go
+++ b/pkg/webhook/infrastructure/layout.go
@@ -73,8 +73,8 @@ func mutate(_ context.Context, logger logr.Logger, newInfra, oldInfra *extension
 		return fmt.Errorf("could not mutate object: %v", err)
 	}
 
-	// if newInfra already contains the zone migration annotation, check if it is still necessary. Otherwise, remove the
-	// the annotation.
+	// if newInfra already contains the zone migration annotation, check if it is still necessary.
+	// Otherwise, remove the annotation.
 	if z, ok := newInfra.Annotations[azuretypes.NetworkLayoutZoneMigrationAnnotation]; ok {
 		findMatchingZone := false
 		for _, zone := range newProviderCfg.Networks.Zones {

--- a/pkg/webhook/infrastructure/layout.go
+++ b/pkg/webhook/infrastructure/layout.go
@@ -22,8 +22,8 @@ type layoutMutator struct {
 	logger logr.Logger
 }
 
-// NewLayoutMutator returns a new Infrastructure layoutMutator
-func NewLayoutMutator(logger logr.Logger) extensionswebhook.Mutator {
+// newLayoutMutator returns a new Infrastructure layoutMutator
+func newLayoutMutator(logger logr.Logger) extensionswebhook.Mutator {
 	return &layoutMutator{
 		logger: logger,
 	}

--- a/pkg/webhook/infrastructure/layout.go
+++ b/pkg/webhook/infrastructure/layout.go
@@ -22,7 +22,7 @@ type layoutMutator struct {
 	logger logr.Logger
 }
 
-// NewLayoutMutator returns a new Infrastructure layoutMutator that uses mutateFunc to perform the mutation.
+// NewLayoutMutator returns a new Infrastructure layoutMutator
 func NewLayoutMutator(logger logr.Logger) extensionswebhook.Mutator {
 	return &layoutMutator{
 		logger: logger,

--- a/pkg/webhook/infrastructure/layout.go
+++ b/pkg/webhook/infrastructure/layout.go
@@ -18,19 +18,14 @@ import (
 	azuretypes "github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 )
 
-// MutateFunc is a function that can perform a mutation on Infrastructure objects.
-type MutateFunc func(ctx context.Context, logger logr.Logger, new, old *extensionsv1alpha1.Infrastructure) error
-
 type layoutMutator struct {
-	logger     logr.Logger
-	mutateFunc MutateFunc
+	logger logr.Logger
 }
 
 // NewLayoutMutator returns a new Infrastructure layoutMutator that uses mutateFunc to perform the mutation.
-func NewLayoutMutator(logger logr.Logger, mutateFunc MutateFunc) extensionswebhook.Mutator {
+func NewLayoutMutator(logger logr.Logger) extensionswebhook.Mutator {
 	return &layoutMutator{
-		logger:     logger,
-		mutateFunc: mutateFunc,
+		logger: logger,
 	}
 }
 
@@ -58,11 +53,11 @@ func (m *layoutMutator) Mutate(ctx context.Context, new, old client.Object) erro
 		return fmt.Errorf("could not mutate: object is not of type Infrastructure")
 	}
 
-	return m.mutateFunc(ctx, m.logger, newInfra, oldInfra)
+	return mutate(ctx, m.logger, newInfra, oldInfra)
 }
 
 // NetworkLayoutMigrationMutate annotates the infrastructure object with additonal information that are necessary during the reconciliation when migrating to a new network layout.
-func NetworkLayoutMigrationMutate(_ context.Context, logger logr.Logger, newInfra, oldInfra *extensionsv1alpha1.Infrastructure) error {
+func mutate(_ context.Context, logger logr.Logger, newInfra, oldInfra *extensionsv1alpha1.Infrastructure) error {
 	var (
 		newProviderCfg, oldProviderCfg *azure.InfrastructureConfig
 		oldProviderStatus              *azure.InfrastructureStatus

--- a/pkg/webhook/infrastructure/layout.go
+++ b/pkg/webhook/infrastructure/layout.go
@@ -56,7 +56,7 @@ func (m *layoutMutator) Mutate(ctx context.Context, new, old client.Object) erro
 	return mutate(ctx, m.logger, newInfra, oldInfra)
 }
 
-// NetworkLayoutMigrationMutate annotates the infrastructure object with additonal information that are necessary during the reconciliation when migrating to a new network layout.
+// mutate annotates the infrastructure object with additional information that are necessary during the reconciliation when migrating to a new network layout.
 func mutate(_ context.Context, logger logr.Logger, newInfra, oldInfra *extensionsv1alpha1.Infrastructure) error {
 	var (
 		newProviderCfg, oldProviderCfg *azure.InfrastructureConfig

--- a/pkg/webhook/infrastructure/layout_test.go
+++ b/pkg/webhook/infrastructure/layout_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Mutate", func() {
 		var mutator extensionswebhook.Mutator
 
 		BeforeEach(func() {
-			mutator = NewLayoutMutator(logger)
+			mutator = newLayoutMutator(logger)
 		})
 
 		Context("add migration annotation", func() {

--- a/pkg/webhook/infrastructure/layout_test.go
+++ b/pkg/webhook/infrastructure/layout_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Mutate", func() {
 		var mutator extensionswebhook.Mutator
 
 		BeforeEach(func() {
-			mutator = NewLayoutMutator(logger, NetworkLayoutMigrationMutate)
+			mutator = NewLayoutMutator(logger)
 		})
 
 		Context("add migration annotation", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

**What this PR does / why we need it**:
Fix bug where only one infra mutator gets called

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix bug where only one infra mutator gets called
```
