### PR TITLE
Restore provider controller's start function

### DIFF
--- a/cmd/gardener-extension-provider-azure/app/app.go
+++ b/cmd/gardener-extension-provider-azure/app/app.go
@@ -273,6 +273,10 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				}
 			}
 
+			if err := mgr.Start(ctx); err != nil {
+				return fmt.Errorf("error running manager: %w", err)
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform azure

**What this PR does / why we need it**:
I've modified the `gardener-extension-provider-azure` controller in [this PR](https://github.com/gardener/gardener-extension-provider-azure/pull/1176). However' I've accidentally removed the `mgr.Start` function. This PR reverts it.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
