### PR TITLE
skip the deployment of allow-egress chart with new annotation

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -175,18 +175,6 @@ In the `identity` section you can specify an [Azure user-assigned managed identi
 
 Apart from the VNet and the worker subnet the Azure extension will also create a dedicated resource group, route tables, security groups, and an availability set (if not using zoned clusters).
 
-#### Disabling the automatic deployment of `allow-{tcp,udp} loadbalancer services` 
-
-Using the `azure-cloud-controller-manager` when a user first creates a loadbalancer service in the cluster, a new Load Balancer is created in Azure and all nodes of the cluster are registered as backend.
-When a NAT Gateway is not used, then this Load Balancer is used as a NAT device for outbound traffic by using one of the registered FrontendIPs assigned to the k8s LB service.
-In cases where a NATGateway is not used, `provider-azure` will deploy by default a set of 2 Load Balancer services in the `kube-system`.
-These are responsible for allowing outbound traffic in all cases for UDP and TCP.
-
-There is a way for users to disable the deployment of these additional LBs by using the `azure.provider.extensions.gardener.cloud/skip-allow-egress="true"` annotation on their shoot.
-[!WARNING]
-Disabling the system Load Balancers may affect the outbound of your shoot.
-Before disabling them, users are highly advised to have created at least one Load Balancer for **TCP and UDP** or forward outbound traffic via a different route.
-
 ### InfrastructureConfig with dedicated subnets per zone
 
 Another deployment option **for zonal clusters only**, is to create and configure a separate subnet per availability zone. This network layout is recommended to users that require fine-grained control over their network setup. One prevalent usecase is to create a zone-redundant NAT Gateway deployment by taking advantage of the ability to deploy separate NAT Gateways for each subnet.
@@ -676,11 +664,24 @@ spec:
 If no configuration is specified the extension will default to the public instance.
 Azure instances other than `AzurePublic`, `AzureGovernment`, or `AzureChina` are not supported at this time.
 
+### Disabling the automatic deployment of `allow-{tcp,udp} loadbalancer services`
+
+Using the `azure-cloud-controller-manager` when a user first creates a loadbalancer service in the cluster, a new Load Balancer is created in Azure and all nodes of the cluster are registered as backend.
+When a NAT Gateway is not used, then this Load Balancer is used as a NAT device for outbound traffic by using one of the registered FrontendIPs assigned to the k8s LB service.
+In cases where a NATGateway is not used, `provider-azure` will deploy by default a set of 2 Load Balancer services in the `kube-system`.
+These are responsible for allowing outbound traffic in all cases for UDP and TCP.
+
+There is a way for users to disable the deployment of these additional LBs by using the `azure.provider.extensions.gardener.cloud/skip-allow-egress="true"` annotation on their shoot.
+[!WARNING]
+Disabling the system Load Balancers may affect the outbound of your shoot.
+Before disabling them, users are highly advised to have created at least one Load Balancer for **TCP and UDP** or forward outbound traffic via a different route.
+
 ### Support for VolumeAttributesClasses (Beta in k8s 1.31)
 
 To have the CSI-driver configured to support the necessary features for [VolumeAttributesClasses](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) on Azure for shoots with a k8s-version greater than 1.31, use the `azure.provider.extensions.gardener.cloud/enable-volume-attributes-class` annotation on the shoot. Keep in mind to also enable the required feature flags and runtime-config on the common kubernetes controllers (as outlined in the link above) in the shoot-spec.
 
 For more information and examples on how to configure the volume attributes class, see [example](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/release-1.31/deploy/example/modifyvolume/README.md) provided in the the azuredisk-csi-driver repository.
+
 
 ### Preview: Shoot clusters with VMSS Flexible Orchestration (VMSS Flex/VMO)
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -175,6 +175,18 @@ In the `identity` section you can specify an [Azure user-assigned managed identi
 
 Apart from the VNet and the worker subnet the Azure extension will also create a dedicated resource group, route tables, security groups, and an availability set (if not using zoned clusters).
 
+#### Disabling the automatic deployment of `allow-{tcp,udp} loadbalancer services` 
+
+Using the `azure-cloud-controller-manager` when a user first creates a loadbalancer service in the cluster, a new Load Balancer is created in Azure and all nodes of the cluster are registered as backend.
+When a NAT Gateway is not used, then this Load Balancer is used as a NAT device for outbound traffic by using one of the registered FrontendIPs assigned to the k8s LB service.
+In cases where a NATGateway is not used, `provider-azure` will deploy by default a set of 2 Load Balancer services in the `kube-system`.
+These are responsible for allowing outbound traffic in all cases for UDP and TCP.
+
+There is a way for users to disable the deployment of these additional LBs by using the `azure.provider.extensions.gardener.cloud/skip-allow-egress="true"` annotation on their shoot.
+[!WARNING]
+Disabling the system Load Balancers may affect the outbound of your shoot.
+Before disabling them, users are highly advised to have created at least one Load Balancer for **TCP and UDP** or forward outbound traffic via a different route.
+
 ### InfrastructureConfig with dedicated subnets per zone
 
 Another deployment option **for zonal clusters only**, is to create and configure a separate subnet per availability zone. This network layout is recommended to users that require fine-grained control over their network setup. One prevalent usecase is to create a zone-redundant NAT Gateway deployment by taking advantage of the ability to deploy separate NAT Gateways for each subnet.

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -16,6 +16,8 @@ const (
 	ShootVmoUsageAnnotation = "alpha.azure.provider.extensions.gardener.cloud/vmo"
 	// ShootVmoMigrationAnnotation is an annotation assigned to the Shoot resource which indicates if the availability set shoot, should be migrated to a VMO shoot.
 	ShootVmoMigrationAnnotation = "migration.azure.provider.extensions.gardener.cloud/vmo"
+	// ShootSkipAllowEgressDeployment skips the deployment of AllowEgress chart. The annotation exposes an option for shoot owners to override the automated behavior of Gardener.
+	ShootSkipAllowEgressDeployment = "azure.provider.extensions.gardener.cloud/skip-allow-egress"
 
 	// NetworkLayoutZoneMigrationAnnotation is used when migrating from a single subnet network layout to a multiple subnet network layout to indicate the zone that the existing subnet should be assigned to.
 	NetworkLayoutZoneMigrationAnnotation = "migration.azure.provider.extensions.gardener.cloud/zone"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow users to disable the deployment of allow-* loadbalancers for outbound traffic.
```
