### PR TITLE
[release 1.45] fix an issue where shoots would be migrated to flow during cp-migration

### DIFF
--- a/pkg/webhook/infrastructure/flow.go
+++ b/pkg/webhook/infrastructure/flow.go
@@ -12,6 +12,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -94,6 +95,13 @@ func (m *flowMutator) Mutate(ctx context.Context, new, old client.Object) error 
 }
 
 func (m *flowMutator) isInMigrationOrRestorePhase(infra *extensionsv1alpha1.Infrastructure) bool {
+	// During the restore phase, the infrastructure object is created without status or state (including the operation type information).
+	// Instead, the object is annotated to indicate that the status and state information will be patched in a subsequent operation.
+	// Therefore, while the GardenerOperationWaitForState  annotation exists, do nothing.
+	if infra.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationWaitForState {
+		return true
+	}
+
 	operationType := helper.ComputeOperationType(infra.ObjectMeta, infra.Status.LastOperation)
 
 	return operationType == v1beta1.LastOperationTypeMigrate || operationType == v1beta1.LastOperationTypeRestore


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug that would migrate shoots away from terraform during control-plane migration. This would occur only if the seed was marked to use the flow reconciler for new shoots.
```
