### PR TITLE
[GEP-26] Update seed backup docs to use credentialsRef field

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -158,7 +158,9 @@ spec:
   backup:
     provider: azure
     region: westeurope # default region
-    secretRef:
+    credentialsRef:
+      apiVersion: v1
+      kind: Secret
       name: backup-credentials
       namespace: garden
   ...
@@ -229,9 +231,9 @@ After the service principal secret has been rotated and the corresponding secret
 ### Rolling Update Triggers
 
 Changes to the `Shoot` worker-pools are applied in-place where possible.
-In case this is not possible a rolling update of the workers will be performed to apply the new configuration, 
+In case this is not possible a rolling update of the workers will be performed to apply the new configuration,
 as outlined in [the Gardener documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#in-place-vs-rolling-updates).
-The exact fields that trigger this behavior are defined in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers), 
+The exact fields that trigger this behavior are defined in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers),
 with a few additions:
 
 - `.spec.provider.workers[].providerConfig`


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei documentation
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Update seed backup docs to use credentialsRef field

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part of https://github.com/gardener/gardener/issues/9586
x-ref: https://github.com/gardener/gardener/pull/12347#discussion_r2160947091

cc @dimityrmirchev

**Release note**:
```other operator
NONE
```
