### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager-provider…

### DIFF
--- a/.ocm/release-notes/github.com_gardener_machine-controller-manager-provider-azure_v0.17.2.release-notes.yaml
+++ b/.ocm/release-notes/github.com_gardener_machine-controller-manager-provider-azure_v0.17.2.release-notes.yaml
@@ -1,0 +1,15 @@
+ocm:
+  component_name: github.com/gardener/machine-controller-manager-provider-azure
+  component_version: v0.17.2
+release_notes:
+- audience: user
+  author:
+    hostname: github.com
+    type: githubUser
+    username: aaronfern
+  category: bugfix
+  contents: Clean up any partially created resources when VM creation fails due to
+    `ResourceExhausted` error
+  mimetype: text/markdown
+  reference: '[#216](https://github.com/gardener/machine-controller-manager-provider-azure/pull/216)'
+  type: standard

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -152,7 +152,7 @@ images:
 - name: machine-controller-manager-provider-azure
   sourceRepository: github.com/gardener/machine-controller-manager-provider-azure
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-azure
-  tag: "v0.17.1"
+  tag: v0.17.2
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform azure

**What this PR does / why we need it**:

Updating machine-controller-manager-provider-azure from v0.17.1 to v0.17.2.

## 🐛 Bug Fixes
- `[USER]` Clean up any partially created resources when VM creation fails due to `ResourceExhausted` error by @aaronfern [[#216](https://github.com/gardener/machine-controller-manager-provider-azure/pull/216)]

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Update mcm image to v0.17.2
```
