### PR TITLE
[release-v1.56] Manual cherry pick of #1367: Bump golang from 1.25.3 to 1.25.4 #1367

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.25.3 AS builder
+FROM golang:1.25.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-azure
 


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #1367 on release-v1.56.

#1367: Bump golang from 1.25.3 to 1.25.4 #1367

**Release Notes:**
```bugfix operator
Executables are now built with Go 1.25.4
```
