### PR TITLE
make sure to also pass cloud instance name to CCM

### DIFF
--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -166,6 +166,7 @@ var _ = Describe("ValuesProvider", func() {
 			"routeTableName":    "route-table-name",
 			"securityGroupName": "security-group-name-workers",
 			"vmType":            "standard",
+			"cloud":             "AZUREPUBLICCLOUD",
 		}
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bugfix
/platform azure

**What this PR does / why we need it**:
Currently, the correct name for the cloud instance is not passed to the CCM chart. With this PR the appropriate value for the shoots region will be passed.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Also pass cloud instance name to the cloud control manager
```
