### PR TITLE
[release-v1.51] Automated cherry pick of #1120: Allow admission to get workloadidentities

### DIFF
--- a/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-azure/charts/application/templates/rbac.yaml
@@ -41,6 +41,12 @@ rules:
   - watch
   - patch
   - update
+- apiGroups:
+  - security.gardener.cloud
+  resources:
+  - workloadidentities
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
/area security
/kind bug

Cherry pick of #1120 on release-v1.51.

#1120: Allow admission to get workloadidentities

**Release Notes:**
```bugfix operator
The admission webhook is now allowed to GET workload identities.
```