### PR TITLE
remove lowercase transformation from vm tags

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -514,7 +514,7 @@ func applyWorkerConfig(diskName string, dataDisk map[string]interface{}, dataVol
 // SanitizeAzureVMTag will sanitize the tag base on the azure tag Restrictions
 // refer: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources#limitations
 func SanitizeAzureVMTag(label string) string {
-	return tagRegex.ReplaceAllString(strings.ToLower(label), "_")
+	return tagRegex.ReplaceAllString(label, "_")
 }
 
 func addTopologyLabel(labels map[string]string, region string, zone *zoneInfo) map[string]string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1326

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove lower-case transformation of worker labels when processing VM tags
```
