### PR TITLE
Update CCM v1.31.9->v1.31.10, v1.32.8->v1.32.9, v1.33.3->v1.33.4

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -32,7 +32,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v1.31.9
+  tag: v1.31.10
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -47,7 +47,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v1.32.8
+  tag: v1.32.9
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -62,7 +62,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v1.33.3
+  tag: v1.33.4
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
Update CCM v1.31.9->v1.31.10, v1.32.8->v1.32.9, v1.33.3->v1.33.4
ref: https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/589 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the cloud controller manager visible in Azure China has been fixed by updating the container images as follows:
- v1.31.9 -> v1.31.10
- v1.32.8 -> v1.32.9
- v1.33.3 -> v1.33.4
```
