### PR TITLE
Update worker pool hash if diagnosticProfile is enabled

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -538,9 +538,9 @@ func (w workerDelegate) workerPoolHashDataV2(workerConfig api.WorkerConfig, addi
 
 	if workerConfig.DiagnosticsProfile != nil && workerConfig.DiagnosticsProfile.Enabled {
 		hashData = append(hashData, "DiagnosticsProfileEnabled")
-	}
-	if workerConfig.DiagnosticsProfile != nil && workerConfig.DiagnosticsProfile.StorageURI != nil {
-		hashData = append(hashData, *workerConfig.DiagnosticsProfile.StorageURI)
+		if workerConfig.DiagnosticsProfile.StorageURI != nil {
+			hashData = append(hashData, *workerConfig.DiagnosticsProfile.StorageURI)
+		}
 	}
 
 	return hashData, nil

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -534,9 +534,11 @@ func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 
 // workerPoolHashDataV2 adds additional provider-specific data points to consider to the given data.
 func (w workerDelegate) workerPoolHashDataV2(workerConfig api.WorkerConfig, additionalData []string) ([]string, error) {
-	hashData := make([]string, len(additionalData))
-	copy(hashData, additionalData)
+	hashData := append([]string{}, additionalData...)
 
+	if workerConfig.DiagnosticsProfile != nil && workerConfig.DiagnosticsProfile.Enabled {
+		hashData = append(hashData, "DiagnosticsProfileEnabled")
+	}
 	if workerConfig.DiagnosticsProfile != nil && workerConfig.DiagnosticsProfile.StorageURI != nil {
 		hashData = append(hashData, *workerConfig.DiagnosticsProfile.StorageURI)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Update worker pool hash if diagnosticProfile is enabled to roll nodes.
Before this PR nodes would only be rolled if diagnosticProfile is enabled and a storageURI is specified.
However the more common approach is to leave the storageURI empty and let Azure handle the storage.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Update worker pool hash if diagnostic profile option is enabled
```
