### PR TITLE
force vmo migration

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensurer.go
+++ b/pkg/controller/infrastructure/infraflow/ensurer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/controller/infrastructure/infraflow/shared"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/features"
 )
 
 // EnsureResourceGroup creates or updates the shoot's resource group.
@@ -757,7 +758,7 @@ func (fctx *FlowContext) MigrateAvailabilitySet(ctx context.Context) error {
 	}
 
 	// IF VMOs are not needed, or the migration is already done, return early.
-	if !helper.HasShootVmoMigrationAnnotation(fctx.cluster.Shoot.GetAnnotations()) {
+	if !helper.HasShootVmoMigrationAnnotation(fctx.cluster.Shoot.GetAnnotations()) && !features.ExtensionFeatureGate.Enabled(features.ForceAvailabilitySetMigration) {
 		return nil
 	}
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -12,6 +12,9 @@ const (
 	// EnableImmutableBuckets controls whether the controller would react to immutable bucket configuration. Extra permissions from Azure are necessary for this feature to work.
 	// alpha: v1.52.0
 	EnableImmutableBuckets featuregate.Feature = "EnableImmutableBuckets"
+	// ForceAvailabilitySetMigration controls whether the controller will force the migration of existing availability sets to virtual machine scale sets.
+	// alpha: v1.54.0
+	ForceAvailabilitySetMigration featuregate.Feature = "ForceAvailabilitySetMigration"
 )
 
 // ExtensionFeatureGate is the feature gate for the extension controllers.
@@ -28,5 +31,8 @@ func RegisterExtensionFeatureGate() {
 	}))
 	runtime.Must(ExtensionFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
 		EnableImmutableBuckets: {Default: false, PreRelease: featuregate.Alpha},
+	}))
+	runtime.Must(ExtensionFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+		ForceAvailabilitySetMigration: {Default: false, PreRelease: featuregate.Alpha},
 	}))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Introduce feature gate to forcefully migrate Availability set based shoots to VMSS
```
