### PR TITLE
Remove unused `hostPaths` from `csi-driver-node`

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.tpl
@@ -110,13 +110,12 @@ spec:
           mountPath: /dev
         - name: cloud-provider-config
           mountPath: /etc/kubernetes/cloudprovider
-        - name: msi
-          mountPath: /var/lib/waagent/ManagedIdentity-Settings
-          readOnly: true
+        {{- if eq .role "disk" }}
         - name: sys-devices-dir
           mountPath: /sys/bus/scsi/devices
         - name: scsi-host-dir
           mountPath: /sys/class/scsi_host/
+        {{- end }}
 
       - name: csi-node-driver-registrar
         image: {{ index .Values.images "csi-node-driver-registrar" }}
@@ -178,9 +177,7 @@ spec:
       - name: cloud-provider-config
         configMap:
           name: cloud-provider-disk-config
-      - name: msi
-        hostPath:
-          path: /var/lib/waagent/ManagedIdentity-Settings
+      {{- if eq .role "disk" }}
       - name: sys-devices-dir
         hostPath:
           path: /sys/bus/scsi/devices
@@ -189,4 +186,5 @@ spec:
         hostPath:
           path: /sys/class/scsi_host/
           type: Directory
+      {{- end }}
 {{- end -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement
/kind cleanup
/platform azure

**What this PR does / why we need it**:
This PR removes the the useless msi `hostPath`: https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/1037

It also removes `hostPath`s for `csi-driver-node-file` that are only used in `csi-driver-node-disk` https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/7e062ccc94926b41e2ade6713f71e3d0800f533e/deploy/csi-azurefile-node.yaml#L143-L166

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
