### PR TITLE
Fix cloudprofile validation

### DIFF
--- a/pkg/admission/validator/cloudprofile.go
+++ b/pkg/admission/validator/cloudprofile.go
@@ -47,5 +47,5 @@ func (cp *cloudProfile) Validate(_ context.Context, newObj, _ client.Object) err
 		return err
 	}
 
-	return azurevalidation.ValidateCloudProfileConfig(cpConfig, providerConfigPath).ToAggregate()
+	return azurevalidation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, providerConfigPath).ToAggregate()
 }

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -106,7 +106,7 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 	machineImagesPath := field.NewPath("spec.providerConfig.machineImages")
 	for i, machineImage := range providerConfig.MachineImages {
 		idxPath := machineImagesPath.Index(i)
-		allErrs = append(allErrs, validation.ValidateMachineImage(idxPath, machineImage)...)
+		allErrs = append(allErrs, validation.ValidateProviderMachineImage(idxPath, machineImage)...)
 	}
 
 	profileImages := util.NewCoreImagesContext(machineImages)

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -111,7 +111,7 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 
 	profileImages := util.NewCoreImagesContext(machineImages)
 	parentImages := util.NewV1beta1ImagesContext(parentSpec.MachineImages)
-	providerImages := newProviderImagesContext(providerConfig.MachineImages)
+	providerImages := validation.NewProviderImagesContext(providerConfig.MachineImages)
 
 	for _, machineImage := range profileImages.Images {
 		// Check that for each new image version defined in the NamespacedCloudProfile, the image is also defined in the providerConfig.
@@ -126,7 +126,7 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 		for _, version := range machineImage.Versions {
 			_, existsInParent := parentImages.GetImageVersion(machineImage.Name, version.Version)
 			for _, expectedArchitecture := range version.Architectures {
-				if _, exists := providerImages.GetImageVersion(machineImage.Name, versionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
+				if _, exists := providerImages.GetImageVersion(machineImage.Name, validation.VersionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
 					allErrs = append(allErrs, field.Required(
 						field.NewPath("spec.providerConfig.machineImages"),
 						fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
@@ -176,23 +176,6 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 	}
 
 	return allErrs
-}
-
-func providerMachineImageKey(v api.MachineImageVersion) string {
-	return versionArchitectureKey(v.Version, ptr.Deref(v.Architecture, constants.ArchitectureAMD64))
-}
-
-func versionArchitectureKey(version, architecture string) string {
-	return version + "-" + architecture
-}
-
-func newProviderImagesContext(providerImages []api.MachineImages) *util.ImagesContext[api.MachineImages, api.MachineImageVersion] {
-	return util.NewImagesContext(
-		utils.CreateMapFromSlice(providerImages, func(mi api.MachineImages) string { return mi.Name }),
-		func(mi api.MachineImages) map[string]api.MachineImageVersion {
-			return utils.CreateMapFromSlice(mi.Versions, func(v api.MachineImageVersion) string { return providerMachineImageKey(v) })
-		},
-	)
 }
 
 func (p *namespacedCloudProfile) validateMachineTypes(providerConfig *api.CloudProfileConfig, machineTypes []core.MachineType, parentSpec gardencorev1beta1.CloudProfileSpec) field.ErrorList {

--- a/pkg/apis/azure/validation/cloudprofile_test.go
+++ b/pkg/apis/azure/validation/cloudprofile_test.go
@@ -30,7 +30,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 		var (
 			cloudProfileMachineImages []core.MachineImage
 			cloudProfileConfig        *apisazure.CloudProfileConfig
-			root                      = field.NewPath("root")
+			nilPath                   *field.Path
 		)
 
 		BeforeEach(func() {
@@ -77,48 +77,48 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 		Context("machine image validation", func() {
 			It("should allow valid cloudProfileConfig", func() {
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 				Expect(errorList).To(BeEmpty())
 			})
 
 			It("should enforce that at least one machine image has been defined", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages"),
+					"Field": Equal("machineImages"),
 				}))))
 			})
 
 			It("should forbid unsupported machine image values", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{{}}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].name"),
+					"Field": Equal("machineImages[0].name"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions"),
+					"Field": Equal("machineImages[0].versions"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages"),
+					"Field": Equal("spec.machineImages[0]"),
 				}))))
 			})
 
 			It("should forbid unsupported machine image architecture", func() {
 				cloudProfileConfig.MachineImages[0].Versions[0].Architecture = ptr.To("foo")
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages.versions"),
+					"Field": Equal("spec.machineImages[0].versions[0]"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
-					"Field": Equal("root.machineImages[0].versions[0].architecture"),
+					"Field": Equal("machineImages[0].versions[0].architecture"),
 				}))))
 			})
 
