### PR TITLE
`chore:` Remove cleanup that is no longer needed

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -176,7 +176,6 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(
 		ensureKubeControllerManagerVolumeMounts(c, cluster.Shoot.Spec.Kubernetes.Version)
 	}
 
-	ensureKubeControllerManagerLabels(template)
 	ensureKubeControllerManagerVolumes(ps, cluster.Shoot.Spec.Kubernetes.Version)
 	return e.ensureChecksumAnnotations(&newDeployment.Spec.Template)
 }
@@ -293,14 +292,6 @@ func ensureClusterAutoscalerCommandLineArgs(c *corev1.Container, k8sVersion *sem
 		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 			"InTreePluginAzureFileUnregister=true", ",")
 	}
-}
-
-func ensureKubeControllerManagerLabels(t *corev1.PodTemplateSpec) {
-	// TODO: This can be removed in a future version.
-	delete(t.Labels, v1beta1constants.LabelNetworkPolicyToBlockedCIDRs)
-
-	delete(t.Labels, v1beta1constants.LabelNetworkPolicyToPublicNetworks)
-	delete(t.Labels, v1beta1constants.LabelNetworkPolicyToPrivateNetworks)
 }
 
 var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Remove cleanup that is no longer needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove controlplane webhook cleanup
```
