### PR TITLE
Availability set deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/dev
 /bin
 hack/tools/bin
+/.run
 
 *.coverprofile
 *.html

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ start-admission:
 		./cmd/$(EXTENSION_PREFIX)-$(ADMISSION_NAME) \
 		--webhook-config-server-host=0.0.0.0 \
 		--webhook-config-server-port=$(WEBHOOK_CONFIG_PORT) \
+		--leader-election-namespace=garden \
         --webhook-config-mode=$(WEBHOOK_CONFIG_MODE) \
         $(WEBHOOK_PARAM)
 

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1021,7 +1021,20 @@ ResourceGroup
 </em>
 </td>
 <td>
-<p>AvailabilitySets is a list of created availability sets</p>
+<p>AvailabilitySets is a list of created availability sets
+Deprecated: Will be removed in future versions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>migratingToVMO</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>MigratingToVMO indicates whether the infrastructure controller has prepared the migration from Availability set.
+Deprecated: Will be removed in future versions.</p>
 </td>
 </tr>
 <tr>
@@ -1034,7 +1047,7 @@ ResourceGroup
 </em>
 </td>
 <td>
-<p>AvailabilitySets is a list of created route tables</p>
+<p>RouteTables is a list of created route tables</p>
 </td>
 </tr>
 <tr>

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
-	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	azurevalidation "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/validation"
 )
 
@@ -114,7 +113,7 @@ func (s *shoot) validateShoot(shoot *core.Shoot, oldInfraConfig, infraConfig *ap
 		// Cloudprofile validation
 		allErrs = append(allErrs, azurevalidation.ValidateInfrastructureConfigAgainstCloudProfile(oldInfraConfig, infraConfig, shoot.Spec.Region, cloudProfileSpec, infraConfigPath)...)
 		// Provider validation
-		allErrs = append(allErrs, azurevalidation.ValidateInfrastructureConfig(infraConfig, shoot.Spec.Networking, helper.HasShootVmoAlphaAnnotation(shoot.Annotations), infraConfigPath)...)
+		allErrs = append(allErrs, azurevalidation.ValidateInfrastructureConfig(infraConfig, shoot, infraConfigPath)...)
 	}
 	if cpConfig != nil {
 		allErrs = append(allErrs, azurevalidation.ValidateControlPlaneConfig(cpConfig, shoot.Spec.Kubernetes.Version, cpConfigPath)...)
@@ -169,7 +168,6 @@ func (s *shoot) validateUpdate(oldShoot, shoot *core.Shoot, cloudProfileSpec *ga
 		allErrs = append(allErrs, azurevalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, metaDataPath)...)
 	}
 
-	allErrs = append(allErrs, azurevalidation.ValidateVmoConfigUpdate(helper.HasShootVmoAlphaAnnotation(oldShoot.Annotations), helper.HasShootVmoAlphaAnnotation(shoot.Annotations), metaDataPath)...)
 	allErrs = append(allErrs, azurevalidation.ValidateWorkersUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, workersPath)...)
 
 	allErrs = append(allErrs, s.validateShoot(shoot, oldInfraConfig, infraConfig, cloudProfileSpec, cpConfig)...)

--- a/pkg/apis/azure/helper/helper.go
+++ b/pkg/apis/azure/helper/helper.go
@@ -125,9 +125,19 @@ func FindImageFromCloudProfile(cloudProfileConfig *api.CloudProfileConfig, image
 	return nil, fmt.Errorf("no machine image found with name %q, architecture %q and version %q", imageName, *architecture, imageVersion)
 }
 
