### PR TITLE
Add strict topology flag to the external provisioner of the CSI Disk controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment.tpl
@@ -133,6 +133,9 @@ spec:
         - --kube-api-qps=100
         - --kube-api-burst=200
         - --v=5
+        {{- if eq .role "disk" }}
+        - --strict-topology
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
         env:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR adds the strict topology flag to the external provisioner of the CSI Disk controller.
We are currently experiencing an issue where newly created PersistentVolumes are provisioned in a different availability zone than the pods that consume them. The external provisioner documentation recommends enabling this flag to address this behavior.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set --strict-topology for the external provisioner of the CSI Disk controller.
```
