### PR TITLE
[release-v1.52] Automated cherry pick of #1166: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.15.1->v0.16.0]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -196,7 +196,7 @@ images:
 - name: machine-controller-manager-provider-azure
   sourceRepository: github.com/gardener/machine-controller-manager-provider-azure
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-azure
-  tag: "v0.15.1"
+  tag: "v0.16.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #1166 on release-v1.52.

#1166: [ci:component:github.com/gardener/machine-controller-manager-provider-azure:v0.15.1->v0.16.0]

**Release Notes:**
```other operator github.com/gardener/machine-controller-manager #981 @takoverflow
Resource exhaustion on machine creation results in a longer retry period
```
```other operator github.com/gardener/machine-controller-manager #968 @takoverflow
Integration test framework enhancements for resource and process cleanup
```
```bugfix operator github.com/gardener/machine-controller-manager #985 @renormalize
machine-controller-manager version, and build information are printed at startup.
```
```feature operator github.com/gardener/machine-controller-manager #973 @acumino
Machine Controller Manager now supports a new machine deployment strategy called InPlaceUpdate.
```
```bugfix operator github.com/gardener/machine-controller-manager #964 @takoverflow
A new termination queue to handle machines scheduled for deletion introduced to separate creation requests from deletion
```