### PR TITLE
Add a predicate to reconcile the extension for `StorageAccountKeyMustRotate` annotation

### DIFF
--- a/pkg/controller/backupbucket/add.go
+++ b/pkg/controller/backupbucket/add.go
@@ -9,8 +9,12 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 )
@@ -36,7 +40,7 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          NewActuator(mgr),
 		ControllerOptions: opts.Controller,
-		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Predicates:        getPredicates(opts),
 		Type:              azure.Type,
 		ExtensionClass:    opts.ExtensionClass,
 	})
@@ -45,4 +49,20 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 // AddToManager adds a controller with the default Options.
 func AddToManager(ctx context.Context, mgr manager.Manager) error {
 	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
+}
+
+func getPredicates(opts AddOptions) []predicate.Predicate {
+	defaultPredicates := predicate.And(backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation)...)
+
+	// Trigger reconcile if StorageAccountKeyMustRotate annotation is set to 'true' and the event is Create or Update.
+	storageAccountKeyMustRotatePredicate := predicate.And(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		backupBucket, ok := obj.(*extensionsv1alpha1.BackupBucket)
+		if !ok {
+			return false
+		}
+
+		return kutil.HasMetaDataAnnotation(backupBucket, azure.StorageAccountKeyMustRotate, "true")
+	}), predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update))
+
+	return []predicate.Predicate{predicate.Or(defaultPredicates, storageAccountKeyMustRotatePredicate)}
 }


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR adds a predicate to reconcile the extension if `azure.provider.extensions.gardener.cloud/rotate` annotation is present and set to true. The annotation was initially added with https://github.com/gardener/gardener-extension-provider-azure/pull/1114.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
