### PR TITLE
export testresults as inlined ocm-resource

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,27 +130,36 @@ jobs:
       - name: run-verify
         run: |
           set -euo pipefail
-          .ci/verify
-          # verify calls `make sast-report`, which generates `gosec-report.sarif`
           mkdir /tmp/blobs.d
-          tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
-      - name: add-sast-report-to-component-descriptor
+          .ci/verify |& tee /tmp/blobs.d/test-results.txt
+          tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif         
+          tar czf /tmp/blobs.d/test-results.tar.gz -C /tmp/blobs.d test-results.txt
+      - name: add-reports-to-component-descriptor
         uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
-            name: gosec-report
-            relation: local
-            access:
-              type: localBlob
-              localReference: gosec-report.tar.gz
-            labels:
-              - name: gardener.cloud/purposes
-                value:
-                  - lint
-                  - sast
-                  - gosec
-              - name: gardener.cloud/comment
-                value: |
-                  we use gosec (linter) for SAST scans
-                  see: https://github.com/securego/gosec
+            - name: gosec-report
+              relation: local
+              access:
+                type: localBlob
+                localReference: gosec-report.tar.gz
+              labels:
+                - name: gardener.cloud/purposes
+                  value:
+                    - lint
+                    - sast
+                    - gosec
+                - name: gardener.cloud/comment
+                  value: |
+                    we use gosec (linter) for SAST scans
+                    see: https://github.com/securego/gosec
+            - name: test-results
+              relation: local
+              access:
+                type: localBlob
+                localReference: test-results.tar.gz
+              labels:
+                - name: gardener.cloud/purposes
+                  value:
+                    - test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling


"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind enhancement
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
export testresults as inlined ocm-resource
```
