### PR TITLE
Fix compute hash v2

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -228,13 +228,15 @@ After the service principal secret has been rotated and the corresponding secret
 
 ### Rolling Update Triggers
 
-Changes to the `Shoot` worker-pools are applied in-place where possible. In case this is not possible a rolling update of the workers will be performed to apply the new configuration, as outlined in [the Gardener documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#in-place-vs-rolling-updates). The exact fields that trigger this behaviour depend on whether the feature gate `NewWorkerPoolHash` is enabled. If it is not enabled, the fields mentioned in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers) are used, with a few additions:
+Changes to the `Shoot` worker-pools are applied in-place where possible.
+In case this is not possible a rolling update of the workers will be performed to apply the new configuration, 
+as outlined in [the Gardener documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#in-place-vs-rolling-updates).
+The exact fields that trigger this behavior are defined in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers), 
+with a few additions:
 
 - `.spec.provider.infrastructureConfig.identity`
 - `.spec.provider.workers[].dataVolumes[].size` (only the affected worker pool)
 - `.spec.provider.workers[].dataVolumes[].type` (only the affected worker pool)
 
-If the feature gate _is_ enabled, instead of the complete provider config only the fields explicitly mentioned above are used, with the addition of
-
-- `.spec.provider.workers[].providerConfig.diagnosticsProfile.enabled`
-- `.spec.provider.workers[].providerConfig.diagnosticsProfile.storageURI`
+For now, if the feature gate `NewWorkerPoolHash` _is_ enabled, the exact same fields are used.
+This behavior may change once MCM supports in-place updates, such as volume updates.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Currently, the NewWorkerPoolHash does not affect updates to the .spec.provider.workers[].providerConfig field.
This behaviour may change once MCM supports in-place updates for certain operations, such as volume updates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
