### PR TITLE
remove obsolete TF resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,11 @@ docker-login:
 
 .PHONY: docker-image-provider
 docker-image-provider:
-	@docker buildx build --platform=$(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
+	@docker buildx build --load --platform=$(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
 
 .PHONY: docker-image-admission
 docker-image-admission:
-	@docker buildx build --platform $(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker buildx build --load --platform $(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
 
 .PHONY: docker-images
 docker-images: docker-image-provider docker-image-admission

--- a/cmd/gardener-extension-provider-azure/app/app.go
+++ b/cmd/gardener-extension-provider-azure/app/app.go
@@ -269,8 +269,15 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 					return purgeMachineControllerManagerRBACResources(ctx, mgr.GetClient(), log)
 				})); err != nil {
-					return fmt.Errorf("error adding migrations: %w", err)
+					return fmt.Errorf("error adding mcm migrations: %w", err)
 				}
+			}
+
+			// TODO (kon-angelo): Remove after the release of version 1.46.0
+			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+				return purgeTerraformerRBACResources(ctx, mgr.GetClient(), log)
+			})); err != nil {
+				return fmt.Errorf("error adding terraformer migrations: %w", err)
 			}
 
 			if err := mgr.Start(ctx); err != nil {

--- a/cmd/gardener-extension-provider-azure/app/migrations.go
+++ b/cmd/gardener-extension-provider-azure/app/migrations.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,5 +64,77 @@ func purgeMachineControllerManagerRBACResources(ctx context.Context, c client.Cl
 	}
 
 	log.Info("Successfully deleted the obsolete ClusterRoles and ClusterRoleBindings")
+	return nil
+}
+
+// TODO (kon-angelo): Remove after the release of version 1.46.0
+func purgeTerraformerRBACResources(ctx context.Context, c client.Client, log logr.Logger) error {
+	log.Info("Starting the deletion of obsolete terraformer resources")
+
+	const (
+		terraformerRoleName = "gardener.cloud:system:terraformer"
+	)
+
+	var (
+		roleBindingList    = &rbacv1.RoleBindingList{}
+		roleList           = &rbacv1.RoleList{}
+		serviceAccountList = &corev1.ServiceAccountList{}
+	)
+
+	// list serviceAccount bindings in all namespaces
+	if err := c.List(ctx, roleBindingList); err != nil {
+		return fmt.Errorf("failed to list RoleBindings: %w", err)
+	}
+
+	for _, roleBinding := range roleBindingList.Items {
+		if strings.EqualFold(roleBinding.Name, terraformerRoleName) {
+			log.Info("Deleting RoleBinding", "roleBinding", client.ObjectKeyFromObject(&roleBinding))
+			if err := kutil.DeleteObject(
+				ctx,
+				c,
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: roleBinding.Namespace, Name: roleBinding.Name}},
+			); err != nil {
+				return fmt.Errorf("failed to delete roleBinding %s: %w", client.ObjectKeyFromObject(&roleBinding), err)
+			}
+		}
+	}
+	log.Info("Successfully deleted the obsolete RoleBindings for terraformer")
+
+	if err := c.List(ctx, roleList); err != nil {
+		return fmt.Errorf("failed to list roles: %w", err)
+	}
+
+	for _, role := range roleList.Items {
+		if strings.EqualFold(role.Name, terraformerRoleName) {
+			log.Info("Deleting Role", "role", client.ObjectKeyFromObject(&role))
+			if err := kutil.DeleteObject(
+				ctx,
+				c,
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: role.Namespace, Name: role.Name}},
+			); err != nil {
+				return fmt.Errorf("failed to delete Role %s: %w", client.ObjectKeyFromObject(&role), err)
+			}
+		}
+	}
+	log.Info("Successfully deleted the obsolete Roles for terraformer")
+
+	if err := c.List(ctx, serviceAccountList); err != nil {
+		return fmt.Errorf("failed to list roles: %w", err)
+	}
+
+	for _, serviceAccount := range serviceAccountList.Items {
+		if strings.EqualFold(serviceAccount.Name, "terraformer") {
+			log.Info("Deleting ServiceAccount", "serviceAccount", client.ObjectKeyFromObject(&serviceAccount))
+			if err := kutil.DeleteObject(
+				ctx,
+				c,
+				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name}},
+			); err != nil {
+				return fmt.Errorf("failed to delete ServiceAccount %s: %w", client.ObjectKeyFromObject(&serviceAccount), err)
+			}
+		}
+	}
+	log.Info("Successfully deleted the obsolete ServiceAccounts for terraformer")
+
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove obsolete terraformer resources
```
