### PR TITLE
Allow admission to get workloadidentities

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
@@ -41,6 +41,12 @@ rules:
   - watch
   - patch
   - update
+- apiGroups:
+  - security.gardener.cloud
+  resources:
+  - workloadidentities
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform azure

**What this PR does / why we need it**:
Fixes permissions. The validator webhook requires GET permissions over workload identities.

https://github.com/gardener/gardener-extension-provider-azure/blob/1b3b81e66cb799a70e3392dec9068af13b7a26b3/pkg/admission/validator/credentialsbinding.go#L69-L71

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/1253

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The admission webhook is now allowed to GET workload identities.
```
