### PR TITLE
Rename autonomousShootCluster to selfHostedShootCluster

### DIFF
--- a/charts/gardener-extension-provider-azure/templates/deployment.yaml
+++ b/charts/gardener-extension-provider-azure/templates/deployment.yaml
@@ -80,8 +80,8 @@ spec:
         - --metrics-bind-address=:{{ tpl .Values.metricsPort . }}
         - --health-bind-address=:{{ tpl .Values.healthPort . }}
         - --gardener-version={{ .Values.gardener.version }}
-        {{- if .Values.gardener.autonomousShootCluster }}
-        - --autonomous-shoot-cluster={{ .Values.gardener.autonomousShootCluster }}
+        {{- if .Values.gardener.selfHostedShootCluster }}
+        - --self-hosted-shoot-cluster={{ .Values.gardener.selfHostedShootCluster }}
         {{- end }}
         {{- if eq (include "seed.provider" .) "azure" }}
         - --seed-provider=azure

--- a/charts/gardener-extension-provider-azure/values.yaml
+++ b/charts/gardener-extension-provider-azure/values.yaml
@@ -108,7 +108,7 @@ gardener:
 # runtimeCluster:
 #   enabled: false
 #   priorityClassName: gardener-garden-system-200
-# autonomousShootCluster: false
+# selfHostedShootCluster: false
 
 usablePorts:
 - 8080  # metrics

--- a/cmd/gardener-extension-provider-azure/app/app.go
+++ b/cmd/gardener-extension-provider-azure/app/app.go
@@ -233,14 +233,14 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			reconcileOpts.Completed().Apply(&azurednsrecord.DefaultAddOptions.IgnoreOperationAnnotation, &azurednsrecord.DefaultAddOptions.ExtensionClass)
 			workerCtrlOpts.Completed().Apply(&azureworker.DefaultAddOptions.Controller)
 			azureworker.DefaultAddOptions.GardenCluster = gardenCluster
-			azureworker.DefaultAddOptions.AutonomousShootCluster = generalOpts.Completed().AutonomousShootCluster
+			azureworker.DefaultAddOptions.SelfHostedShootCluster = generalOpts.Completed().SelfHostedShootCluster
 
 			topology.SeedRegion = seedOptions.Completed().Region
 			topology.SeedProvider = seedOptions.Completed().Provider
 			haNamespace.SeedRegion = seedOptions.Completed().Region
 			haNamespace.SeedProvider = seedOptions.Completed().Provider
 
-			shootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil, generalOpts.Completed().AutonomousShootCluster)
+			shootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil, generalOpts.Completed().SelfHostedShootCluster)
 			if err != nil {
 				return fmt.Errorf("could not add webhooks to manager: %w", err)
 			}

--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -209,7 +209,7 @@ func (a *actuator) forceDeleteShootRemedyControllerResources(ctx context.Context
 
 	_, shootClient, err := util.NewClientForShoot(ctx, a.client, cluster.Shoot.GetName(), client.Options{}, extensionsconfigv1alpha1.RESTOptions{})
 	if err != nil {
-		// No need to report the error as this is anyway only best effort. Some scenarios, e.g. autonomous shoot clusters,
+		// No need to report the error as this is anyway only best effort. Some scenarios, e.g. self hosted shoot clusters,
 		// might not have the gardener secret and hence cannot construct the shoot client here.
 		log.Info("Could not create shoot client to check for existing remedy controller resources", "error", err.Error())
 		return err

--- a/pkg/controller/worker/add.go
+++ b/pkg/controller/worker/add.go
@@ -32,8 +32,8 @@ type AddOptions struct {
 	GardenCluster cluster.Cluster
 	// ExtensionClass defines the extension class this extension is responsible for.
 	ExtensionClass extensionsv1alpha1.ExtensionClass
-	// AutonomousShootCluster indicates whether the extension runs in an autonomous shoot cluster.
-	AutonomousShootCluster bool
+	// SelfHostedShootCluster indicates whether the extension runs in a self hosted shoot cluster.
+	SelfHostedShootCluster bool
 }
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
@@ -53,7 +53,7 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 		Predicates:             worker.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
 		Type:                   azure.Type,
 		ExtensionClass:         opts.ExtensionClass,
-		AutonomousShootCluster: opts.AutonomousShootCluster,
+		SelfHostedShootCluster: opts.SelfHostedShootCluster,
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Following [PR13273](https://github.com/gardener/gardener/pull/13273), this PR renames `autonomous shoot cluster` to `self hosted shoot cluster`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This requires the new gardener version introduces by [PR1376](https://github.com/gardener/gardener-extension-provider-azure/pull/1376).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Following the renaming based on [PR13273](https://github.com/gardener/gardener/pull/13273), **autonomous shoot cluster** was renamed to **self hosted shoot cluster**. This leads to e.g. a change of the `/gardener-extension-provider-azure`'s cli argument `--autonomous-shoot-cluster` to change to `--self-hosted-shoot-cluster` and the respective helm chart's variable `.Values.gardener.autonomousShootCluster` to change to `.Values.gardener.selfHostedShootCluster`.
```
