### PR TITLE
Fix markdown warning and polish usage doc

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -788,7 +788,7 @@ Options:
 - **`retentionPeriod`**: Defines the duration for which objects in the bucket will remain immutable. Azure Blob Storage only supports immutability durations in days, therefore this field must be set as multiples of 24h.
 - **`locked`**: A boolean indicating whether the retention policy is locked. Once locked, the policy cannot be removed or shortened, ensuring immutability. Learn more about locking policies [here](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-policy-configure-container-scope?tabs=azure-portal#lock-a-time-based-retention-policy).
 
-To configure a `BackupBucket` with immutability, include the `BackupBucketConfig` in the `ProviderConfig` of the `BackupBucket` resource. If the `locked` field is set to `true`, the retention policy will be locked, preventing further changes.
+To configure a `BackupBucket` with immutability, include the `BackupBucketConfig` in the `ProviderConfig` of the `BackupBucket` resource. If the `locked` field is set to `true`, the retention policy will be locked, preventing further changes. However, the retention interval can be lengthened for a locked policy up to five times, but it can't be shortened.
 
 Here is an example of configuring a `BackupBucket` with immutability:
 
@@ -844,7 +844,7 @@ Options:
 - **`rotationPeriodDays`**: Defines the period after its creation that an `storage account key` should be rotated.
 - **`expirationPeriodDays`**: When specified it will install an expiration policy for keys in the Azure storage account.
 
-[!WARN]
-A full rotation (a rotation of both storage account keys) is completed after 2*`rotationPeriod`.
-   It is suggested that the `rotationPeriod` is configured at least twice the maintenance frequency of the shoots. 
-   This will ensure that at least one active key is currently used by the etcd-backup pods.
+> [!WARNING]
+> A full rotation (a rotation of both storage account keys) is completed after 2*`rotationPeriod`.
+> It is suggested that the `rotationPeriod` is configured at least twice the maintenance interval of the shoots. 
+> This will ensure that at least one active key is currently used by the etcd-backup pods.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug
/platform azure

**What this PR does / why we need it**:
This PR fixes the markdown warning key and adds a bit info for clarification.
