### PR TITLE
[Release 1.50] Cleanup snapshot-validation leftovers

### DIFF
--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -156,6 +156,9 @@ const (
 	CCMServiceTagKey = "k8s-azure-service"
 	// CCMLegacyServiceTagKey is the legacy service key applied for public IP tags.
 	CCMLegacyServiceTagKey = "service"
+
+	// CSISnapshotValidationName is the constant for the name of the csi-snapshot-validation-webhook component.
+	CSISnapshotValidationName = "csi-snapshot-validation" // TODO(AndreasBurger): Clean up once SnapshotValidation is removed everywhere
 )
 
 // UsernamePrefix is a constant for the username prefix of components deployed by Azure.

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -334,7 +334,6 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 			return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", k8sclient.ObjectKeyFromObject(cp), err)
 		}
 	}
-
 	cpConfigSecret := &corev1.Secret{}
 	if err := vp.client.Get(ctx, k8sclient.ObjectKey{Namespace: cp.Namespace, Name: azure.CloudProviderConfigName}, cpConfigSecret); err != nil {
 		return nil, err
@@ -355,6 +354,11 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	// TODO(rfranzke): Delete this in a future release.
 	if err := kutil.DeleteObject(ctx, vp.client, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "csi-driver-controller-observability-config", Namespace: cp.Namespace}}); err != nil {
 		return nil, fmt.Errorf("failed deleting legacy csi-driver-controller-observability-config ConfigMap: %w", err)
+	}
+
+	// TODO(AndreasBurger): rm in future release.
+	if err := cleanupSeedLegacyCSISnapshotValidation(ctx, vp.client, cp.Namespace); err != nil {
+		return nil, err
 	}
 
 	// TODO(rfranzke): Delete this after August 2024.
@@ -720,4 +724,27 @@ func getControlPlaneShootChartValues(
 			"enabled": !disableRemedyController,
 		},
 	}, err
+}
+
+func cleanupSeedLegacyCSISnapshotValidation(
+	ctx context.Context,
+	client k8sclient.Client,
+	namespace string,
+) error {
+	if err := kutil.DeleteObject(
+		ctx,
+		client,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: azure.CSISnapshotValidationName, Namespace: namespace}},
+	); err != nil {
+		return fmt.Errorf("failed to delete legacy csi snapshot validation deployment: %w", err)
+	}
+	if err := kutil.DeleteObject(
+		ctx,
+		client,
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: azure.CSISnapshotValidationName, Namespace: namespace}},
+	); err != nil {
+		return fmt.Errorf("failed to delete legacy csi snapshot validation service: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -344,6 +344,9 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-azure-controlplane", Namespace: namespace}})).To(Succeed())
 			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
 
+			c.EXPECT().Delete(context.TODO(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: azure.CSISnapshotValidationName, Namespace: namespace}})
+			c.EXPECT().Delete(context.TODO(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: azure.CSISnapshotValidationName, Namespace: namespace}})
+
 			c.EXPECT().Delete(context.TODO(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "csi-driver-controller-observability-config", Namespace: namespace}})
 			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: "prometheus-shoot", Namespace: namespace}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
