### PR TITLE
Periodically rotate etcd storage account secret

### DIFF
--- a/pkg/azure/client/storage.go
+++ b/pkg/azure/client/storage.go
@@ -65,12 +65,8 @@ func NewBlobStorageClient(_ context.Context, storageAccountName, storageAccountK
 	return &BlobStorageClient{blobclient}, err
 }
 
-// NewBlobStorageClientFromSecretRef creates a client for an Azure Blob storage by reading auth information from secret reference.
-func NewBlobStorageClientFromSecretRef(ctx context.Context, client client.Client, secretRef *corev1.SecretReference) (*BlobStorageClient, error) {
-	secret, err := extensionscontroller.GetSecretByReference(ctx, client, secretRef)
-	if err != nil {
-		return nil, err
-	}
+// NewBlobStorageClientFromSecret creates a client for an Azure Blob storage by reading auth information from a secret.
+func NewBlobStorageClientFromSecret(ctx context.Context, secret *corev1.Secret) (*BlobStorageClient, error) {
 	storageAccountName, ok := secret.Data[azure.StorageAccount]
 	if !ok {
 		return nil, fmt.Errorf("secret %s/%s doesn't have a storage account", secret.Namespace, secret.Name)
@@ -87,6 +83,15 @@ func NewBlobStorageClientFromSecretRef(ctx context.Context, client client.Client
 	}
 
 	return NewBlobStorageClient(ctx, string(storageAccountName), string(storageAccountKey), storageDomain)
+}
+
+// NewBlobStorageClientFromSecretRef creates a client for an Azure Blob storage by reading auth information from secret reference.
+func NewBlobStorageClientFromSecretRef(ctx context.Context, client client.Client, secretRef *corev1.SecretReference) (*BlobStorageClient, error) {
+	secret, err := extensionscontroller.GetSecretByReference(ctx, client, secretRef)
+	if err != nil {
+		return nil, err
+	}
+	return NewBlobStorageClientFromSecret(ctx, secret)
 }
 
 // DeleteObjectsWithPrefix deletes the blob objects with the specific <prefix> from <container>.

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -140,6 +140,7 @@ type VirtualNetwork interface {
 type StorageAccount interface {
 	CreateStorageAccount(context.Context, string, string, string) error
 	ListStorageAccountKey(context.Context, string, string) (string, error)
+	RotateKey(context.Context, string, string, string) (string, error)
 }
 
 // DNSZone represents an Azure DNS zone k8sClient.

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -147,6 +147,10 @@ const (
 	SeedAnnotationKeyUseFlow = AnnotationKeyUseFlow
 	// SeedAnnotationUseFlowValueNew is the value to restrict flow reconciliation to new shoot clusters
 	SeedAnnotationUseFlowValueNew = "new"
+
+	// AnnotationSecretPossiblyOutdated is an annotation we set on BackupBucket secrets before rotating them to signal
+	// that these secrets might be outdated (in case of an error during automated rotation/cleanup).
+	AnnotationSecretPossiblyOutdated = "azure.provider.extensions.gardener.cloud/possibly-outdated"
 )
 
 // UsernamePrefix is a constant for the username prefix of components deployed by Azure.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Rotate the key used to authenticate with the storage account for etcd-backups periodically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Credentials used for ETCD backups will now be periodically rotated.
```