@@ -126,16 +126,16 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				func(urn string, matcher gomegatypes.GomegaMatcher) {
 					cloudProfileConfig.MachineImages[0].Versions[0].URN = &urn
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 					Expect(errorList).To(matcher)
 				},
 				Entry("correct urn", "foo:bar:baz:ban", BeEmpty()),
-				Entry("empty urn", "", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("root.machineImages[0].versions[0].urn")})))),
-				Entry("only one part", "foo", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].urn")})))),
-				Entry("only two parts", "foo:bar", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].urn")})))),
-				Entry("only three parts", "foo:bar:baz", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].urn")})))),
-				Entry("more than four parts", "foo:bar:baz:ban:bam", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].urn")})))),
+				Entry("empty urn", "", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("machineImages[0].versions[0].urn")})))),
+				Entry("only one part", "foo", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].urn")})))),
+				Entry("only two parts", "foo:bar", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].urn")})))),
+				Entry("only three parts", "foo:bar:baz", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].urn")})))),
+				Entry("more than four parts", "foo:bar:baz:ban:bam", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].urn")})))),
 			)
 
 			DescribeTable("forbid unsupported machine image ID",
@@ -143,12 +143,12 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					cloudProfileConfig.MachineImages[0].Versions[0].URN = nil
 					cloudProfileConfig.MachineImages[0].Versions[0].ID = &id
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 					Expect(errorList).To(matcher)
 				},
 				Entry("correct id", "/non/empty/id", BeEmpty()),
-				Entry("empty id", "", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("root.machineImages[0].versions[0].id")})))),
+				Entry("empty id", "", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("machineImages[0].versions[0].id")})))),
 			)
 
 			DescribeTable("forbid unsupported communityGalleryImageID",
@@ -156,14 +156,14 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					cloudProfileConfig.MachineImages[0].Versions[0].URN = nil
 					cloudProfileConfig.MachineImages[0].Versions[0].CommunityGalleryImageID = &communityGalleryImageID
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 					Expect(errorList).To(matcher)
 				},
 				Entry("correct id", communityGalleryImageID, BeEmpty()),
-				Entry("incorrect number of parts id", "/too/little/parts/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].communityGalleryImageID")})))),
-				Entry("incorrect number of parts id", "/there/are/way/too/many/parts/in/this/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].communityGalleryImageID")})))),
-				Entry("does not start with correct prefix", "/somegallery/id/Images/myImageDefinition/versions/version", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].communityGalleryImageID")})))),
+				Entry("incorrect number of parts id", "/too/little/parts/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].communityGalleryImageID")})))),
+				Entry("incorrect number of parts id", "/there/are/way/too/many/parts/in/this/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].communityGalleryImageID")})))),
+				Entry("does not start with correct prefix", "/somegallery/id/Images/myImageDefinition/versions/version", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].communityGalleryImageID")})))),
 			)
 
 			DescribeTable("forbid unsupported sharedGalleryImageID",
@@ -171,14 +171,14 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					cloudProfileConfig.MachineImages[0].Versions[0].URN = nil
 					cloudProfileConfig.MachineImages[0].Versions[0].SharedGalleryImageID = &sharedGalleryImageID
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 					Expect(errorList).To(matcher)
 				},
 				Entry("correct id", sharedGalleryImageID, BeEmpty()),
