### PR TITLE
Deprecate resourcegroup field on infraConfig level

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -172,16 +172,13 @@ networks:
   #   natGateway:
   #     enabled: false
 zoned: false
-# resourceGroup:
-#   name: mygroup
 #identity:
 #  name: my-identity-name
 #  resourceGroup: my-identity-resource-group
 #  acrAccess: true
 ```
 
-Currently, it's not yet possible to deploy into existing resource groups.
-The `.resourceGroup.name` field will allow specifying the name of an already existing resource group that the shoot cluster and all infrastructure resources will be deployed to.
+It is **not** possible to deploy **all** infrastructure resources into an existing resource group.
 
 Via the `.zoned` boolean you can tell whether you want to use Azure availability zones or not.
 When `.zoned` is set to false, the cluster will use VMSS-Flex as the backend of the worker nodes.

--- a/example/30-infrastructure.yaml
+++ b/example/30-infrastructure.yaml
@@ -83,5 +83,3 @@ spec:
     #   serviceEndpoints:
     #   - entry1
     zoned: false
-  # resourceGroup:
-  #   name: mygroup

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -300,7 +300,8 @@ ResourceGroup
 </td>
 <td>
 <em>(Optional)</em>
-<p>ResourceGroup is azure resource group.</p>
+<p>ResourceGroup is azure resource group.
+Deprecated: This feature is no longer supported and will be removed in a future release.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/azure/types_infrastructure.go
+++ b/pkg/apis/azure/types_infrastructure.go
@@ -14,6 +14,7 @@ import (
 type InfrastructureConfig struct {
 	metav1.TypeMeta
 	// ResourceGroup is azure resource group
+	// Deprecated: This feature is no longer supported and will be removed in a future release.
 	ResourceGroup *ResourceGroup
 	// Networks is the network configuration (VNets, subnets, etc.)
 	Networks NetworkConfig

--- a/pkg/apis/azure/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/azure/v1alpha1/types_infrastructure.go
@@ -15,6 +15,7 @@ type InfrastructureConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// ResourceGroup is azure resource group.
 	// +optional
+	// Deprecated: This feature is no longer supported and will be removed in a future release.
 	ResourceGroup *ResourceGroup `json:"resourceGroup,omitempty"`
 	// Networks is the network configuration (VNet, subnets, etc.).
 	Networks NetworkConfig `json:"networks"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR improves documentation to make clear that deploying all resources into a given resource group is not possible.
In addition this PR deprecates the `resourceGroup` field of the infrastructureConfig.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Deprecate resourceGroup field of infrastructureConfig
```
