### PR TITLE
Validate `NamespacedCloudProfile` `MachineImage` architectures against providerConfig

### DIFF
--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -7,6 +7,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -17,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -123,11 +125,13 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 		}
 		for _, version := range machineImage.Versions {
 			_, existsInParent := parentImages.GetImageVersion(machineImage.Name, version.Version)
-			if _, exists := providerImages.GetImageVersion(machineImage.Name, version.Version); !existsInParent && !exists {
-				allErrs = append(allErrs, field.Required(
-					field.NewPath("spec.providerConfig.machineImages"),
-					fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
-				))
+			for _, expectedArchitecture := range version.Architectures {
+				if _, exists := providerImages.GetImageVersion(machineImage.Name, versionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
+					allErrs = append(allErrs, field.Required(
+						field.NewPath("spec.providerConfig.machineImages"),
+						fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
+					))
+				}
 			}
 		}
 	}
@@ -152,11 +156,20 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 			continue
 		}
 		for versionIdx, version := range machineImage.Versions {
-			if _, exists := profileImages.GetImageVersion(machineImage.Name, version.Version); !exists {
+			profileImageVersion, exists := profileImages.GetImageVersion(machineImage.Name, version.Version)
+			if !exists {
 				allErrs = append(allErrs, field.Invalid(
 					field.NewPath("spec.providerConfig.machineImages").Index(imageIdx).Child("versions").Index(versionIdx),
 					fmt.Sprintf("%s@%s", machineImage.Name, version.Version),
 					"machine image version is not defined in the NamespacedCloudProfile",
+				))
+			}
+			providerConfigArchitecture := ptr.Deref(version.Architecture, constants.ArchitectureAMD64)
+			if !slices.Contains(profileImageVersion.Architectures, providerConfigArchitecture) {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec.providerConfig.machineImages"),
+					fmt.Sprintf("machine image version %s@%s has an excess entry for architecture %q, which is not defined in the machineImages spec",
+						machineImage.Name, version.Version, providerConfigArchitecture),
 				))
 			}
 		}
@@ -165,11 +178,19 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 	return allErrs
 }
 
+func providerMachineImageKey(v api.MachineImageVersion) string {
+	return versionArchitectureKey(v.Version, ptr.Deref(v.Architecture, constants.ArchitectureAMD64))
+}
+
+func versionArchitectureKey(version, architecture string) string {
+	return version + "-" + architecture
+}
+
 func newProviderImagesContext(providerImages []api.MachineImages) *util.ImagesContext[api.MachineImages, api.MachineImageVersion] {
 	return util.NewImagesContext(
 		utils.CreateMapFromSlice(providerImages, func(mi api.MachineImages) string { return mi.Name }),
 		func(mi api.MachineImages) map[string]api.MachineImageVersion {
-			return utils.CreateMapFromSlice(mi.Versions, func(v api.MachineImageVersion) string { return v.Version })
+			return utils.CreateMapFromSlice(mi.Versions, func(v api.MachineImageVersion) string { return providerMachineImageKey(v) })
 		},
 	)
 }

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -101,11 +101,11 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
 				{
 					Name:     "image-1",
-					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "1.1"}}},
+					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "1.1"}, Architectures: []string{"amd64"}}},
 				},
 				{
 					Name:     "image-2",
-					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "2.0"}}},
+					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "2.0"}, Architectures: []string{"amd64"}}},
 				},
 			}
 			namespacedCloudProfile.Spec.MachineTypes = []core.MachineType{
@@ -147,7 +147,7 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				{
 					Name: "image-1",
 					Versions: []core.MachineImageVersion{
-						{ExpirableVersion: core.ExpirableVersion{Version: "1.0"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.0"}, Architectures: []string{"amd64"}},
 					},
 				},
 			}
@@ -179,7 +179,7 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				{
 					Name: "image-1",
 					Versions: []core.MachineImageVersion{
-						{ExpirableVersion: core.ExpirableVersion{Version: "1.2"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.2"}, Architectures: []string{"amd64"}},
 					},
 				},
 			}
@@ -196,6 +196,10 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				"Field":    Equal("spec.providerConfig.machineImages[0].versions[0]"),
 				"BadValue": Equal("image-1@1.1"),
 				"Detail":   Equal("machine image version is not defined in the NamespacedCloudProfile"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1 has an excess entry for architecture \"amd64\", which is not defined in the machineImages spec"),
 			}))))
 		})
 
@@ -225,7 +229,7 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				{
 					Name: "image-3",
 					Versions: []core.MachineImageVersion{
-						{ExpirableVersion: core.ExpirableVersion{Version: "3.0"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "3.0"}, Architectures: []string{"amd64"}},
 					},
 				},
 			}
@@ -237,6 +241,47 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("spec.providerConfig.machineImages"),
 				"Detail": Equal("machine image image-3 is not defined in the NamespacedCloudProfile providerConfig"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying new spec.machineImages without the according version and architecture entries in the provider config", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[
+	{"version":"1.1","id":"image-id-1","architecture":"arm64"},
+	{"version":"1.1","id":"image-id-2","architecture":"amd64"},
+    {"version":"1.1-fallback","id":"image-id-3"}
+  ]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1"}, Architectures: []string{"amd64", "arm64"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-fallback"}, Architectures: []string{"arm64"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-missing"}, Architectures: []string{"arm64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-fallback has an excess entry for architecture \"amd64\", which is not defined in the machineImages spec"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-fallback is not defined in the NamespacedCloudProfile providerConfig"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-missing is not defined in the NamespacedCloudProfile providerConfig"),
 			}))))
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Validate machine image version architectures in machine images spec and provider config.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @hebelsan 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