-// IsVmoRequired determines if VMO is required.
+// IsVmoRequired determines if VMO is required. It is different from the condition in the infrastructure as this one depends on whether the infra controller
+// has finished migrating the Availability sets.
 func IsVmoRequired(infrastructureStatus *api.InfrastructureStatus) bool {
-	return !infrastructureStatus.Zoned && len(infrastructureStatus.AvailabilitySets) == 0
+	return !infrastructureStatus.Zoned && (len(infrastructureStatus.AvailabilitySets) == 0 || infrastructureStatus.MigratingToVMO)
+}
+
+// HasShootVmoMigrationAnnotation determines if the passed Shoot annotations contain instruction to use VMO.
+func HasShootVmoMigrationAnnotation(shootAnnotations map[string]string) bool {
+	value, exists := shootAnnotations[azure.ShootVmoMigrationAnnotation]
+	if exists && value == "true" {
+		return true
+	}
+	return false
 }
 
 // HasShootVmoAlphaAnnotation determines if the passed Shoot annotations contain instruction to use VMO.

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -105,8 +105,12 @@ type InfrastructureStatus struct {
 	// ResourceGroup is azure resource group
 	ResourceGroup ResourceGroup
 	// AvailabilitySets is a list of created availability sets
+	// Deprecated: Will be removed in future versions.
 	AvailabilitySets []AvailabilitySet
-	// AvailabilitySets is a list of created route tables
+	// MigratingToVMO indicates whether the infrastructure controller has prepared the migration from Availability set.
+	// Deprecated: Will be removed in future versions.
+	MigratingToVMO bool
+	// RouteTables is a list of created route tables
 	RouteTables []RouteTable
 	// SecurityGroups is a list of created security groups
 	SecurityGroups []SecurityGroup

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -118,8 +118,12 @@ type InfrastructureStatus struct {
 	// ResourceGroup is azure resource group
 	ResourceGroup ResourceGroup `json:"resourceGroup"`
 	// AvailabilitySets is a list of created availability sets
+	// Deprecated: Will be removed in future versions.
 	AvailabilitySets []AvailabilitySet `json:"availabilitySets"`
-	// AvailabilitySets is a list of created route tables
+	// MigratingToVMO indicates whether the infrastructure controller has prepared the migration from Availability set.
+	// Deprecated: Will be removed in future versions.
+	MigratingToVMO bool `json:"migratingToVMO,omitempty"`
+	// RouteTables is a list of created route tables
 	RouteTables []RouteTable `json:"routeTables"`
 	// SecurityGroups is a list of created security groups
 	SecurityGroups []SecurityGroup `json:"securityGroups"`

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -758,6 +758,7 @@ func autoConvert_v1alpha1_InfrastructureStatus_To_azure_InfrastructureStatus(in 
 		return err
 	}
 	out.AvailabilitySets = *(*[]azure.AvailabilitySet)(unsafe.Pointer(&in.AvailabilitySets))
+	out.MigratingToVMO = in.MigratingToVMO
 	out.RouteTables = *(*[]azure.RouteTable)(unsafe.Pointer(&in.RouteTables))
 	out.SecurityGroups = *(*[]azure.SecurityGroup)(unsafe.Pointer(&in.SecurityGroups))
 	out.Identity = (*azure.IdentityStatus)(unsafe.Pointer(in.Identity))
@@ -778,6 +779,7 @@ func autoConvert_azure_InfrastructureStatus_To_v1alpha1_InfrastructureStatus(in 
 		return err
 	}
 	out.AvailabilitySets = *(*[]AvailabilitySet)(unsafe.Pointer(&in.AvailabilitySets))
+	out.MigratingToVMO = in.MigratingToVMO
 	out.RouteTables = *(*[]RouteTable)(unsafe.Pointer(&in.RouteTables))
 	out.SecurityGroups = *(*[]SecurityGroup)(unsafe.Pointer(&in.SecurityGroups))
 	out.Identity = (*IdentityStatus)(unsafe.Pointer(in.Identity))

--- a/pkg/azure/client/loadbalancers.go
+++ b/pkg/azure/client/loadbalancers.go
@@ -25,6 +25,15 @@ func NewLoadBalancersClient(auth internal.ClientAuth, tc azcore.TokenCredential,
 	return &LoadBalancersClient{client}, err
 }
 
+// Get gets a given virtual load balancer by name
+func (c *LoadBalancersClient) Get(ctx context.Context, resourceGroupName, name string) (*armnetwork.LoadBalancer, error) {
+	res, err := c.client.Get(ctx, resourceGroupName, name, nil)
+	if err != nil {
+		return nil, FilterNotFoundError(err)
+	}
+	return &res.LoadBalancer, err
+}
+
 // List lists all subnets of a given virtual network.
 func (c *LoadBalancersClient) List(ctx context.Context, resourceGroupName string) ([]*armnetwork.LoadBalancer, error) {
 	pager := c.client.NewListPager(resourceGroupName, nil)

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -125,6 +125,7 @@ type Subnet interface {
 
 // LoadBalancer represents an Azure LoadBalancer k8sClient.
 type LoadBalancer interface {
+	GetFunc[armnetwork.LoadBalancer]
 	ListFunc[armnetwork.LoadBalancer]
 	DeleteFunc[armnetwork.LoadBalancer]
 }

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -14,6 +14,8 @@ const (
 
 	// ShootVmoUsageAnnotation is an annotation assigned to the Shoot resource which indicates if VMO should be used.
 	ShootVmoUsageAnnotation = "alpha.azure.provider.extensions.gardener.cloud/vmo"
+	// ShootVmoMigrationAnnotation is an annotation assigned to the Shoot resource which indicates if the availability set shoot, should be migrated to a VMO shoot.
+	ShootVmoMigrationAnnotation = "migration.azure.provider.extensions.gardener.cloud/vmo"
 
 	// NetworkLayoutZoneMigrationAnnotation is used when migrating from a single subnet network layout to a multiple subnet network layout to indicate the zone that the existing subnet should be assigned to.
 	NetworkLayoutZoneMigrationAnnotation = "migration.azure.provider.extensions.gardener.cloud/zone"

--- a/pkg/controller/infrastructure/infraflow/const.go
+++ b/pkg/controller/infrastructure/infraflow/const.go
@@ -17,4 +17,8 @@ const (
 	KeyManagedIdentityClientId = "managed_identity_client_id"
 	// KeyManagedIdentityId is a key for the MI's identity ID.
 	KeyManagedIdentityId = "managed_identity_id"
+	// ChildKeyMigration is the prefix key for data stored during migrations.
+	ChildKeyMigration = "migration"
+	// ChildKeyComplete is a key to indicate whether a task is complete.
+	ChildKeyComplete = "complete"
 )

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -178,7 +178,7 @@ func (fctx *FlowContext) EnsureAvailabilitySet(ctx context.Context) error {
 	}
 
 	// complete AS migration.
-	if v := fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Get("complete"); v != nil && *v == "true" {
+	if v := fctx.whiteboard.GetChild(ChildKeyMigration).GetChild(KindAvailabilitySet.String()).Get(ChildKeyComplete); v != nil && *v == "true" {
 		err := fctx.deleteAvailabilitySet(ctx, log)
 		if err != nil {
 			return err
@@ -750,7 +750,7 @@ func (fctx *FlowContext) MigrateAvailabilitySet(ctx context.Context) error {
 	)
 
 	// return early if the migration has already been complete
-	if v := fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Get("complete"); v != nil && *v == "true" {
+	if v := fctx.whiteboard.GetChild(ChildKeyMigration).GetChild(KindAvailabilitySet.String()).Get(ChildKeyComplete); v != nil && *v == "true" {
 		return nil
 	}
 	// return early if the cluster does not have AS.
@@ -820,7 +820,7 @@ func (fctx *FlowContext) MigrateAvailabilitySet(ctx context.Context) error {
 	if err := fctx.UpdatePublicIPs(ctx); err != nil {
 		return err
 	}
-	fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Set("complete", "true")
+	fctx.whiteboard.GetChild(ChildKeyMigration).GetChild(KindAvailabilitySet.String()).Set(ChildKeyComplete, "true")
 	return fctx.PersistState(ctx)
 }
 
@@ -890,7 +890,7 @@ func (fctx *FlowContext) GetInfrastructureStatus(_ context.Context) (*v1alpha1.I
 				CountUpdateDomains: cfg.CountUpdateDomains,
 			},
 		}
-		if v := fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Get("complete"); v != nil && *v == "true" {
+		if v := fctx.whiteboard.GetChild(ChildKeyMigration).GetChild(KindAvailabilitySet.String()).Get(ChildKeyComplete); v != nil && *v == "true" {
 			status.MigratingToVMO = true
 		}
 	}

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -808,12 +808,15 @@ func (fctx *FlowContext) MigrateAvailabilitySet(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Info("Deleting load balancer", "Name", fctx.infra.Namespace)
-	if err := loadbalancerClient.Delete(ctx, fctx.adapter.ResourceGroupName(), fctx.adapter.TechnicalName()); err != nil {
+	loadbalancerName := fctx.adapter.TechnicalName()
+	log.Info("Deleting load balancer", "Name", loadbalancerName)
+	if err := loadbalancerClient.Delete(ctx, fctx.adapter.ResourceGroupName(), loadbalancerName); err != nil {
 		return err
 	}
-	log.Info("Deleting internal load balancer", "Name", fctx.infra.Namespace)
-	if err := loadbalancerClient.Delete(ctx, fctx.adapter.ResourceGroupName(), fmt.Sprintf("%s-internal", fctx.adapter.TechnicalName())); err != nil {
+
+	loadbalancerName = fmt.Sprintf("%s-internal", fctx.adapter.TechnicalName())
+	log.Info("Deleting internal load balancer", "Name", loadbalancerName)
+	if err := loadbalancerClient.Delete(ctx, fctx.adapter.ResourceGroupName(), loadbalancerName); err != nil {
 		return err
 	}
 

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -771,7 +772,7 @@ func (fctx *FlowContext) MigrateAvailabilitySet(ctx context.Context) error {
 			Name:      azure.CloudControllerManagerName,
 		}, deployment); k8sclient.IgnoreNotFound(err) != nil {
 			return err
-		} else if k8sclient.IgnoreNotFound(err) != nil {
+		} else if err != nil && apierrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -8,18 +8,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/controller/infrastructure/infraflow/shared"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/internal/infrastructure"
@@ -171,7 +176,16 @@ func (fctx *FlowContext) EnsureAvailabilitySet(ctx context.Context) error {
 		return nil
 	}
 
-	avset, err := fctx.ensureAvailabilitySet(ctx, log, *avsetCfg)
+	// complete AS migration.
+	if v := fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Get("complete"); v != nil && *v == "true" {
+		err := fctx.deleteAvailabilitySet(ctx, log)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	avset, err := fctx.ensureAvailabilitySet(ctx, log)
 	if err != nil {
 		return err
 	}
@@ -183,13 +197,41 @@ func (fctx *FlowContext) EnsureAvailabilitySet(ctx context.Context) error {
 	fctx.whiteboard.GetChild(ChildKeyIDs).Set(KindAvailabilitySet.String(), *avset.ID)
 	return nil
 }
+func (fctx *FlowContext) deleteAvailabilitySet(ctx context.Context, log logr.Logger) error {
+	// try to delete the availability set. It can only  work if it does not contain any VMs.
+	asClient, err := fctx.factory.AvailabilitySet()
+	if err != nil {
+		return err
+	}
 
-func (fctx *FlowContext) ensureAvailabilitySet(ctx context.Context, log logr.Logger, avsetCfg AvailabilitySetConfig) (*armcompute.AvailabilitySet, error) {
+	av, err := asClient.Get(ctx, fctx.adapter.AvailabilitySetConfig().ResourceGroup, fctx.adapter.AvailabilitySetConfig().Name)
+	if err != nil {
+		return err
+	}
+	if av == nil {
+		return nil
+	}
+	// if the AS contains no VMs then we attempt to delete it and complete the migration
+	if len(av.Properties.VirtualMachines) == 0 {
+		log.Info("Deleting Availability Set", "Name", *av.Name)
+		if err := asClient.Delete(ctx, fctx.adapter.ResourceGroupName(), *av.Name); err != nil {
+			return err
+		}
+		fctx.whiteboard.GetChild(ChildKeyIDs).Delete(KindAvailabilitySet.String())
+		fctx.inventory.Delete(*av.ID)
+		return nil
+	}
+	log.Info("Skipping deleting Availability Set because it still contains VMs", "Name", *av.Name)
+	return nil
+}
+
+func (fctx *FlowContext) ensureAvailabilitySet(ctx context.Context, log logr.Logger) (*armcompute.AvailabilitySet, error) {
 	asClient, err := fctx.factory.AvailabilitySet()
 	if err != nil {
 		return nil, err
 	}
 
+	avsetCfg := fctx.adapter.AvailabilitySetConfig()
 	avset, err := asClient.Get(ctx, avsetCfg.ResourceGroup, avsetCfg.Name)
 	if err != nil {
 		return nil, err
@@ -699,6 +741,88 @@ func (fctx *FlowContext) EnsureManagedIdentity(ctx context.Context) (err error) 
 	return err
 }
 
+// MigrateAvailabilitySet prepares an AS-based shoot to be migrated to VMSS-Flex.
+func (fctx *FlowContext) MigrateAvailabilitySet(ctx context.Context) error {
+	var (
+		log = shared.LogFromContext(ctx)
+		c   = fctx.client
+	)
+
+	// return early if the migration has already been complete
+	if v := fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Get("complete"); v != nil && *v == "true" {
+		return nil
+	}
+	// return early if the cluster does not have AS.
+	if fctx.whiteboard.GetChild(ChildKeyIDs).Get(KindAvailabilitySet.String()) == nil {
+		return nil
+	}
+
+	// IF VMOs are not needed, or the migration is already done, return early.
+	if !helper.HasShootVmoMigrationAnnotation(fctx.cluster.Shoot.GetAnnotations()) {
+		return nil
+	}
+
+	log.Info("Preparing for the migration to VMOs")
+	scaleDownDeployment := func(ctx context.Context, key k8sclient.ObjectKey) error {
+		log.Info("Scaling deployment to 0 replicas", "Name", key.String())
+		deployment := &appsv1.Deployment{}
+		if err := fctx.client.Get(ctx, k8sclient.ObjectKey{
+			Namespace: fctx.infra.Namespace,
+			Name:      azure.CloudControllerManagerName,
+		}, deployment); k8sclient.IgnoreNotFound(err) != nil {
+			return err
+		} else if k8sclient.IgnoreNotFound(err) != nil {
+			return nil
+		}
+
+		if ptr.Deref(deployment.Spec.Replicas, 1) == 0 {
+			return nil
+		}
+		patch := k8sclient.MergeFrom(deployment.DeepCopy())
+		deployment.Spec.Replicas = ptr.To(int32(0))
+		// Apply the patch on the "scale" subresource
+		if err := c.SubResource("scale").Patch(ctx, deployment, patch); err != nil {
+			return fmt.Errorf("failed to patch deployment %s with replicas: %w", key.String(), err)
+		}
+		return nil
+	}
+
+	if err := flow.Parallel(func(ctx context.Context) error {
+		return scaleDownDeployment(ctx, k8sclient.ObjectKey{Namespace: fctx.infra.Namespace, Name: azure.CloudControllerManagerName})
+	}, func(ctx context.Context) error {
+		// we want to scale CA down to avoid VMs getting created as they may claim internal subnet IPs in the case of an existing internal loadbalancer.
+		return scaleDownDeployment(ctx, k8sclient.ObjectKey{Namespace: fctx.infra.Namespace, Name: "cluster-autoscaler"})
+	}).RetryUntilTimeout(5*time.Second, defaultTimeout)(ctx); err != nil {
+		return err
+	}
+
+	log.Info("Backing-up Public IPs to be migrated")
+	// we will first back up the PIPs that we want to migrate. In the simplest case, we would only migrate PIPs in the shoot's RG. But the loadbalancer may reference PIPs from other RGs.
+	// If we delete the LB we would have no way to recover the PIPs in other RGs, hence we will back it up.
+	if err := fctx.BackupPIPsForBasicLBMigration(ctx); err != nil {
+		return err
+	}
+
+	loadbalancerClient, err := fctx.factory.LoadBalancer()
+	if err != nil {
+		return err
+	}
+	log.Info("Deleting load balancer", "Name", fctx.infra.Namespace)
+	if err := loadbalancerClient.Delete(ctx, fctx.adapter.ResourceGroupName(), fctx.adapter.TechnicalName()); err != nil {
+		return err
+	}
+	log.Info("Deleting internal load balancer", "Name", fctx.infra.Namespace)
+	if err := loadbalancerClient.Delete(ctx, fctx.adapter.ResourceGroupName(), fmt.Sprintf("%s-internal", fctx.adapter.TechnicalName())); err != nil {
+		return err
+	}
+
+	if err := fctx.UpdatePublicIPs(ctx); err != nil {
+		return err
+	}
+	fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Set("complete", "true")
+	return fctx.PersistState(ctx)
+}
+
 // GetInfrastructureStatus returns the infrastructure status.
 func (fctx *FlowContext) GetInfrastructureStatus(_ context.Context) (*v1alpha1.InfrastructureStatus, error) {
 	status := &v1alpha1.InfrastructureStatus{
@@ -754,7 +878,8 @@ func (fctx *FlowContext) GetInfrastructureStatus(_ context.Context) (*v1alpha1.I
 	}
 	status.Networks.OutboundAccessType = outboundAccessType
 
-	if cfg := fctx.adapter.AvailabilitySetConfig(); cfg != nil {
+	if fctx.whiteboard.GetChild(ChildKeyIDs).Get(KindAvailabilitySet.String()) != nil {
+		cfg := fctx.adapter.AvailabilitySetConfig()
 		status.AvailabilitySets = []v1alpha1.AvailabilitySet{
 			{
 				Purpose:            v1alpha1.PurposeNodes,
@@ -763,6 +888,9 @@ func (fctx *FlowContext) GetInfrastructureStatus(_ context.Context) (*v1alpha1.I
 				CountFaultDomains:  cfg.CountFaultDomains,
 				CountUpdateDomains: cfg.CountUpdateDomains,
 			},
+		}
+		if v := fctx.whiteboard.GetChild("migration").GetChild(KindAvailabilitySet.String()).Get("complete"); v != nil && *v == "true" {
+			status.MigratingToVMO = true
 		}
 	}
 
@@ -782,6 +910,7 @@ func (fctx *FlowContext) GetInfrastructureState() *runtime.RawExtension {
 	state := &v1alpha1.InfrastructureState{
 		TypeMeta:     helper.InfrastructureStateTypeMeta,
 		ManagedItems: fctx.inventory.ToList(),
+		Data:         fctx.whiteboard.ExportAsFlatMap(),
 	}
 
 	return &runtime.RawExtension{

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -171,11 +171,6 @@ func (ia *InfrastructureAdapter) IsAvailabilitySetReconciliationRequired() bool 
 	return false
 }
 
-// IsVmoRequiredForInfrastructure determines if VMO is required.
-func (ia *InfrastructureAdapter) IsVmoRequiredForInfrastructure() bool {
-	return !ia.config.Zoned && (len(ia.status.AvailabilitySets) == 0 || helper.HasShootVmoMigrationAnnotation(ia.cluster.Shoot.GetAnnotations()))
-}
-
 // AvailabilitySetConfig returns the configuration for the shoot's availability set.
 func (ia *InfrastructureAdapter) AvailabilitySetConfig() *AvailabilitySetConfig {
 	return ia.avSetConfig

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -162,7 +162,7 @@ func (ia *InfrastructureAdapter) IsAvailabilitySetReconciliationRequired() bool 
 	if ia.config.Zoned {
 		return false
 	}
-	// If the infrastructureStatus already exists that mean the Infrastucture is already created.
+	// If the infrastructureStatus already exists that means the Infrastructure is already created.
 	if len(ia.status.AvailabilitySets) > 0 {
 		if _, err := helper.FindAvailabilitySetByPurpose(ia.status.AvailabilitySets, azure.PurposeNodes); err == nil {
 			return true

--- a/pkg/controller/infrastructure/infraflow/migrations.go
+++ b/pkg/controller/infrastructure/infraflow/migrations.go
@@ -35,9 +35,6 @@ func (fctx *FlowContext) BackupPIPsForBasicLBMigration(ctx context.Context) erro
 		len(lb.Properties.FrontendIPConfigurations) == 0 {
 		return nil
 	}
-	if lb.Properties == nil || len(lb.Properties.FrontendIPConfigurations) == 0 {
-		return nil
-	}
 	for _, fipc := range lb.Properties.FrontendIPConfigurations {
 		if fipc.Properties == nil {
 			continue

--- a/pkg/controller/infrastructure/infraflow/migrations.go
+++ b/pkg/controller/infrastructure/infraflow/migrations.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package infraflow
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+
+	"github.com/gardener/gardener-extension-provider-azure/pkg/controller/infrastructure/infraflow/shared"
+)
+
+// BackupPIPsForBasicLBMigration saves the Public IPs attached to the basic load balancer of the shoot to the state.
+func (fctx *FlowContext) BackupPIPsForBasicLBMigration(ctx context.Context) error {
+	loadbalancerClient, err := fctx.factory.LoadBalancer()
+	if err != nil {
+		return err
+	}
+	lb, err := loadbalancerClient.Get(ctx, fctx.adapter.ResourceGroupName(), fctx.infra.Namespace)
+	if err != nil {
+		return err
+	}
+	// if we don't find the loadbalancer or some properties are missing, exit early
+	if lb == nil ||
+		lb.SKU == nil ||
+		lb.SKU.Name == nil ||
+		*lb.SKU.Name != armnetwork.LoadBalancerSKUNameBasic ||
+		lb.Properties == nil ||
+		len(lb.Properties.FrontendIPConfigurations) == 0 {
+		return nil
+	}
+	if lb.Properties == nil || len(lb.Properties.FrontendIPConfigurations) == 0 {
+		return nil
+	}
+	for _, fipc := range lb.Properties.FrontendIPConfigurations {
+		if fipc.Properties == nil {
+			continue
+		}
+		if fipc.Properties.PublicIPAddress != nil {
+			resourceID, err := arm.ParseResourceID(*fipc.Properties.PublicIPAddress.ID)
+			if err != nil {
+				return err
+			}
+			fctx.whiteboard.GetChild("migration").GetChild("basic-lb").GetChild(resourceID.ResourceGroupName).Set(resourceID.Name, "true")
+		}
+	}
+	return fctx.PersistState(ctx)
+}
+
+// UpdatePublicIPs updates the public IPs saved in the state from basic to standard SKU.
+func (fctx *FlowContext) UpdatePublicIPs(ctx context.Context) error {
+	log := shared.LogFromContext(ctx)
+	ipc, err := fctx.factory.PublicIP()
+	if err != nil {
+		return err
+	}
+	var (
+		wg   = sync.WaitGroup{}
+		errs error
+	)
+	for _, resourceGroup := range fctx.whiteboard.GetChild("migration").GetChild("basic-lb").GetChildrenKeys() {
+		for _, pipName := range fctx.whiteboard.GetChild("migration").GetChild("basic-lb").GetChild(resourceGroup).Keys() {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pip, err := ipc.Get(ctx, resourceGroup, pipName, nil)
+				if err != nil {
+					errs = errors.Join(err)
+					return
+				}
+				if pip == nil || pip.SKU == nil || pip.SKU.Name == nil || *pip.SKU.Name != armnetwork.PublicIPAddressSKUNameBasic {
+					return
+				}
+				pip.SKU = &armnetwork.PublicIPAddressSKU{
+					Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard),
+					Tier: to.Ptr(armnetwork.PublicIPAddressSKUTierRegional),
+				}
+				log.Info("upgrading basic PIP", "ResourceGroup", resourceGroup, "Name", pipName)
+				_, err = ipc.CreateOrUpdate(ctx, resourceGroup, pipName, *pip)
+				if err != nil {
+					errs = errors.Join(err)
+					return
+				}
+				// removing upgraded PIP from state.
+				fctx.whiteboard.GetChild("migration").GetChild("basic-lb").GetChild(resourceGroup).Delete(pipName)
+			}()
+		}
+	}
+	wg.Wait()
+	return errs
+}

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard.go
@@ -14,10 +14,13 @@ import (
 )
 
 const (
-	// Separator is used to on translating keys to/from flat maps
-	Separator = "/"
 	// deleted is a special value to mark a resource id as deleted
 	deleted = "<deleted>"
+)
+
+var (
+	// Separator is used to on translating keys to/from flat maps
+	Separator = "/"
 )
 
 // FlatMap is a semantic name for string map used for importing and exporting

--- a/pkg/controller/worker/machine_dependencies_test.go
+++ b/pkg/controller/worker/machine_dependencies_test.go
@@ -83,9 +83,6 @@ var _ = Describe("MachinesDependencies", func() {
 
 			faultDomainCount = 3
 			cluster = makeCluster("", "westeurope", nil, nil, faultDomainCount)
-			cluster.Shoot.Annotations = map[string]string{
-				azure.ShootVmoUsageAnnotation: "true",
-			}
 			infrastructureStatus = makeInfrastructureStatus(resourceGroupName, "vnet-name", "subnet-name", false, nil, nil, nil)
 			pool = extensionsv1alpha1.WorkerPool{
 				Name: "my-pool",

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Terraform", func() {
 					},
 				},
 			},
+			Status: extensionsv1alpha1.InfrastructureStatus{},
 		}
 
 		cluster = MakeCluster("11.0.0.0/16", "12.0.0.0/16", infra.Spec.Region, countFaultDomain, countUpdateDomain)

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -299,54 +299,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("Infrastructure tests", func() {
-	Context("AvailabilitySet cluster", func() {
-		AfterEach(func() {
-			framework.RunCleanupActions()
-		})
-
-		It("should successfully create and delete AvailabilitySet cluster creating new vNet", func() {
-			providerConfig := newInfrastructureConfig(nil, nil, nil, false)
-
-			namespace, err := generateName()
-			Expect(err).ToNot(HaveOccurred())
-
-			err = runTest(ctx, log, c, clientSet, namespace, providerConfig, false, decoder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should successfully create and delete AvailabilitySet cluster using existing vNet and existing identity", func() {
-			foreignName, err := generateName()
-			Expect(err).ToNot(HaveOccurred())
-			foreignNameVnet := foreignName + "-vnet"
-			foreignNameId := foreignName + "-id"
-
-			var cleanupHandle framework.CleanupActionHandle
-			cleanupHandle = framework.AddCleanupAction(func() {
-				Expect(ignoreAzureNotFoundError(teardownResourceGroup(ctx, clientSet, foreignName))).To(Succeed())
-				framework.RemoveCleanupAction(cleanupHandle)
-			})
-
-			Expect(prepareNewResourceGroup(ctx, log, clientSet, foreignName, *region)).To(Succeed())
-			Expect(prepareNewVNet(ctx, log, clientSet, foreignName, foreignNameVnet, *region, VNetCIDR)).To(Succeed())
-			Expect(prepareNewIdentity(ctx, log, clientSet, foreignName, foreignNameId, *region)).To(Succeed())
-
-			vnetConfig := &azurev1alpha1.VNet{
-				Name:          ptr.To(foreignNameVnet),
-				ResourceGroup: ptr.To(foreignName),
-			}
-			identityConfig := &azurev1alpha1.IdentityConfig{
-				Name:          foreignNameId,
-				ResourceGroup: foreignName,
-			}
-			providerConfig := newInfrastructureConfig(vnetConfig, nil, identityConfig, false)
-
-			namespace, err := generateName()
-			Expect(err).ToNot(HaveOccurred())
-			err = runTest(ctx, log, c, clientSet, namespace, providerConfig, false, decoder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
 	Context("Zonal cluster", func() {
 		AfterEach(func() {
 			framework.RunCleanupActions()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

- Deprecate Availability-Set based shoots
- Make VMSS-FLex (VMO) the default for non-zonal clusters
- Create a migration path based on https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance to migrate AS to VMO shoots.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Disable the creation of Availability-Set-based shoots.
```
```breaking user
VMSS-Flex based shoots are not the default deployment for non-zonal shoots.
```
```feature user
Introduce an annotation to migrate the availability-set shoots to VMSS-Flex shoots.
```