-				Entry("incorrect number of parts id", "/too/little/parts/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID")})))),
-				Entry("incorrect number of parts id", "/there/are/way/too/many/parts/in/this/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID")})))),
-				Entry("does not start with correct prefix", "/somegallery/id/Images/myImageDefinition/versions/version", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID")})))),
+				Entry("incorrect number of parts id", "/too/little/parts/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].sharedGalleryImageID")})))),
+				Entry("incorrect number of parts id", "/there/are/way/too/many/parts/in/this/id", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].sharedGalleryImageID")})))),
+				Entry("does not start with correct prefix", "/somegallery/id/Images/myImageDefinition/versions/version", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("machineImages[0].versions[0].sharedGalleryImageID")})))),
 			)
 
 			DescribeTable("forbid invalid image reference configuration",
@@ -188,7 +188,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					cloudProfileConfig.MachineImages[0].Versions[0].SharedGalleryImageID = sharedGalleryImageID
 					cloudProfileConfig.MachineImages[0].Versions[0].CommunityGalleryImageID = communityGalleryImageID
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 					Expect(errorList).To(matcher)
 				},
@@ -198,52 +198,52 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				Entry("only valid SharedGalleryImageID", nil, nil, nil, &sharedGalleryImageID, BeEmpty()),
 				Entry("urn, id, communityGalleryImageID and sharedGalleryImageID are nil", nil, nil, nil, nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn and id are non-empty", &urn, &id, nil, nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn and communityGalleryImageID are non-empty", &urn, nil, &communityGalleryImageID, nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("id and communityGalleryImageID are non-empty", nil, &id, &communityGalleryImageID, nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("sharedGalleryImageID and communityGalleryImageID are non-empty", nil, nil, &communityGalleryImageID, &sharedGalleryImageID, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn and sharedGalleryImageID are non-empty", &urn, nil, nil, &sharedGalleryImageID, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("id and sharedGalleryImageID are non-empty", nil, &id, nil, &sharedGalleryImageID, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn, id and communityGalleryImageID are non-empty", &urn, &id, &communityGalleryImageID, nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn, id and sharedGalleryImageID are non-empty", &urn, &id, nil, &sharedGalleryImageID, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn, communityGalleryImageID and sharedGalleryImageID are non-empty", &urn, nil, &communityGalleryImageID, &sharedGalleryImageID, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("id, communityGalleryImageID and sharedGalleryImageID are non-empty", nil, &id, &communityGalleryImageID, &sharedGalleryImageID, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]")})))),
+					"Field": Equal("machineImages[0].versions[0]")})))),
 				Entry("urn, id, communityGalleryImageID and sharedGalleryImageID are empty", ptr.To(""), ptr.To(""), ptr.To(""), ptr.To(""), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]"),
+					"Field": Equal("machineImages[0].versions[0]"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0].id"),
+					"Field": Equal("machineImages[0].versions[0].id"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0].urn"),
+					"Field": Equal("machineImages[0].versions[0].urn"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0].communityGalleryImageID"),
+					"Field": Equal("machineImages[0].versions[0].communityGalleryImageID"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID"),
+					"Field": Equal("machineImages[0].versions[0].sharedGalleryImageID"),
 				})))))
 
 			It("should forbid unsupported cloud profile config image", func() {
@@ -254,39 +254,39 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					},
 				}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0].version"),
