### PR TITLE
Fix multi-subnet subnet name calculation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=builder /go/bin/gardener-extension-provider-azure /gardener-extensio
 ENTRYPOINT ["/gardener-extension-provider-azure"]
 
 ############# gardener-extension-admission-azure
-FROM base as gardener-extension-admission-azure
+FROM base AS gardener-extension-admission-azure
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-admission-azure /gardener-extension-admission-azure

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -285,9 +285,9 @@ func (ia *InfrastructureAdapter) shootSubnetNamePrefix() string {
 	return fmt.Sprintf("%s-nodes", ia.TechnicalName())
 }
 
-func (ia *InfrastructureAdapter) subnetName(zone *int32) string {
+func (ia *InfrastructureAdapter) subnetName(zone *int32, migrated bool) string {
 	n := ia.shootSubnetNamePrefix()
-	if zone != nil {
+	if zone != nil && !migrated {
 		n = fmt.Sprintf("%s-z%d", n, *zone)
 	}
 	return n
@@ -302,8 +302,8 @@ func (ia *InfrastructureAdapter) IsOwnSubnetName(name *string) bool {
 	if name == nil {
 		return false
 	}
-	expected_prefix := ia.shootSubnetNamePrefix()
-	if _, found := strings.CutPrefix(*name, expected_prefix); found {
+	expectedPrefix := ia.shootSubnetNamePrefix()
+	if _, found := strings.CutPrefix(*name, expectedPrefix); found {
 		return true
 		// No need to check further. The important thing to check is that there is nothing
 		// between the technical name and the next expected part.
@@ -334,7 +334,7 @@ func (ia *InfrastructureAdapter) zonesConfig() []ZoneConfig {
 			Subnet: SubnetConfig{
 				AzureResourceMetadata: AzureResourceMetadata{
 					ResourceGroup: ia.vnetConfig.ResourceGroup,
-					Name:          ia.subnetName(&configZone.Name),
+					Name:          ia.subnetName(&configZone.Name, isMigratedZone),
 					Parent:        ia.vnetConfig.Name,
 					Kind:          KindSubnet,
 				},
@@ -397,7 +397,7 @@ func (ia *InfrastructureAdapter) defaultZone() []ZoneConfig {
 		Subnet: SubnetConfig{
 			AzureResourceMetadata: AzureResourceMetadata{
 				ResourceGroup: ia.vnetConfig.ResourceGroup,
-				Name:          ia.subnetName(nil),
+				Name:          ia.subnetName(nil, false),
 				Parent:        ia.vnetConfig.Name,
 				Kind:          KindSubnet,
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where the subnet name was not calculated correctly in the migration to multi-subnet setup
```
