### PR TITLE
Publish separate admission Helm charts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,9 +10,18 @@ gardener-extension-provider-azure:
         attribute: image.repository
       - ref: ocm-resource:gardener-extension-provider-azure.tag
         attribute: image.tag
-    - &admission-azure
-      name: admission-azure
-      dir: charts/gardener-extension-admission-azure
+    - &admission-azure-application
+      name: admission-azure-application
+      dir: charts/gardener-extension-admission-azure/charts/application
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-azure.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-azure.tag
+        attribute: global.image.tag
+    - &admission-azure-runtime
+      name: admission-azure-runtime
+      dir: charts/gardener-extension-admission-azure/charts/runtime
       registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
       mappings:
       - ref: ocm-resource:gardener-extension-admission-azure.repository
@@ -73,7 +82,8 @@ gardener-extension-provider-azure:
         publish:
           helmcharts:
           - *provider-azure
-          - *admission-azure
+          - *admission-azure-application
+          - *admission-azure-runtime
     pull-request:
       traits:
         pull-request: ~
@@ -85,7 +95,8 @@ gardener-extension-provider-azure:
         publish:
           helmcharts:
           - *provider-azure
-          - *admission-azure
+          - *admission-azure-application
+          - *admission-azure-runtime
     release:
       steps:
         test-integration:
@@ -121,5 +132,7 @@ gardener-extension-provider-azure:
           helmcharts:
           - <<: *provider-azure
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
-          - <<: *admission-azure
+          - <<: *admission-azure-application
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-azure-runtime
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Admission Helm charts have to be published as separate charts for application and runtime that they can be used in `operator.gardener.cloud/v1alpha1.Extension` resource.

**Which issue(s) this PR fixes**:
Follow up to #920 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