+					"Field": Equal("machineImages[0].versions[0].version"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]"),
+					"Field": Equal("machineImages[0].versions[0]"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages"),
+					"Field": Equal("spec.machineImages[0]"),
 				}))))
 			})
 
 			It("should forbid machineImage without mapping in cloud profile config", func() {
 				cloudProfileMachineImages[0].Name = "abc"
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages"),
+					"Field": Equal("spec.machineImages[0]"),
 				}))))
 			})
 
 			It("should forbid missing architecture in cpConfigMachineImages", func() {
 				cloudProfileMachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages.versions"),
+					"Field": Equal("spec.machineImages[0].versions[0]"),
 				}))))
 			})
 		})
@@ -295,11 +295,11 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			It("should enforce that at least one fault domain count has been defined", func() {
 				cloudProfileConfig.CountFaultDomains = []apisazure.DomainCount{}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.countFaultDomains"),
+					"Field": Equal("countFaultDomains"),
 				}))))
 			})
 
@@ -311,14 +311,14 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					},
 				}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.countFaultDomains[0].region"),
+					"Field": Equal("countFaultDomains[0].region"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("root.countFaultDomains[0].count"),
+					"Field": Equal("countFaultDomains[0].count"),
 				}))))
 			})
 		})
@@ -327,11 +327,11 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			It("should enforce that at least one update domain count has been defined", func() {
 				cloudProfileConfig.CountUpdateDomains = []apisazure.DomainCount{}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.countUpdateDomains"),
+					"Field": Equal("countUpdateDomains"),
 				}))))
 			})
 
@@ -343,14 +343,14 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					},
 				}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.countUpdateDomains[0].region"),
+					"Field": Equal("countUpdateDomains[0].region"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("root.countUpdateDomains[0].count"),
+					"Field": Equal("countUpdateDomains[0].count"),
 				}))))
 			})
 		})

--- a/pkg/apis/azure/validation/cloudprofile_test.go
+++ b/pkg/apis/azure/validation/cloudprofile_test.go
@@ -246,7 +246,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					"Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID"),
 				})))))
 
-			It("should forbid unsupported machine image version configuration", func() {
+			It("should forbid unsupported cloud profile config image", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{
 					{
 						Name:     "abc",
@@ -263,6 +263,17 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("root.machineImages[0].versions[0]"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("root.machineImages"),
+				}))))
+			})
+
+			It("should forbid machineImage without mapping in cloud profile config", func() {
+				cloudProfileMachineImages[0].Name = "abc"
+
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("root.machineImages"),
 				}))))

--- a/pkg/apis/azure/validation/cloudprofile_test.go
+++ b/pkg/apis/azure/validation/cloudprofile_test.go
@@ -115,7 +115,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions"),
+					"Field": Equal("root.machineImages.versions"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
 					"Field": Equal("root.machineImages[0].versions[0].architecture"),
@@ -275,7 +275,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions"),
+					"Field": Equal("root.machineImages.versions"),
 				}))))
 			})
 		})

--- a/pkg/apis/azure/validation/cloudprofile_test.go
+++ b/pkg/apis/azure/validation/cloudprofile_test.go
@@ -246,6 +246,28 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					"Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID"),
 				})))))
 
