### PR TITLE
[release-v1.56] Automated cherry pick of #1368: Update CCM v1.31.9->v1.31.10, v1.32.8->v1.32.9, v1.33.3->v1.33.4

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -32,7 +32,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v1.31.9
+  tag: v1.31.10
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -47,7 +47,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v1.32.8
+  tag: v1.32.9
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -62,7 +62,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
-  tag: v1.33.3
+  tag: v1.33.4
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #1368 on release-v1.56.

#1368: Update CCM v1.31.9->v1.31.10, v1.32.8->v1.32.9, v1.33.3->v1.33.4

**Release Notes:**
```bugfix operator
A bug in the cloud controller manager visible in Azure China has been fixed by updating the container images as follows:
- v1.31.9 -> v1.31.10
- v1.32.8 -> v1.32.9
- v1.33.3 -> v1.33.4
```
