### PR TITLE
Fix reconciliation of user managed public IPs in flow

### DIFF
--- a/pkg/controller/infrastructure/infraflow/const.go
+++ b/pkg/controller/infrastructure/infraflow/const.go
@@ -21,4 +21,7 @@ const (
 	ChildKeyMigration = "migration"
 	// ChildKeyComplete is a key to indicate whether a task is complete.
 	ChildKeyComplete = "complete"
+
+	// ManagedByGardenerTag is the tag used to mark resources managed by Gardener.
+	ManagedByGardenerTag = "managedByGardener"
 )

--- a/pkg/controller/infrastructure/infraflow/const.go
+++ b/pkg/controller/infrastructure/infraflow/const.go
@@ -22,6 +22,8 @@ const (
 	// ChildKeyComplete is a key to indicate whether a task is complete.
 	ChildKeyComplete = "complete"
 
-	// ManagedByGardenerTag is the tag used to mark resources managed by Gardener.
-	ManagedByGardenerTag = "managedByGardener"
+	// TagManagedByGardener is the tag used to mark resources managed by Gardener.
+	TagManagedByGardener = "managed-by-gardener"
+	// TagShootName is the tag used to mark the shoot name on resources managed by Gardener.
+	TagShootName = "gardener-shoot-name"
 )

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -398,7 +398,10 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 	}
 	currentIPs = Filter(currentIPs, func(address *armnetwork.PublicIPAddress) bool {
 		// filter only these IpConfigs that are managed by gardener
-		return fctx.adapter.HasShootPrefix(address.Name) && address.Tags[ManagedByGardenerTag] != nil
+		return fctx.adapter.HasShootPrefix(address.Name) &&
+			ptr.Deref(address.Tags[TagManagedByGardener], "") == "true" &&
+			ptr.Deref(address.Tags[TagShootName], "") == fctx.adapter.TechnicalName()
+
 	})
 	// obtain an indexed list of current IPs
 	nameToCurrentIps := ToMap(currentIPs, func(t *armnetwork.PublicIPAddress) string {
@@ -424,6 +427,13 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 		// delete all the resources that are not in the list of target resources
 		pipCfg, ok := desiredConfiguration[name]
 		if !ok {
+			// 	skip deletion of IPs that may fit our criteria, but are referenced explicitly in the shoot spec.
+			if fctx.adapter.IsPublicIPPinned(name) {
+				// mark the IP as not managed by gardener.
+				log.Info("Found public IP pinned... skipping deletion", "ip", nameToCurrentIps[name].ID)
+				fctx.inventory.Delete(*current.ID)
+				continue
+			}
 			log.Info("Will delete public IP because it is not needed", "Resource Group", fctx.adapter.ResourceGroupName(), "Name", name)
 			toDelete[name] = *current.ID
 			continue

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -397,9 +397,8 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 		return err
 	}
 	currentIPs = Filter(currentIPs, func(address *armnetwork.PublicIPAddress) bool {
-		// filter only these IpConfigs prefixed by the cluster name and that do not contain the CCM tags.
-		return fctx.adapter.HasShootPrefix(address.Name) &&
-			(address.Tags[azure.CCMServiceTagKey] == nil && address.Tags[azure.CCMLegacyServiceTagKey] == nil)
+		// filter only these IpConfigs that are managed by gardener
+		return fctx.adapter.HasShootPrefix(address.Name) && address.Tags[ManagedByGardenerTag] != nil
 	})
 	// obtain an indexed list of current IPs
 	nameToCurrentIps := ToMap(currentIPs, func(t *armnetwork.PublicIPAddress) string {

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -401,7 +401,6 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 		return fctx.adapter.HasShootPrefix(address.Name) &&
 			ptr.Deref(address.Tags[TagManagedByGardener], "") == "true" &&
 			ptr.Deref(address.Tags[TagShootName], "") == fctx.adapter.TechnicalName()
-
 	})
 	// obtain an indexed list of current IPs
 	nameToCurrentIps := ToMap(currentIPs, func(t *armnetwork.PublicIPAddress) string {
@@ -427,7 +426,7 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 		// delete all the resources that are not in the list of target resources
 		pipCfg, ok := desiredConfiguration[name]
 		if !ok {
-			// 	skip deletion of IPs that may fit our criteria, but are referenced explicitly in the shoot spec.
+			// skip deletion of IPs that may fit our criteria, but are referenced explicitly in the shoot spec.
 			if fctx.adapter.IsPublicIPPinned(name) {
 				// mark the IP as not managed by gardener.
 				log.Info("Found public IP pinned... skipping deletion", "ip", nameToCurrentIps[name].ID)

--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -409,6 +409,7 @@ func (fctx *FlowContext) ensurePublicIps(ctx context.Context) error {
 	for name, ip := range desiredConfiguration {
 		toReconcile[name] = ip.ToProvider(nameToCurrentIps[name])
 	}
+
 	for _, resource := range fctx.inventory.ByKind(KindPublicIP) {
 		if _, ok := nameToCurrentIps[resource.Name]; !ok {
 			log.Info("Removing public IP from inventory", "id", resource.String())

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -529,6 +529,7 @@ func (ip *PublicIPConfig) ToProvider(base *armnetwork.PublicIPAddress) *armnetwo
 			Tier: to.Ptr(armnetwork.PublicIPAddressSKUTierRegional),
 		},
 		Name: to.Ptr(ip.Name),
+		Tags: map[string]*string{ManagedByGardenerTag: to.Ptr("true")},
 	}
 	if len(ip.Zones) > 0 {
 		// if no zones selected, zones has to be nil, to match what the API returns - otherwise reflect.DeepEqual fails the check.
@@ -539,6 +540,11 @@ func (ip *PublicIPConfig) ToProvider(base *armnetwork.PublicIPAddress) *armnetwo
 	if base != nil {
 		target.ID = base.ID
 		target.Tags = base.Tags
+	}
+
+	// TODO(hebelsan) remove in later release because we add the key when creating the object.
+	if _, ok := target.Tags[ManagedByGardenerTag]; !ok {
+		target.Tags[ManagedByGardenerTag] = to.Ptr("true")
 	}
 
 	return target

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/helper"
@@ -72,6 +73,11 @@ func (ia *InfrastructureAdapter) TechnicalName() string {
 type ResourceGroupConfig struct {
 	AzureResourceMetadata
 	Location string
+}
+
+// ShootInfo contains information about the shoot the resource belongs.
+type ShootInfo struct {
+	ShootName string
 }
 
 // ResourceGroup returns the configuration for the shoot's resource group.
@@ -249,6 +255,7 @@ func (ia *InfrastructureAdapter) SecurityGroupConfig() SecurityGroupConfig {
 // PublicIPConfig contains configuration for a public IP resource.
 type PublicIPConfig struct {
 	AzureResourceMetadata
+	ShootInfo
 	Zones    []string
 	Location string
 	Managed  bool
@@ -370,6 +377,9 @@ func (ia *InfrastructureAdapter) zonesConfig() []ZoneConfig {
 			if len(configZone.NatGateway.IPAddresses) > 0 {
 				for _, ipRef := range configZone.NatGateway.IPAddresses {
 					ip := PublicIPConfig{
+						ShootInfo: ShootInfo{
+							ShootName: ia.TechnicalName(),
+						},
 						AzureResourceMetadata: AzureResourceMetadata{
 							ResourceGroup: ipRef.ResourceGroup,
 							Name:          ipRef.Name,
@@ -382,6 +392,9 @@ func (ia *InfrastructureAdapter) zonesConfig() []ZoneConfig {
 				}
 			} else {
 				ip := PublicIPConfig{
+					ShootInfo: ShootInfo{
+						ShootName: ia.TechnicalName(),
+					},
 					AzureResourceMetadata: AzureResourceMetadata{
 						ResourceGroup: ia.ResourceGroupName(),
 						Name:          ia.publicIPName(ngw.Name),
@@ -435,6 +448,9 @@ func (ia *InfrastructureAdapter) defaultZone() []ZoneConfig {
 	if len(config.Networks.NatGateway.IPAddresses) > 0 {
 		for _, ipRef := range config.Networks.NatGateway.IPAddresses {
 			ip := PublicIPConfig{
+				ShootInfo: ShootInfo{
+					ShootName: ia.TechnicalName(),
+				},
 				AzureResourceMetadata: AzureResourceMetadata{
 					ResourceGroup: ipRef.ResourceGroup,
 					Name:          ipRef.Name,
@@ -447,6 +463,9 @@ func (ia *InfrastructureAdapter) defaultZone() []ZoneConfig {
 		}
 	} else {
 		ip := PublicIPConfig{
+			ShootInfo: ShootInfo{
+				ShootName: ia.TechnicalName(),
+			},
 			AzureResourceMetadata: AzureResourceMetadata{
 				ResourceGroup: ia.ResourceGroupName(),
 				Name:          ia.publicIPName(ngw.Name),
@@ -497,6 +516,26 @@ func (ia *InfrastructureAdapter) IpConfigs() []PublicIPConfig {
 	return res
 }
 
+// IsPublicIPPinned checks whether a public IP found in the shoot's resource group is also pinned via the provider spec
+// as a NATGateway IP.
+func (ia *InfrastructureAdapter) IsPublicIPPinned(name string) bool {
+	for _, z := range ia.zoneConfigs {
+		if z.NatGateway == nil {
+			continue
+		}
+		for _, ip := range z.NatGateway.PublicIPList {
+			if ip.Managed {
+				continue
+			}
+			if ip.ResourceGroup == ia.ResourceGroupName() && ip.Name == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // NatGatewayConfigs is the configuration for the desired NAT Gateways.
 func (ia *InfrastructureAdapter) NatGatewayConfigs() map[string]NatGatewayConfig {
 	res := make(map[string]NatGatewayConfig)
@@ -519,6 +558,9 @@ func (ia *InfrastructureAdapter) HasShootPrefix(name *string) bool {
 
 // ToProvider translates the config into the actual providerAccess object.
 func (ip *PublicIPConfig) ToProvider(base *armnetwork.PublicIPAddress) *armnetwork.PublicIPAddress {
+	if base == nil {
+		base = &armnetwork.PublicIPAddress{}
+	}
 	target := &armnetwork.PublicIPAddress{
 		Location: to.Ptr(ip.Location),
 		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
@@ -529,26 +571,19 @@ func (ip *PublicIPConfig) ToProvider(base *armnetwork.PublicIPAddress) *armnetwo
 			Tier: to.Ptr(armnetwork.PublicIPAddressSKUTierRegional),
 		},
 		Name: to.Ptr(ip.Name),
-		Tags: map[string]*string{ManagedByGardenerTag: to.Ptr("true")},
 	}
 	if len(ip.Zones) > 0 {
 		// if no zones selected, zones has to be nil, to match what the API returns - otherwise reflect.DeepEqual fails the check.
 		target.Zones = to.SliceOfPtrs(ip.Zones...)
 	}
 
+	target.Tags = utils.MergeStringMaps(base.Tags, map[string]*string{
+		TagManagedByGardener: to.Ptr("true"),
+		TagShootName:         to.Ptr(ip.ShootName),
+	})
+
 	// inherited from base
-	if base != nil {
-		// TODO(hebelsan) remove in later release because we add the key when creating the object.
-		for key, value := range target.Tags {
-			if _, ok := base.Tags[key]; !ok {
-				base.Tags[key] = value
-			}
-		}
-
-		target.ID = base.ID
-		target.Tags = base.Tags
-	}
-
+	target.ID = base.ID
 	return target
 }
 

--- a/pkg/controller/infrastructure/infraflow/infra_adapter.go
+++ b/pkg/controller/infrastructure/infraflow/infra_adapter.go
@@ -538,13 +538,15 @@ func (ip *PublicIPConfig) ToProvider(base *armnetwork.PublicIPAddress) *armnetwo
 
 	// inherited from base
 	if base != nil {
+		// TODO(hebelsan) remove in later release because we add the key when creating the object.
+		for key, value := range target.Tags {
+			if _, ok := base.Tags[key]; !ok {
+				base.Tags[key] = value
+			}
+		}
+
 		target.ID = base.ID
 		target.Tags = base.Tags
-	}
-
-	// TODO(hebelsan) remove in later release because we add the key when creating the object.
-	if _, ok := target.Tags[ManagedByGardenerTag]; !ok {
-		target.Tags[ManagedByGardenerTag] = to.Ptr("true")
 	}
 
 	return target

--- a/pkg/controller/infrastructure/strategyselector_test.go
+++ b/pkg/controller/infrastructure/strategyselector_test.go
@@ -85,7 +85,6 @@ var _ = Describe("ReconcilationStrategy", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(useFlow).To(BeTrue())
 	})
-
 })
 
 func getRawTerraformState(jsonContent string) []byte {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR prevents the deletion of certain user managed public IPs during flow reconciliation after Terraform migration.
It adds a tag to IPs that reside in the shoot namespace and have the shoot prefix but should not be touched by us.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
This PR prevents the deletion of certain user managed public IPs during flow reconciliation after Terraform migration
```