+			It("should forbid unsupported machine image version configuration", func() {
+				cloudProfileConfig.MachineImages = []apisazure.MachineImages{
+					{
+						Name:     "abc",
+						Versions: []apisazure.MachineImageVersion{{Architecture: ptr.To("amd64")}},
+					},
+				}
+
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("root.machineImages[0].versions[0].version"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("root.machineImages[0].versions[0]"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("root.machineImages"),
+				}))))
+			})
+
 			It("should forbid missing architecture in cpConfigMachineImages", func() {
 				cloudProfileMachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
 

--- a/pkg/apis/azure/validation/cloudprofile_test.go
+++ b/pkg/apis/azure/validation/cloudprofile_test.go
@@ -5,6 +5,7 @@
 package validation_test
 
 import (
+	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -17,6 +18,7 @@ import (
 )
 
 var (
+	imageName               = "ubuntu"
 	urn                     = "Publisher:Offer:Sku:Version"
 	id                      = "/subscription/id/image/id"
 	communityGalleryImageID = "/CommunityGalleries/id/Images/myImageDefinition/versions/version"
@@ -26,11 +28,25 @@ var (
 var _ = Describe("CloudProfileConfig validation", func() {
 	Describe("#ValidateCloudProfileConfig", func() {
 		var (
-			cloudProfileConfig *apisazure.CloudProfileConfig
-			root               = field.NewPath("root")
+			cloudProfileMachineImages []core.MachineImage
+			cloudProfileConfig        *apisazure.CloudProfileConfig
+			root                      = field.NewPath("root")
 		)
 
 		BeforeEach(func() {
+			cloudProfileMachineImages = []core.MachineImage{
+				{
+					Name: imageName,
+					Versions: []core.MachineImageVersion{
+						{
+							ExpirableVersion: core.ExpirableVersion{
+								Version: "Version",
+							},
+							Architectures: []string{"amd64"},
+						},
+					},
+				},
+			}
 			cloudProfileConfig = &apisazure.CloudProfileConfig{
 				CountUpdateDomains: []apisazure.DomainCount{
 					{
@@ -46,7 +62,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				},
 				MachineImages: []apisazure.MachineImages{
 					{
-						Name: "ubuntu",
+						Name: imageName,
 						Versions: []apisazure.MachineImageVersion{
 							{
 								Version:      "Version",
@@ -61,14 +77,14 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 		Context("machine image validation", func() {
 			It("should allow valid cloudProfileConfig", func() {
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 				Expect(errorList).To(BeEmpty())
 			})
 
 			It("should enforce that at least one machine image has been defined", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
@@ -79,7 +95,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			It("should forbid unsupported machine image values", func() {
 				cloudProfileConfig.MachineImages = []apisazure.MachineImages{{}}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
@@ -87,14 +103,20 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("root.machineImages[0].versions"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("root.machineImages"),
 				}))))
 			})
 
 			It("should forbid unsupported machine image architecture", func() {
 				cloudProfileConfig.MachineImages[0].Versions[0].Architecture = ptr.To("foo")
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("root.machineImages[0].versions"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
 					"Field": Equal("root.machineImages[0].versions[0].architecture"),
 				}))))
@@ -102,20 +124,9 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 			DescribeTable("forbid unsupported machine image urn",
 				func(urn string, matcher gomegatypes.GomegaMatcher) {
-					cloudProfileConfig.MachineImages = []apisazure.MachineImages{
-						{
-							Name: "my-image",
-							Versions: []apisazure.MachineImageVersion{
-								{
-									Version:      "1.2.3",
-									URN:          &urn,
-									Architecture: ptr.To("amd64"),
-								},
-							},
-						},
-					}
+					cloudProfileConfig.MachineImages[0].Versions[0].URN = &urn
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 					Expect(errorList).To(matcher)
 				},
@@ -129,20 +140,10 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 			DescribeTable("forbid unsupported machine image ID",
 				func(id string, matcher gomegatypes.GomegaMatcher) {
-					cloudProfileConfig.MachineImages = []apisazure.MachineImages{
-						{
-							Name: "my-image",
-							Versions: []apisazure.MachineImageVersion{
-								{
-									Version:      "1.2.3",
-									ID:           &id,
-									Architecture: ptr.To("amd64"),
-								},
-							},
-						},
-					}
+					cloudProfileConfig.MachineImages[0].Versions[0].URN = nil
+					cloudProfileConfig.MachineImages[0].Versions[0].ID = &id
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 					Expect(errorList).To(matcher)
 				},
@@ -152,20 +153,10 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 			DescribeTable("forbid unsupported communityGalleryImageID",
 				func(communityGalleryImageID string, matcher gomegatypes.GomegaMatcher) {
-					cloudProfileConfig.MachineImages = []apisazure.MachineImages{
-						{
-							Name: "my-communiyImage",
-							Versions: []apisazure.MachineImageVersion{
-								{
-									Version:                 "1.2.3",
-									CommunityGalleryImageID: &communityGalleryImageID,
-									Architecture:            ptr.To("amd64"),
-								},
-							},
-						},
-					}
+					cloudProfileConfig.MachineImages[0].Versions[0].URN = nil
+					cloudProfileConfig.MachineImages[0].Versions[0].CommunityGalleryImageID = &communityGalleryImageID
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 					Expect(errorList).To(matcher)
 				},
@@ -177,20 +168,10 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 			DescribeTable("forbid unsupported sharedGalleryImageID",
 				func(sharedGalleryImageID string, matcher gomegatypes.GomegaMatcher) {
-					cloudProfileConfig.MachineImages = []apisazure.MachineImages{
-						{
-							Name: "my-communiyImage",
-							Versions: []apisazure.MachineImageVersion{
-								{
-									Version:              "1.2.3",
-									SharedGalleryImageID: &sharedGalleryImageID,
-									Architecture:         ptr.To("amd64"),
-								},
-							},
-						},
-					}
+					cloudProfileConfig.MachineImages[0].Versions[0].URN = nil
+					cloudProfileConfig.MachineImages[0].Versions[0].SharedGalleryImageID = &sharedGalleryImageID
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 					Expect(errorList).To(matcher)
 				},
@@ -202,23 +183,12 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 			DescribeTable("forbid invalid image reference configuration",
 				func(urn, id *string, communityGalleryImageID *string, sharedGalleryImageID *string, matcher gomegatypes.GomegaMatcher) {
-					cloudProfileConfig.MachineImages = []apisazure.MachineImages{
-						{
-							Name: "my-image",
-							Versions: []apisazure.MachineImageVersion{
-								{
-									Version:                 "1.2.3",
-									ID:                      id,
-									CommunityGalleryImageID: communityGalleryImageID,
-									SharedGalleryImageID:    sharedGalleryImageID,
-									URN:                     urn,
-									Architecture:            ptr.To("amd64"),
-								},
-							},
-						},
-					}
+					cloudProfileConfig.MachineImages[0].Versions[0].ID = id
+					cloudProfileConfig.MachineImages[0].Versions[0].URN = urn
+					cloudProfileConfig.MachineImages[0].Versions[0].SharedGalleryImageID = sharedGalleryImageID
+					cloudProfileConfig.MachineImages[0].Versions[0].CommunityGalleryImageID = communityGalleryImageID
 
-					errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+					errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 					Expect(errorList).To(matcher)
 				},
@@ -276,22 +246,14 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					"Field": Equal("root.machineImages[0].versions[0].sharedGalleryImageID"),
 				})))))
 
-			It("should forbid unsupported machine image version configuration", func() {
-				cloudProfileConfig.MachineImages = []apisazure.MachineImages{
-					{
-						Name:     "abc",
-						Versions: []apisazure.MachineImageVersion{{Architecture: ptr.To("amd64")}},
-					},
-				}
+			It("should forbid missing architecture in cpConfigMachineImages", func() {
+				cloudProfileMachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0].version"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("root.machineImages[0].versions[0]"),
+					"Field": Equal("root.machineImages[0].versions"),
 				}))))
 			})
 		})
@@ -300,7 +262,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			It("should enforce that at least one fault domain count has been defined", func() {
 				cloudProfileConfig.CountFaultDomains = []apisazure.DomainCount{}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
@@ -316,7 +278,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					},
 				}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
@@ -332,7 +294,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			It("should enforce that at least one update domain count has been defined", func() {
 				cloudProfileConfig.CountUpdateDomains = []apisazure.DomainCount{}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
@@ -348,7 +310,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					},
 				}
 
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, root)
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, cloudProfileMachineImages, root)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
We should validate that all images in cloudProfile are valid images in the cloudProfileConfig 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Validate that all images in cloudProfile are valid images in the cloudProfileConfig 
```
