### PR TITLE
[release v1.47] filter more strictly when looking at subnets

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -579,7 +579,7 @@ func (fctx *FlowContext) ensureSubnets(ctx context.Context) (err error) {
 	}
 
 	filteredSubnets := Filter(currentSubnets, func(s *armnetwork.Subnet) bool {
-		return fctx.adapter.HasShootPrefix(s.Name)
+		return fctx.adapter.IsOwnSubnetName(s.Name)
 	})
 	mappedSubnets := ToMap(filteredSubnets, func(s *armnetwork.Subnet) string {
 		return *s.Name


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind regression
/platform azure

**What this PR does / why we need it**:
With this PR, subnet detection by name is more strict than before. This avoids erroneously detecting subnets that are deployed in the same vnet whose name only differs by a suffix from the current shoot when deploying into existing subnets.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Flow reconciliation is now more strict when filtering subnets. This prevents subnets of shoots that are deployed into one Vnet from interfering with reconciliation.
```
