### PR TITLE
Fix: Support 2 key variants for dns secret keys (#1403)

### DIFF
--- a/pkg/apis/azure/validation/dnssecrets.go
+++ b/pkg/apis/azure/validation/dnssecrets.go
@@ -12,8 +12,40 @@ import (
 )
 
 var (
-	// dnsCredentialMapping defines validation rules for DNS provider secrets
+	// dnsCredentialMapping defines validation rules for DNS provider secrets using infrastructure keys
 	dnsCredentialMapping = CredentialMapping{
+		Fields: map[string]FieldSpec{
+			azure.SubscriptionIDKey: {
+				Required:    true,
+				IsGUID:      true,
+				IsImmutable: false,
+			},
+			azure.TenantIDKey: {
+				Required:    true,
+				IsGUID:      true,
+				IsImmutable: false,
+			},
+			azure.ClientIDKey: {
+				Required:    true,
+				IsGUID:      true,
+				IsImmutable: false,
+			},
+			azure.ClientSecretKey: {
+				Required:    true,
+				IsGUID:      false,
+				IsImmutable: false,
+			},
+			azure.DNSAzureCloud: {
+				Required:      false,
+				IsGUID:        false,
+				IsImmutable:   false,
+				AllowedValues: []string{"AzurePublic", "AzureChina", "AzureGovernment"},
+			},
+		},
+	}
+
+	// dnsCredentialMappingAlias defines validation rules for DNS provider secrets using DNS-specific keys
+	dnsCredentialMappingAlias = CredentialMapping{
 		Fields: map[string]FieldSpec{
 			azure.DNSSubscriptionIDKey: {
 				Required:    true,
@@ -47,5 +79,25 @@ var (
 
 // ValidateDNSProviderSecret validates Azure DNS provider credentials in a secret.
 func ValidateDNSProviderSecret(secret *corev1.Secret, fldPath *field.Path) field.ErrorList {
-	return dnsCredentialMapping.Validate(secret, nil, fldPath, "DNS records")
+	mapping := selectDNSCredentialMapping(secret)
+	return mapping.Validate(secret, nil, fldPath, "DNS records")
+}
+
+// selectDNSCredentialMapping determines which credential mapping to use based on the
+// keys present in the secret.
+func selectDNSCredentialMapping(secret *corev1.Secret) *CredentialMapping {
+	// Check for any DNS-specific key to determine which key set is used
+	if _, ok := secret.Data[azure.DNSSubscriptionIDKey]; ok {
+		return &dnsCredentialMappingAlias
+	}
+	if _, ok := secret.Data[azure.DNSTenantIDKey]; ok {
+		return &dnsCredentialMappingAlias
+	}
+	if _, ok := secret.Data[azure.DNSClientIDKey]; ok {
+		return &dnsCredentialMappingAlias
+	}
+	if _, ok := secret.Data[azure.DNSClientSecretKey]; ok {
+		return &dnsCredentialMappingAlias
+	}
+	return &dnsCredentialMapping
 }

--- a/pkg/apis/azure/validation/dnssecrets_test.go
+++ b/pkg/apis/azure/validation/dnssecrets_test.go
@@ -45,149 +45,217 @@ var _ = Describe("DNS secrets validation", func() {
 	})
 
 	Describe("ValidateDNSProviderSecret", func() {
-		It("should pass with valid minimal DNS credentials", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+		Context("with DNS-specific keys (alias keys)", func() {
+			It("should pass with valid minimal DNS credentials", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
 
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(BeEmpty())
-		})
-
-		It("should pass with valid complete DNS credentials", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-			secret.Data[azure.DNSAzureCloud] = []byte("AzurePublic")
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(BeEmpty())
-		})
-
-		It("should fail when required AZURE_SUBSCRIPTION_ID is missing", func() {
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
-			expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSSubscriptionIDKey, namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_SUBSCRIPTION_ID]"))
-			Expect(errs[0].Detail).To(Equal(expected))
-		})
-
-		It("should fail when required AZURE_TENANT_ID is missing", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
-			expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSTenantIDKey, namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_TENANT_ID]"))
-			Expect(errs[0].Detail).To(Equal(expected))
-		})
-
-		It("should fail when required AZURE_CLIENT_ID is missing", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
-			expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSClientIDKey, namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLIENT_ID]"))
-			Expect(errs[0].Detail).To(Equal(expected))
-		})
-
-		It("should fail when required AZURE_CLIENT_SECRET is missing", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
-			expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSClientSecretKey, namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLIENT_SECRET]"))
-			Expect(errs[0].Detail).To(Equal(expected))
-		})
-
-		It("should fail when AZURE_SUBSCRIPTION_ID has invalid GUID format", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(invalidGUIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
-			expected := fmt.Sprintf("field %q must be a valid GUID in secret %s/%s", azure.DNSSubscriptionIDKey, namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_SUBSCRIPTION_ID]"))
-			Expect(errs[0].Detail).To(Equal(expected))
-			Expect(errs[0].BadValue).To(Equal("(hidden)"))
-		})
-
-		It("should fail when AZURE_CLIENT_SECRET contains trailing newline (whitespace)", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretNewline)
-
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
-			expected := fmt.Sprintf("field %q must not contain leading or trailing whitespace in secret %s/%s", azure.DNSClientSecretKey, namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLIENT_SECRET]"))
-			Expect(errs[0].Detail).To(Equal(expected))
-			Expect(errs[0].BadValue).To(Equal("(hidden)"))
-		})
-
-		It("should pass with each allowed AZURE_CLOUD value", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-
-			for _, v := range []string{"AzurePublic", "AzureChina", "AzureGovernment"} {
-				secret.Data[azure.DNSAzureCloud] = []byte(v)
 				errs := ValidateDNSProviderSecret(secret, fldPath)
 				Expect(errs).To(BeEmpty())
-			}
+			})
+
+			It("should pass with valid complete DNS credentials", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+				secret.Data[azure.DNSAzureCloud] = []byte("AzurePublic")
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(BeEmpty())
+			})
+
+			It("should fail when required AZURE_SUBSCRIPTION_ID is missing", func() {
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+				expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSSubscriptionIDKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_SUBSCRIPTION_ID]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
+
+			It("should fail when required AZURE_TENANT_ID is missing", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+				expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSTenantIDKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_TENANT_ID]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
+
+			It("should fail when required AZURE_CLIENT_ID is missing", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+				expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSClientIDKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLIENT_ID]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
+
+			It("should fail when required AZURE_CLIENT_SECRET is missing", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+				expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.DNSClientSecretKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLIENT_SECRET]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
+
+			It("should fail when AZURE_SUBSCRIPTION_ID has invalid GUID format", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(invalidGUIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+				expected := fmt.Sprintf("field %q must be a valid GUID in secret %s/%s", azure.DNSSubscriptionIDKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_SUBSCRIPTION_ID]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+				Expect(errs[0].BadValue).To(Equal("(hidden)"))
+			})
+
+			It("should fail when AZURE_CLIENT_SECRET contains trailing newline (whitespace)", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretNewline)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+				expected := fmt.Sprintf("field %q must not contain leading or trailing whitespace in secret %s/%s", azure.DNSClientSecretKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLIENT_SECRET]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+				Expect(errs[0].BadValue).To(Equal("(hidden)"))
+			})
+
+			It("should pass with each allowed AZURE_CLOUD value", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+
+				for _, v := range []string{"AzurePublic", "AzureChina", "AzureGovernment"} {
+					secret.Data[azure.DNSAzureCloud] = []byte(v)
+					errs := ValidateDNSProviderSecret(secret, fldPath)
+					Expect(errs).To(BeEmpty())
+				}
+			})
+
+			It("should fail with invalid AZURE_CLOUD value", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+				secret.Data[azure.DNSAzureCloud] = []byte(invalidAzureCloudValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeNotSupported))
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLOUD]"))
+				Expect(errs[0].BadValue).To(Equal(invalidAzureCloudValue))
+			})
+
+			It("should fail when unexpected field present", func() {
+				secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
+				secret.Data["UNEXPECTED_FIELD"] = []byte("value")
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeForbidden))
+				expected := fmt.Sprintf("unexpected field %q in secret %s/%s", "UNEXPECTED_FIELD", namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[UNEXPECTED_FIELD]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
 		})
 
