### PR TITLE
Fix reconciliation of user managed public IPs in flow

### DIFF
--- a/pkg/azure/client/interface.go
+++ b/pkg/azure/client/interface.go
@@ -82,3 +82,8 @@ type ContainerDeleteFunc[T any] interface {
 type ContainerCheckExistenceFunc[T any] interface {
 	CheckExistence(ctx context.Context, container string) (bool, error)
 }
+
+// UpdateTags updates the tags of a resource.
+type UpdateTags interface {
+	UpdateTags(ctx context.Context, name, resourceGroupName string, tags map[string]*string) error
+}

--- a/pkg/azure/client/mock/mocks.go
+++ b/pkg/azure/client/mock/mocks.go
@@ -889,6 +889,20 @@ func (mr *MockPublicIPMockRecorder) List(ctx, resourceGroupName any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPublicIP)(nil).List), ctx, resourceGroupName)
 }
 
+// UpdateTags mocks base method.
+func (m *MockPublicIP) UpdateTags(ctx context.Context, name, resourceGroupName string, tags map[string]*string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTags", ctx, name, resourceGroupName, tags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateTags indicates an expected call of UpdateTags.
+func (mr *MockPublicIPMockRecorder) UpdateTags(ctx, name, resourceGroupName, tags any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTags", reflect.TypeOf((*MockPublicIP)(nil).UpdateTags), ctx, name, resourceGroupName, tags)
+}
+
 // MockAvailabilitySet is a mock of AvailabilitySet interface.
 type MockAvailabilitySet struct {
 	ctrl     *gomock.Controller

--- a/pkg/azure/client/publicip.go
+++ b/pkg/azure/client/publicip.go
@@ -70,6 +70,15 @@ func (c *PublicIPClient) List(ctx context.Context, resourceGroupName string) ([]
 	return ips, nil
 }
 
+// UpdateTags will add tags to a network Public IP Address.
+func (c *PublicIPClient) UpdateTags(ctx context.Context, name, resourceGroupName string, tags map[string]*string) error {
+	_, err := c.client.UpdateTags(ctx, resourceGroupName, name, armnetwork.TagsObject{Tags: tags}, nil)
+	if err != nil {
+		return FilterNotFoundError(err)
+	}
+	return nil
+}
+
 // Delete will delete a network Public IP Address.
 func (c *PublicIPClient) Delete(ctx context.Context, resourceGroupName, name string) error {
 	future, err := c.client.BeginDelete(ctx, resourceGroupName, name, nil)

--- a/pkg/azure/client/types.go
+++ b/pkg/azure/client/types.go
@@ -99,6 +99,7 @@ type PublicIP interface {
 	CreateOrUpdateFunc[armnetwork.PublicIPAddress]
 	DeleteFunc[armnetwork.PublicIPAddress]
 	ListFunc[armnetwork.PublicIPAddress]
+	UpdateTags
 }
 
 // NetworkInterface represents an Azure Network Interface k8sClient.

--- a/pkg/controller/infrastructure/infraflow/const.go
+++ b/pkg/controller/infrastructure/infraflow/const.go
@@ -21,4 +21,9 @@ const (
 	ChildKeyMigration = "migration"
 	// ChildKeyComplete is a key to indicate whether a task is complete.
 	ChildKeyComplete = "complete"
+
+	// IgnoredByGardenerTag is the tag used to mark resources managed by Gardener.
+	// It's used for an edge case where public IPs that are customer managed + migrated
+	// from terraform + reside in our RG + have the shoot prefix name.
+	IgnoredByGardenerTag = "managedByGardener"
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR prevents the deletion of certain user managed public IPs during flow reconciliation after Terraform migration.
It adds a tag to IPs that reside in the shoot namespace and have the shoot prefix but should not be touched by us.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
This PR prevents the deletion of certain user managed public IPs during flow reconciliation after Terraform migration
```
