### PR TITLE
Make infra-flow deletion more resilient

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -804,9 +804,7 @@ func (fctx *FlowContext) DeleteSubnetsInForeignGroup(ctx context.Context) error 
 	currentSubnets, err := c.List(ctx, vnetRgroup, vnetName)
 
 	// In case we cannot list any subnets at all, assume that the deletion succeeded at an earlier point in time.
-	err = client.FilterNotFoundError(err)
-
-	if err != nil {
+	if client.FilterNotFoundError(err) != nil {
 		return err
 	}
 
@@ -841,9 +839,7 @@ func (fctx *FlowContext) DeleteLoadBalancers(ctx context.Context) error {
 
 	// If we do not find any loadbalancers, assume the resource group was successfully deleted and we
 	// are done.
-	err = client.FilterNotFoundError(err)
-
-	if err != nil {
+	if client.FilterNotFoundError(err) != nil {
 		return err
 	}
 

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -802,6 +802,10 @@ func (fctx *FlowContext) DeleteSubnetsInForeignGroup(ctx context.Context) error 
 	}
 
 	currentSubnets, err := c.List(ctx, vnetRgroup, vnetName)
+
+	// In case we cannot list any subnets at all, assume that the deletion succeeded at an earlier point in time.
+	err = client.FilterNotFoundError(err)
+
 	if err != nil {
 		return err
 	}
@@ -834,6 +838,11 @@ func (fctx *FlowContext) DeleteLoadBalancers(ctx context.Context) error {
 	resourceGroup := fctx.adapter.ResourceGroupName()
 
 	loadBalancers, err := c.List(ctx, resourceGroup)
+
+	// If we do not find any loadbalancers, assume the resource group was successfully deleted and we
+	// are done.
+	err = client.FilterNotFoundError(err)
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform azure

**What this PR does / why we need it**:
We've recently seen a few edge cases where some referenced resources were already successfully deleted but the deletion flow was not finished completely. Upon retry the deletion was now stuck since the supposedly still existing resources could not be found anymore.
This PR makes the deletion more resilient against these cases.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Deletion will now continue if non-gardener-managed loadbalancers and subnets were already deleted beforehand
```
