### PR TITLE
[release-v1.47] Automated cherry pick of #978: fix natgw disassociation with subnet

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -610,14 +610,14 @@ func (fctx *FlowContext) ensureSubnets(ctx context.Context) (err error) {
 			if actual.ID != nil &&
 				actual.Properties != nil &&
 				actual.Properties.NatGateway != nil &&
-				&actual.Properties.NatGateway.ID != nil {
+				actual.Properties.NatGateway.ID != nil {
 				resourceId, err := arm.ParseResourceID(*actual.Properties.NatGateway.ID)
 				if err != nil {
 					joinErr = errors.Join(joinErr, err)
 					continue
 				}
 				// if this is a user-managed NAT gateway, do nothing. This is checked by looking at the resource group of the NGW.
-				// In case that the NGW belongs to our RG, but it should not exist (z.NatGAteway == nil), we remove the association.
+				// In case that the NGW belongs to our RG, but it should not exist (z.NatGateway == nil), we remove the association.
 				if resourceId.ResourceGroupName == fctx.adapter.ResourceGroupName() {
 					actual.Properties.NatGateway = nil
 				}

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -578,13 +578,15 @@ func (fctx *FlowContext) ensureSubnets(ctx context.Context) (err error) {
 		return err
 	}
 
+	// filteredSubnets are the subnets of this shoot. In a shared VNet scenario, it is not guaranteed that all subnets in the VNet belong to a particular shoot.
 	filteredSubnets := Filter(currentSubnets, func(s *armnetwork.Subnet) bool {
 		return fctx.adapter.IsOwnSubnetName(s.Name)
 	})
+	// mappedSubnets maps the unique subnet name to the subnet object.
 	mappedSubnets := ToMap(filteredSubnets, func(s *armnetwork.Subnet) string {
 		return *s.Name
 	})
-
+	// clean the current inventory and rebuild it.
 	for _, name := range fctx.inventory.ByKind(KindSubnet) {
 		if subnet, ok := mappedSubnets[name]; !ok {
 			fctx.inventory.Delete(*subnet.ID)
@@ -594,12 +596,32 @@ func (fctx *FlowContext) ensureSubnets(ctx context.Context) (err error) {
 	zones := fctx.adapter.Zones()
 	for _, z := range zones {
 		actual := z.Subnet.ToProvider(mappedSubnets[z.Subnet.Name])
+
 		rtCfg := fctx.adapter.RouteTableConfig()
-		sgCfg := fctx.adapter.SecurityGroupConfig()
 		actual.Properties.RouteTable = &armnetwork.RouteTable{ID: to.Ptr(GetIdFromTemplate(TemplateRouteTable, fctx.auth.SubscriptionID, rtCfg.ResourceGroup, rtCfg.Name))}
+
+		sgCfg := fctx.adapter.SecurityGroupConfig()
 		actual.Properties.NetworkSecurityGroup = &armnetwork.SecurityGroup{ID: to.Ptr(GetIdFromTemplate(TemplateSecurityGroup, fctx.auth.SubscriptionID, sgCfg.ResourceGroup, sgCfg.Name))}
+
 		if z.NatGateway != nil {
 			actual.Properties.NatGateway = &armnetwork.SubResource{ID: to.Ptr(GetIdFromTemplate(TemplateNatGateway, fctx.auth.SubscriptionID, z.NatGateway.ResourceGroup, z.NatGateway.Name))}
+		} else {
+			// let's allow users to override the NAT Gateway config for a subnet, if that NGW is not managed by gardener.
+			if actual.ID != nil &&
+				actual.Properties != nil &&
+				actual.Properties.NatGateway != nil &&
+				&actual.Properties.NatGateway.ID != nil {
+				resourceId, err := arm.ParseResourceID(*actual.Properties.NatGateway.ID)
+				if err != nil {
+					joinErr = errors.Join(joinErr, err)
+					continue
+				}
+				// if this is a user-managed NAT gateway, do nothing. This is checked by looking at the resource group of the NGW.
+				// In case that the NGW belongs to our RG, but it should not exist (z.NatGAteway == nil), we remove the association.
+				if resourceId.ResourceGroupName == fctx.adapter.ResourceGroupName() {
+					actual.Properties.NatGateway = nil
+				}
+			}
 		}
 		toReconcile[z.Subnet.Name] = actual
 	}

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -566,10 +566,6 @@ func (s *SubnetConfig) ToProvider(base *armnetwork.Subnet) *armnetwork.Subnet {
 		Name: to.Ptr(s.Name),
 		Properties: &armnetwork.SubnetPropertiesFormat{
 			AddressPrefix: to.Ptr(s.cidr),
-			// will be filled later
-			NatGateway:           nil,
-			NetworkSecurityGroup: nil,
-			RouteTable:           nil,
 		},
 		Etag: nil,
 	}
@@ -582,12 +578,19 @@ func (s *SubnetConfig) ToProvider(base *armnetwork.Subnet) *armnetwork.Subnet {
 	// inherited from base
 	if base != nil {
 		target.ID = base.ID
+
+		// For now, use whatever is already existing in the remote object. We will later overwrite them with what we consider appropriate.
+		target.Properties.NatGateway = base.Properties.NatGateway
+		target.Properties.NetworkSecurityGroup = base.Properties.NetworkSecurityGroup
+		target.Properties.RouteTable = base.Properties.RouteTable
+
 		target.Properties.ServiceEndpointPolicies = base.Properties.ServiceEndpointPolicies
 		target.Properties.PrivateLinkServiceNetworkPolicies = base.Properties.PrivateLinkServiceNetworkPolicies
 
 		target.Properties.PrivateEndpoints = base.Properties.PrivateEndpoints
 		target.Properties.PrivateEndpointNetworkPolicies = base.Properties.PrivateEndpointNetworkPolicies
 		target.Properties.Delegations = base.Properties.Delegations
+
 	}
 
 	return target


### PR DESCRIPTION
/area control-plane
/kind bug
/kind enhancement

Cherry pick of #978 on release-v1.47.

#978: fix natgw disassociation with subnet

**Release Notes:**
```other operator
Do not reconcile user-configured NAT Gateways in the gardener subnet.
```