### PR TITLE
[Release v1.47] Infer cloud instance from bucket region when possible

### DIFF
--- a/pkg/azure/client/storage.go
+++ b/pkg/azure/client/storage.go
@@ -65,8 +65,7 @@ func NewBlobStorageClient(_ context.Context, storageAccountName, storageAccountK
 	return &BlobStorageClient{blobclient}, err
 }
 
-// NewBlobStorageClientFromSecretRef creates a client for an Azure Blob storage by reading auth information from secret reference. Requires passing the storage domain (formerly
-// blobstorage host name) to determine the endpoint to build the service url for.
+// NewBlobStorageClientFromSecretRef creates a client for an Azure Blob storage by reading auth information from secret reference.
 func NewBlobStorageClientFromSecretRef(ctx context.Context, client client.Client, secretRef *corev1.SecretReference) (*BlobStorageClient, error) {
 	secret, err := extensionscontroller.GetSecretByReference(ctx, client, secretRef)
 	if err != nil {

--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -66,7 +66,12 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, backupBucket *e
 			return util.DetermineError(err, helper.KnownCodes)
 		}
 
-		storageDomain, err := azureclient.BlobStorageDomainFromCloudConfiguration(backupConfig.CloudConfiguration)
+		bucketCloudConfiguration, err := azureclient.CloudConfiguration(backupConfig.CloudConfiguration, &backupBucket.Spec.Region)
+		if err != nil {
+			return err
+		}
+
+		storageDomain, err := azureclient.BlobStorageDomainFromCloudConfiguration(bucketCloudConfiguration)
 		if err != nil {
 			return fmt.Errorf("failed to determine blob storage service domain: %w", err)
 		}

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -560,7 +560,7 @@ func findDomainCounts(cluster *controller.Cluster, infra *extensionsv1alpha1.Inf
 		}
 
 		// Take values from the availability set status.
-		// StorageDomain counts can still be nil, esp. if the status was written by an earlier version of this provider extension.
+		// Domain counts can still be nil, esp. if the status was written by an earlier version of this provider extension.
 		if nodesAvailabilitySet != nil {
 			faultDomainCount = nodesAvailabilitySet.CountFaultDomains
 			updateDomainCount = nodesAvailabilitySet.CountUpdateDomains


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement
/platform azure

**What this PR does / why we need it**:
The storage domain to use for backup buckets will now be inferred from the buckets' region if no explicit config is given. This is consistent with how the rest of our codebase does it.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The storage domain to use for backup buckets is now inferred from the buckets' region if no explicit config is given
```
