### PR TITLE
extension: Fix RBAC issues

### DIFF
--- a/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/role.yaml
+++ b/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/role.yaml
@@ -5,6 +5,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
   - azure.remedy.gardener.cloud
   resources:
   - publicipaddresses


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform azure

**What this PR does / why we need it**:
With @ialidzhikov we found that the remedy-controller requires permissions to managed events, it currently errors with:
```
"Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:shoot--foo--bar:remedy-controller-azure\" cannot create resource \"events\" in API group \"\" in the namespace \"shoot--foo--bar\""
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug which was causing the `remedy-controller` to not be able to create and patch `events`
```
