### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.31 | 1.31.0+ | [![Gardener v1.31 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.31%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.31%20Azure) |
 | Kubernetes 1.30 | 1.30.0+ | [![Gardener v1.30 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.30%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.30%20Azure) |
 | Kubernetes 1.29 | 1.29.0+ | [![Gardener v1.29 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.29%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.29%20Azure) |
-| Kubernetes 1.28 | 1.28.0+ | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20Azure) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.30 | 1.30.0+ | [![Gardener v1.30 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.30%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.30%20Azure) |
 | Kubernetes 1.29 | 1.29.0+ | [![Gardener v1.29 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.29%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.29%20Azure) |
 | Kubernetes 1.28 | 1.28.0+ | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20Azure) |
-| Kubernetes 1.27 | 1.27.0+ | [![Gardener v1.27 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.27%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.27%20Azure) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -1,6 +1,5 @@
 replicas: 1
 clusterName: shoot-foo-bar
-kubernetesVersion: 1.32.0
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 clusterName: shoot-foo-bar
-kubernetesVersion: 1.23.9
+kubernetesVersion: 1.32.0
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -78,8 +78,8 @@ spec:
   kubernetes:
     versions:
     - version: 1.32.0
-    - version: 1.23.8
-      expirationDate: "2022-10-31T23:59:59Z"
+    - version: 1.31.1
+      expirationDate: "2025-10-28T23:59:59Z"
   machineImages:
   - name: coreos
     versions:

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -77,7 +77,7 @@ spec:
   type: azure
   kubernetes:
     versions:
-    - version: 1.28.2
+    - version: 1.32.0
     - version: 1.23.8
       expirationDate: "2022-10-31T23:59:59Z"
   machineImages:

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -524,7 +524,7 @@ spec:
     nodes: 10.250.0.0/16
     services: 100.64.0.0/13
   kubernetes:
-    version: 1.28.2
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -582,7 +582,7 @@ spec:
     nodes: 10.250.0.0/16
     services: 100.64.0.0/13
   kubernetes:
-    version: 1.28.2
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -655,7 +655,7 @@ spec:
     nodes: 10.250.0.0/16
     services: 100.64.0.0/13
   kubernetes:
-    version: 1.28.2
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -166,7 +166,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/kube-apiserver:v1.28.2
+        image: registry.k8s.io/kube-apiserver:v1.32.0
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -38,7 +38,7 @@ spec:
       networking:
         pods: 10.250.0.0/19
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
       hibernation:
         enabled: false
     status:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -36,7 +36,7 @@ spec:
     kind: Shoot
     spec:
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
     status:
       lastOperation:
         state: Succeeded

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -16,21 +16,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.27.21"
-  targetVersion: "1.27.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
   tag: "v1.28.14"
   targetVersion: "1.28.x"
   labels:
@@ -117,21 +102,6 @@ images:
         confidentiality_requirement: 'high'
         integrity_requirement: 'high'
         availability_requirement: 'low'
-
-- name: cloud-node-manager
-  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.27.21"
-  targetVersion: "1.27.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
 
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -16,21 +16,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: "v1.28.14"
-  targetVersion: "1.28.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
   tag: "v1.29.15"
   targetVersion: "1.29.x"
   labels:
@@ -102,21 +87,6 @@ images:
         confidentiality_requirement: 'high'
         integrity_requirement: 'high'
         availability_requirement: 'low'
-
-- name: cloud-node-manager
-  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
-  tag: "v1.28.14"
-  targetVersion: "1.28.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
 
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure

--- a/pkg/apis/azure/validation/controlplane_test.go
+++ b/pkg/apis/azure/validation/controlplane_test.go
@@ -37,7 +37,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 				},
 			}
 
-			errorList := ValidateControlPlaneConfig(controlPlane, "1.28.2", fldPath)
+			errorList := ValidateControlPlaneConfig(controlPlane, "1.32.0", fldPath)
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -570,11 +570,10 @@ func getCCMChartValues(
 	}
 
 	values := map[string]interface{}{
-		"enabled":           true,
-		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
-		"clusterName":       cp.Namespace,
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-		"podNetwork":        strings.Join(extensionscontroller.GetPodNetwork(cluster), ","),
+		"enabled":     true,
+		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+		"clusterName": cp.Namespace,
+		"podNetwork":  strings.Join(extensionscontroller.GetPodNetwork(cluster), ","),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 			"checksum/secret-" + azure.CloudProviderConfigName:            checksums[azure.CloudProviderConfigName],
@@ -713,8 +712,7 @@ func getControlPlaneShootChartValues(
 			"vpaEnabled": gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 		},
 		azure.CSINodeName: map[string]interface{}{
-			"enabled":           true,
-			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"enabled": true,
 			"podAnnotations": map[string]interface{}{
 				"checksum/configmap-" + azure.CloudProviderDiskConfigName: cloudProviderDiskConfigChecksum,
 			},

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -308,10 +308,9 @@ var _ = Describe("ValuesProvider", func() {
 			}
 
 			ccmChartValues = utils.MergeMaps(enabledTrue, map[string]interface{}{
-				"replicas":          1,
-				"clusterName":       namespace,
-				"kubernetesVersion": k8sVersion,
-				"podNetwork":        cidr,
+				"replicas":    1,
+				"clusterName": namespace,
+				"podNetwork":  cidr,
 				"podAnnotations": map[string]interface{}{
 					"checksum/secret-cloudprovider":         "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 					"checksum/secret-cloud-provider-config": "77627eb2343b9f2dc2fca3cce35f2f9eec55783aa5f7dac21c473019e5825de2",
@@ -372,7 +371,6 @@ var _ = Describe("ValuesProvider", func() {
 					"genericTokenKubeconfigSecretName": genericTokenKubeconfigSecretName,
 				},
 				azure.CloudControllerManagerName: utils.MergeMaps(ccmChartValues, map[string]interface{}{
-					"kubernetesVersion":   cluster.Shoot.Spec.Kubernetes.Version,
 					"useWorkloadIdentity": false,
 				}),
 				azure.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
@@ -408,7 +406,6 @@ var _ = Describe("ValuesProvider", func() {
 					"genericTokenKubeconfigSecretName": genericTokenKubeconfigSecretName,
 				},
 				azure.CloudControllerManagerName: utils.MergeMaps(ccmChartValues, map[string]interface{}{
-					"kubernetesVersion":   cluster.Shoot.Spec.Kubernetes.Version,
 					"useWorkloadIdentity": false,
 				}),
 				azure.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
@@ -447,7 +444,6 @@ var _ = Describe("ValuesProvider", func() {
 					"genericTokenKubeconfigSecretName": genericTokenKubeconfigSecretName,
 				},
 				azure.CloudControllerManagerName: utils.MergeMaps(ccmChartValues, map[string]interface{}{
-					"kubernetesVersion":   cluster.Shoot.Spec.Kubernetes.Version,
 					"useWorkloadIdentity": false,
 				}),
 				azure.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
@@ -516,7 +512,6 @@ var _ = Describe("ValuesProvider", func() {
 					"checksum/configmap-" + azure.CloudProviderDiskConfigName: checksums[azure.CloudProviderDiskConfigName],
 				},
 				"cloudProviderConfig": cloudProviderConfigData,
-				"kubernetesVersion":   "1.32.0",
 			})
 			cloudControllerManager = map[string]interface{}{
 				"enabled":    true,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -116,7 +116,7 @@ var _ = Describe("ValuesProvider", func() {
 		cidr                    = "10.250.0.0/19"
 		cloudProviderConfigData = "foo"
 
-		k8sVersion = "1.28.2"
+		k8sVersion = "1.32.0"
 
 		enabledTrue    = map[string]interface{}{"enabled": true}
 		enabledFalse   = map[string]interface{}{"enabled": false}
@@ -516,7 +516,7 @@ var _ = Describe("ValuesProvider", func() {
 					"checksum/configmap-" + azure.CloudProviderDiskConfigName: checksums[azure.CloudProviderDiskConfigName],
 				},
 				"cloudProviderConfig": cloudProviderConfigData,
-				"kubernetesVersion":   "1.28.2",
+				"kubernetesVersion":   "1.32.0",
 			})
 			cloudControllerManager = map[string]interface{}{
 				"enabled":    true,

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -60,12 +60,12 @@ var _ = Describe("Ensurer", func() {
 		mgr     *mockmanager.MockManager
 
 		dummyContext   = gcontext.NewGardenContext(nil, nil)
-		eContextK8s127 = gcontext.NewInternalGardenContext(
+		eContextK8s129 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.27.1",
+							Version: "1.29.0",
 						},
 					},
 					Status: gardencorev1beta1.ShootStatus{
@@ -141,10 +141,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to kube-apiserver deployment (k8s < 1.30)", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.27.1")
+			checkKubeAPIServerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to kube-apiserver deployment (k8s = 1.30)", func() {
@@ -215,10 +215,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (k8s < 1.30)", func() {
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.27.1")
+			checkKubeControllerManagerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (k8s = 1.30)", func() {
@@ -283,10 +283,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to kube-scheduler deployment (k8s < 1.30)", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.27.1")
+			checkKubeSchedulerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to kube-scheduler deployment (k8s = 1.30)", func() {
@@ -325,10 +325,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (k8s < 1.30)", func() {
-			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, "1.27.1")
+			checkClusterAutoscalerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (k8s = 1.30)", func() {
@@ -385,7 +385,7 @@ var _ = Describe("Ensurer", func() {
 			newUnitOptions[0].Value += ` \
     --azure-container-registry-config=/var/lib/kubelet/acr.conf`
 
-			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s127, nil, oldUnitOptions, nil)
+			opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s129, nil, oldUnitOptions, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(opts).To(Equal(newUnitOptions))
 		})
@@ -422,8 +422,8 @@ var _ = Describe("Ensurer", func() {
 			},
 
 			Entry("kubelet k8s < 1.30",
-				eContextK8s127,
-				semver.MustParse("1.27.0"),
+				eContextK8s129,
+				semver.MustParse("1.29.0"),
 				map[string]bool{
 					"CSIMigrationAzureFile":           true,
 					"InTreePluginAzureDiskUnregister": true,
@@ -448,7 +448,7 @@ var _ = Describe("Ensurer", func() {
 
 	Describe("#ShouldProvisionKubeletCloudProviderConfig", func() {
 		It("should return false ", func() {
-			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s127, semver.MustParse("1.27.0"))).To(BeFalse())
+			Expect(ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, eContextK8s129, semver.MustParse("1.29.0"))).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform azure

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`provider-azure` no longer supports Shoots with Кubernetes version <= 1.28.
```
