### PR TITLE
[release-v1.51] Automated cherry pick of #1143: Correctly mount workload identity token to csi driver controller

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -554,7 +554,7 @@ func getControlPlaneChartValues(
 		return nil, err
 	}
 
-	csi, err := getCSIControllerChartValues(cluster, scaledDown, infraStatus, checksums)
+	csi, err := getCSIControllerChartValues(cluster, scaledDown, infraStatus, checksums, useWorkloadIdentity)
 	if err != nil {
 		return nil, err
 	}
@@ -624,6 +624,7 @@ func getCSIControllerChartValues(
 	scaledDown bool,
 	infraStatus *apisazure.InfrastructureStatus,
 	checksums map[string]string,
+	useWorkloadIdentity bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
 		"enabled": true,
@@ -634,6 +635,7 @@ func getCSIControllerChartValues(
 		"csiSnapshotController": map[string]interface{}{
 			"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		},
+		"useWorkloadIdentity": useWorkloadIdentity,
 	}
 
 	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -383,7 +383,8 @@ var _ = Describe("ValuesProvider", func() {
 					"csiSnapshotController": map[string]interface{}{
 						"replicas": 1,
 					},
-					"vmType": "vmss",
+					"vmType":              "vmss",
+					"useWorkloadIdentity": false,
 				}),
 				azure.RemedyControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
 					"replicas": 1,
@@ -421,6 +422,7 @@ var _ = Describe("ValuesProvider", func() {
 					"csiSnapshotController": map[string]interface{}{
 						"replicas": 1,
 					},
+					"useWorkloadIdentity": false,
 				}),
 				azure.RemedyControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
 					"replicas": 1,
@@ -461,6 +463,7 @@ var _ = Describe("ValuesProvider", func() {
 					"csiSnapshotController": map[string]interface{}{
 						"replicas": 1,
 					},
+					"useWorkloadIdentity": false,
 				}),
 				azure.RemedyControllerName: remedyDisabled,
 			}))


### PR DESCRIPTION
/area security
/kind bug

Cherry pick of #1143 on release-v1.51.

#1143: Correctly mount workload identity token to csi driver controller

**Release Notes:**
```bugfix user
An issue causing `csi-driver-controller` to not have mounted a workload identity token when the feature is enabled is now fixed.
```