-		It("should fail with invalid AZURE_CLOUD value", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-			secret.Data[azure.DNSAzureCloud] = []byte(invalidAzureCloudValue)
+		Context("with infrastructure keys", func() {
+			It("should pass with valid minimal DNS credentials using infrastructure keys", func() {
+				secret.Data[azure.SubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.TenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.ClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.ClientSecretKey] = []byte(clientSecretValue)
 
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeNotSupported))
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[AZURE_CLOUD]"))
-			Expect(errs[0].BadValue).To(Equal(invalidAzureCloudValue))
-		})
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(BeEmpty())
+			})
 
-		It("should fail when unexpected field present", func() {
-			secret.Data[azure.DNSSubscriptionIDKey] = []byte(subscriptionIDValue)
-			secret.Data[azure.DNSTenantIDKey] = []byte(tenantIDValue)
-			secret.Data[azure.DNSClientIDKey] = []byte(clientIDValue)
-			secret.Data[azure.DNSClientSecretKey] = []byte(clientSecretValue)
-			secret.Data["UNEXPECTED_FIELD"] = []byte("value")
+			It("should pass with valid complete DNS credentials using infrastructure keys", func() {
+				secret.Data[azure.SubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.TenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.ClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.ClientSecretKey] = []byte(clientSecretValue)
+				secret.Data[azure.DNSAzureCloud] = []byte("AzureChina")
 
-			errs := ValidateDNSProviderSecret(secret, fldPath)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeForbidden))
-			expected := fmt.Sprintf("unexpected field %q in secret %s/%s", "UNEXPECTED_FIELD", namespace, secretName)
-			Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[UNEXPECTED_FIELD]"))
-			Expect(errs[0].Detail).To(Equal(expected))
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(BeEmpty())
+			})
+
+			It("should fail when required subscriptionID is missing", func() {
+				secret.Data[azure.TenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.ClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.ClientSecretKey] = []byte(clientSecretValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+				expected := fmt.Sprintf("missing required field %q in secret %s/%s", azure.SubscriptionIDKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[subscriptionID]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
+
+			It("should fail when subscriptionID has invalid GUID format", func() {
+				secret.Data[azure.SubscriptionIDKey] = []byte(invalidGUIDValue)
+				secret.Data[azure.TenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.ClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.ClientSecretKey] = []byte(clientSecretValue)
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+				expected := fmt.Sprintf("field %q must be a valid GUID in secret %s/%s", azure.SubscriptionIDKey, namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[subscriptionID]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+				Expect(errs[0].BadValue).To(Equal("(hidden)"))
+			})
+
+			It("should fail when unexpected field present with infrastructure keys", func() {
+				secret.Data[azure.SubscriptionIDKey] = []byte(subscriptionIDValue)
+				secret.Data[azure.TenantIDKey] = []byte(tenantIDValue)
+				secret.Data[azure.ClientIDKey] = []byte(clientIDValue)
+				secret.Data[azure.ClientSecretKey] = []byte(clientSecretValue)
+				secret.Data["UNEXPECTED_FIELD"] = []byte("value")
+
+				errs := ValidateDNSProviderSecret(secret, fldPath)
+				Expect(errs).To(HaveLen(1))
+				Expect(errs[0].Type).To(Equal(field.ErrorTypeForbidden))
+				expected := fmt.Sprintf("unexpected field %q in secret %s/%s", "UNEXPECTED_FIELD", namespace, secretName)
+				Expect(errs[0].Field).To(Equal("dnsRecord.spec.secretRef.data[UNEXPECTED_FIELD]"))
+				Expect(errs[0].Detail).To(Equal(expected))
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/platform azure

**What this PR does / why we need it**:
This fix is to support not only the DNS-specific keys for dns provider secrets, but in addition the infrastructure secret keys.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Support not only the DNS-specific keys for dns provider secrets, but in addition the infrastructure secret keys.
```
