### PR TITLE
Fix flow reconcile ensure public ip

### DIFF
--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -155,6 +155,11 @@ const (
 	SeedAnnotationUseFlowValueNew = "new"
 	// AnnotationEnableVolumeAttributesClass is the annotation to use on shoots to enable VolumeAttributesClasses
 	AnnotationEnableVolumeAttributesClass = "azure.provider.extensions.gardener.cloud/enable-volume-attributes-class"
+
+	// CCMServiceTagKey is the service key applied for public IP tags.
+	CCMServiceTagKey = "k8s-azure-service"
+	// CCMLegacyServiceTagKey is the legacy service key applied for public IP tags.
+	CCMLegacyServiceTagKey = "service"
 )
 
 // UsernamePrefix is a constant for the username prefix of components deployed by Azure.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform azure

**What this PR does / why we need it**:
If a public IP was created by the azure CCM (Cloud Controller Manager) in the past with a pretty old CCM version it was tagged under the key "service" and not "k8s-azure-service".
The flow code up until now does not support this old key and therefore the reconciliation fails.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Support legacy CCM service tag key in flow reconciliation
```
