### PR TITLE
Separate bastion reconcile and delete options

### DIFF
--- a/pkg/controller/bastion/bastion_test.go
+++ b/pkg/controller/bastion/bastion_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 )
@@ -49,6 +50,7 @@ var _ = Describe("Bastion test", func() {
 	var (
 		cluster *extensions.Cluster
 		bastion *extensionsv1alpha1.Bastion
+		log     = logf.Log.WithName("bastion-test")
 
 		ctrl                 *gomock.Controller
 		maxLengthForResource int
@@ -69,20 +71,20 @@ var _ = Describe("Bastion test", func() {
 
 	Describe("Testing prepared set of rules based on provided CIDRs", func() {
 		It("should return 4 rules", func() {
-			opt := &Options{
+			opts := Options{
 				PrivateIPAddressV4: "1.1.1.1",
 				PrivateIPAddressV6: "::2.2.2.2",
 				CIDRs:              []string{"213.69.151.131/32", "2001:db8:3333:4444:5555:6666:7777:8888/128"},
 			}
-			rules := prepareNSGRules(opt)
+			rules := prepareNSGRules(opts)
 			Expect(rules).Should(HaveLen(4))
 		})
 		It("should return 2 rules without ipv6", func() {
-			opt := &Options{
+			opts := Options{
 				PrivateIPAddressV4: "1.1.1.1",
 				CIDRs:              []string{"213.69.151.131/32", "2001:db8:3333:4444:5555:6666:7777:8888/128"},
 			}
-			rules := prepareNSGRules(opt)
+			rules := prepareNSGRules(opts)
 			Expect(rules).Should(HaveLen(3))
 		})
 	})
@@ -149,11 +151,11 @@ var _ = Describe("Bastion test", func() {
 
 	Describe("Determine options", func() {
 		It("should return options", func() {
-			options, err := DetermineOptions(bastion, cluster, "cluster1")
+			options, err := NewOpts(bastion, cluster, "cluster1", log)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Expect(options.BastionInstanceName).To(Equal("cluster1-bastionName1-bastion-1cdc8"))
-			Expect(options.BastionPublicIPName).To(Equal("cluster1-bastionName1-bastion-1cdc8-public-ip"))
+			Expect(options.PublicIPName).To(Equal("cluster1-bastionName1-bastion-1cdc8-public-ip"))
 			Expect(options.SecretReference).To(Equal(corev1.SecretReference{
 				Namespace: "cluster1",
 				Name:      "cloudprovider",

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -27,36 +28,42 @@ import (
 // https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
 const maxLengthForBaseName = 33
 
+// BaseOptions contain the information needed for deleting a Bastion on Azure.
+type BaseOptions struct {
+	BastionInstanceName string
+	ResourceGroupName   string
+	DiskName            string
+	PublicIPName        string
+	NicName             string
+	SecurityGroupName   string
+	SecretReference     corev1.SecretReference
+	Logr                logr.Logger
+}
+
 // Options contains provider-related information required for setting up
 // a bastion instance. This struct combines precomputed values like the
 // bastion instance name with the IDs of pre-existing cloud provider
-// resources, like the nic name etc.
+// resources, like the VPC ID, subnet ID etc.
 type Options struct {
-	BastionInstanceName string
-	BastionPublicIPName string
-	PrivateIPAddressV4  string
-	PrivateIPAddressV6  string
-	ResourceGroupName   string
-	SecurityGroupName   string
-	Location            string
-	NicName             string
-	NicID               string
-	DiskName            string
-	SecretReference     corev1.SecretReference
-	WorkersCIDR         []string
-	CIDRs               []string
-	Tags                map[string]*string
-	MachineType         string
-	ImageRef            *armcompute.ImageReference
+	PrivateIPAddressV4 string
+	PrivateIPAddressV6 string
+	Location           string
+	NicID              string
+	WorkersCIDR        []string
+	CIDRs              []string
+	Tags               map[string]*string
+	MachineType        string
+	ImageRef           *armcompute.ImageReference
+	// needed for creation and deletion
+	BaseOptions
 }
 
-// DetermineOptions determines the information that are required to reconcile a Bastion on Azure. This
-// function does not create any IaaS resources.
-func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.Cluster, resourceGroup string) (*Options, error) {
+// NewBaseOpts determines base opts that are required for creating and deleting a Bastion.
+func NewBaseOpts(bastion *extensionsv1alpha1.Bastion, cluster *controller.Cluster, resourceGroup string, log logr.Logger) (BaseOptions, error) {
 	clusterName := cluster.ObjectMeta.Name
 	baseResourceName, err := generateBastionBaseResourceName(clusterName, bastion.Name)
 	if err != nil {
-		return nil, err
+		return BaseOptions{}, err
 	}
 
 	secretReference := corev1.SecretReference{
@@ -64,50 +71,63 @@ func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.C
 		Name:      v1beta1constants.SecretNameCloudProvider,
 	}
 
+	return BaseOptions{
+		BastionInstanceName: baseResourceName,
+		ResourceGroupName:   resourceGroup,
+		SecretReference:     secretReference,
+		Logr:                log,
+		DiskName:            DiskResourceName(baseResourceName),
+		PublicIPName:        publicIPResourceName(baseResourceName),
+		NicName:             NicResourceName(baseResourceName),
+		SecurityGroupName:   NSGName(clusterName),
+	}, nil
+}
+
+// NewOpts determines the information that is required to reconcile a Bastion.
+func NewOpts(bastion *extensionsv1alpha1.Bastion, cluster *controller.Cluster, resourceGroup string, log logr.Logger) (Options, error) {
+	baseOpts, err := NewBaseOpts(bastion, cluster, resourceGroup, log)
+	if err != nil {
+		return Options{}, err
+	}
+
 	cidrs, err := ingressPermissions(bastion)
 	if err != nil {
-		return nil, err
+		return Options{}, err
 	}
 
 	workersCidr, err := getWorkersCIDR(cluster)
 	if err != nil {
-		return nil, err
+		return Options{}, err
 	}
 
 	tags := map[string]*string{
-		"Name": &baseResourceName,
+		"Name": &baseOpts.BastionInstanceName,
 		"Type": ptr.To("gardenctl"),
 	}
 
 	machineSpec, err := extensionsbastion.GetMachineSpecFromCloudProfile(cluster.CloudProfile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine VM details for bastion host: %w", err)
+		return Options{}, fmt.Errorf("failed to determine VM details for bastion host: %w", err)
 	}
 
 	cloudProfileConfig, err := helper.CloudProfileConfigFromCluster(cluster)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract cloud provider config from cluster: %w", err)
+		return Options{}, fmt.Errorf("failed to extract cloud provider config from cluster: %w", err)
 	}
 
 	imageRef, err := getProviderSpecificImage(cloudProfileConfig.MachineImages, machineSpec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract image from provider config: %w", err)
+		return Options{}, fmt.Errorf("failed to extract image from provider config: %w", err)
 	}
 
-	return &Options{
-		BastionInstanceName: baseResourceName,
-		BastionPublicIPName: publicIPResourceName(baseResourceName),
-		SecretReference:     secretReference,
-		CIDRs:               cidrs,
-		WorkersCIDR:         workersCidr,
-		DiskName:            DiskResourceName(baseResourceName),
-		Location:            cluster.Shoot.Spec.Region,
-		ResourceGroupName:   resourceGroup,
-		NicName:             NicResourceName(baseResourceName),
-		Tags:                tags,
-		SecurityGroupName:   NSGName(clusterName),
-		MachineType:         machineSpec.MachineTypeName,
-		ImageRef:            imageRef,
+	return Options{
+		CIDRs:       cidrs,
+		WorkersCIDR: workersCidr,
+		Location:    cluster.Shoot.Spec.Region,
+		Tags:        tags,
+		MachineType: machineSpec.MachineTypeName,
+		ImageRef:    imageRef,
+		BaseOptions: baseOpts,
 	}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Separate bastion reconcile and delete options.
Before deleting a bastion could lead to an error if the image was not found in CloudProfile anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Separate bastion reconcile and delete options
```
