### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,20 @@ updates:
   schedule:
     interval: "weekly"
   groups:
-  # Group all version-updates, except Gardener. Gardener-components should receive their own PR this way. Security updates will
-  # also receive their own individual PRs.
     non-gardener-dependencies:
       applies-to: "version-updates"
       patterns:
       - "*"
       exclude-patterns:
       - "github.com/gardener*"
+      - "github.com/Azure/*"
+    provider-sdk-dependencies:
+      applies-to: "version-updates"
+      patterns:
+      - "github.com/Azure/*"
+  ignore:
+  - dependency-name: "k8s.io/*"
+  - dependency-name: "github.com/gardener/etcd-druid/*"
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
Update dependabot to:
- group SDK updates into one PR
- ignore etcd and k8s.io as those are closely tied to Gardener updates