### PR TITLE
Fix order rotation

### DIFF
--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -70,7 +70,7 @@ func (a *actuator) reconcile(ctx context.Context, logger logr.Logger, backupBuck
 		return err
 	}
 
-	resourceGroupName, storageAccountName, err := ensureResourceGroupAndStorageAccount(ctx, factory, backupBucket, &backupBucketConfig)
+	resourceGroupName, storageAccountName, err := a.ensureResourceGroupAndStorageAccount(ctx, factory, backupBucket, &backupBucketConfig)
 	if err != nil {
 		return logWithError(logger, err, "Failed to ensure the resource group and storage account")
 	}

--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -288,8 +288,8 @@ func (a *actuator) delete(ctx context.Context, _ logr.Logger, backupBucket *exte
 	return a.deleteBackupBucketGeneratedSecret(ctx, backupBucket)
 }
 
-func logWithError(logger logr.Logger, err error, msg string, otherFields ...string) error {
-	logger.WithCallDepth(1).Error(err, msg, otherFields)
+func logWithError(logger logr.Logger, err error, msg string, otherFields ...any) error {
+	logger.WithCallDepth(1).Error(err, msg, otherFields...)
 	if err == nil {
 		return fmt.Errorf("%s", strings.ToLower(msg))
 	}

--- a/pkg/controller/backupbucket/actuator_test.go
+++ b/pkg/controller/backupbucket/actuator_test.go
@@ -823,6 +823,17 @@ func mockGeneratedSecretNoop(
 		},
 	}
 
+	secret := &corev1.Secret{}
+	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), secret).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+		*obj = *generatedSecret.DeepCopy()
+		obj.Data = map[string][]byte{
+			azure.StorageDomain:  []byte(azure.AzureBlobStorageDomain),
+			azure.StorageAccount: []byte(storageAccountName),
+			azure.StorageKey:     []byte("secret1"),
+		}
+		return nil
+	})
+
 	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), generatedSecret.DeepCopy()).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 		generatedSecret.Data = map[string][]byte{
 			azure.StorageDomain:  []byte(azure.AzureBlobStorageDomain),
@@ -854,10 +865,22 @@ func mockGeneratedSecretUpdate(
 		},
 	}
 
+	secret := &corev1.Secret{}
+	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), secret).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+		*obj = *generatedSecret.DeepCopy()
+		obj.Data = map[string][]byte{
+			"domain":         []byte(azure.AzureBlobStorageDomain),
+			"storageAccount": []byte(storageAccountName),
+			"storageKey":     []byte(oldStorageAccountKey),
+		}
+		return nil
+	})
 	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), generatedSecret.DeepCopy()).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 		secret := generatedSecret.DeepCopy()
 		secret.Data = map[string][]byte{
-			azure.StorageKey: []byte(oldStorageAccountKey),
+			"domain":         []byte(azure.AzureBlobStorageDomain),
+			"storageAccount": []byte(storageAccountName),
+			"storageKey":     []byte(oldStorageAccountKey),
 		}
 		*obj = *secret
 		return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Addendum to https://github.com/gardener/gardener-extension-provider-azure/pull/1114

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
