### PR TITLE
[GEP-28] Use technicalID from `Cluster` instead of `Worker.Namespace`

### DIFF
--- a/pkg/controller/worker/machine_dependencies_test.go
+++ b/pkg/controller/worker/machine_dependencies_test.go
@@ -41,7 +41,7 @@ var _ = Describe("MachinesDependencies", func() {
 
 		ctx context.Context
 
-		namespace, resourceGroupName, region string
+		namespace, technicalID, resourceGroupName, region string
 	)
 
 	BeforeEach(func() {
@@ -54,13 +54,10 @@ var _ = Describe("MachinesDependencies", func() {
 		c.EXPECT().Status().AnyTimes().Return(statusWriter)
 
 		ctx = context.TODO()
-		namespace = "shoot--foobar--azure"
-		resourceGroupName = namespace
+		namespace = "control-plane-namespace"
+		technicalID = "shoot--foobar--azure"
+		resourceGroupName = technicalID
 		region = "westeurope"
-		// secretRef = corev1.SecretReference{
-		// 	Name:      "secret",
-		// 	Namespace: namespace,
-		// }
 	})
 
 	Describe("VMO Dependencies", func() {
@@ -82,7 +79,7 @@ var _ = Describe("MachinesDependencies", func() {
 			factory.EXPECT().Vmss().AnyTimes().Return(vmoClient, nil)
 
 			faultDomainCount = 3
-			cluster = makeCluster("", "westeurope", nil, nil, faultDomainCount)
+			cluster = makeCluster(technicalID, "", "westeurope", nil, nil, faultDomainCount)
 			infrastructureStatus = makeInfrastructureStatus(resourceGroupName, "vnet-name", "subnet-name", false, nil, nil)
 			pool = extensionsv1alpha1.WorkerPool{
 				Name: "my-pool",

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -302,7 +302,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 
 			var (
-				deploymentName = fmt.Sprintf("%s-%s", w.worker.Namespace, pool.Name)
+				deploymentName = fmt.Sprintf("%s-%s", w.cluster.Shoot.Status.TechnicalID, pool.Name)
 				className      = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 			)
 
@@ -407,9 +407,9 @@ func (w *workerDelegate) isMachineTypeSupportingAcceleratedNetworking(machineTyp
 // getVMTags returns a map of vm tags
 func (w *workerDelegate) getVMTags(pool extensionsv1alpha1.WorkerPool) map[string]string {
 	vmTags := map[string]string{
-		"Name": w.worker.Namespace,
-		SanitizeAzureVMTag(fmt.Sprintf("kubernetes.io-cluster-%s", w.worker.Namespace)): "1",
-		SanitizeAzureVMTag("kubernetes.io-role-node"):                                   "1",
+		"Name": w.cluster.Shoot.Status.TechnicalID,
+		SanitizeAzureVMTag(fmt.Sprintf("kubernetes.io-cluster-%s", w.cluster.Shoot.Status.TechnicalID)): "1",
+		SanitizeAzureVMTag("kubernetes.io-role-node"):                                                   "1",
 	}
 	for k, v := range pool.Labels {
 		vmTags[SanitizeAzureVMTag(k)] = v

--- a/pkg/controller/worker/utils_test.go
+++ b/pkg/controller/worker/utils_test.go
@@ -103,7 +103,7 @@ func makeWorker(namespace string, region string, sshKey *string, infrastructureS
 	}
 }
 
-func makeCluster(shootVersion, region string, machineTypes []v1alpha1.MachineType, machineImages []v1alpha1.MachineImages, faultDomainCount int32) *extensionscontroller.Cluster {
+func makeCluster(technicalID, shootVersion, region string, machineTypes []v1alpha1.MachineType, machineImages []v1alpha1.MachineImages, faultDomainCount int32) *extensionscontroller.Cluster {
 	cloudProfileConfig := &v1alpha1.CloudProfileConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
@@ -134,6 +134,9 @@ func makeCluster(shootVersion, region string, machineTypes []v1alpha1.MachineTyp
 				Kubernetes: gardencorev1beta1.Kubernetes{
 					Version: shootVersion,
 				},
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				TechnicalID: technicalID,
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement
/platform azure

**What this PR does / why we need it**:

To support self-hosted shoots with managed infrastructure, the `Worker` controller/delegate needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots.
This PR is similar to [gardener/gardener@`22f4295` (#13485)](https://github.com/gardener/gardener/pull/13485/commits/22f429593ba87fb08c3a37fb0ce3c1da914c0f21).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/pull/13485

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `Worker` controller is prepared to support self-hosted shoot clusters with managed infrastructure (see [GEP-28](https://github.com/gardener/gardener/blob/master/docs/proposals/28-self-hosted-shoot-clusters.md#managed-infrastructure)).
```
