### PR TITLE
Set user agent when creating Azure clients

### DIFF
--- a/pkg/azure/client/client_opts.go
+++ b/pkg/azure/client/client_opts.go
@@ -68,6 +68,10 @@ func getAzureClientOpts() *arm.ClientOptions {
 				Transport: getTransport(),
 			},
 			Cloud: cloud.AzurePublic,
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: "GardenerExtProviderAzure", // Limited to 24 chars, no spaces.
+				Disabled:      false,
+			},
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area audit-logging
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Adds information to the UserAgent string of the created client to make it easier to identify calls made by clients created by the extension provider

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Azure seems to have the most restricting of the Provider-SDKs. I've decided to leave the other UA-strings consistent and just shorten the Azure one, but I'll need to test how strictly this is actually enforced.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Clients created by the Azure extension provider will now identify themselves by adding to the `user-agent` header of their calls.
```
