### PR TITLE
[Release 1.57] fix vac CA fg

### DIFF
--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -5,6 +5,9 @@
 package azure
 
 import (
+	"strconv"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
@@ -183,3 +186,12 @@ var (
 		"standard_dc",
 	}
 )
+
+// VolumeAttributesClassBetaEnabled returns true if the VolumeAttributesClass feature is enabled for the given shoot.
+func VolumeAttributesClassBetaEnabled(shoot *gardencorev1beta1.Shoot) bool {
+	if shoot == nil || shoot.GetAnnotations() == nil {
+		return false
+	}
+	ok, _ := strconv.ParseBool(shoot.GetAnnotations()[AnnotationEnableVolumeAttributesClass])
+	return ok
+}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -621,8 +621,8 @@ func getCSIControllerChartValues(
 	if err != nil {
 		return nil, err
 	}
-	if versionutils.ConstraintK8sGreaterEqual131.Check(k8sVersion) {
-		if _, ok := cluster.Shoot.Annotations[azure.AnnotationEnableVolumeAttributesClass]; ok {
+	if versionutils.ConstraintK8sGreaterEqual131.Check(k8sVersion) && versionutils.ConstraintK8sLess134.Check(k8sVersion) {
+		if azure.VolumeAttributesClassBetaEnabled(cluster.Shoot) {
 			values["csiResizer"] = map[string]any{
 				"featureGates": map[string]string{
 					"VolumeAttributesClass": "true",

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -88,6 +88,22 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
+		eContextK8s131WithVAC = gcontext.NewInternalGardenContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"azure.provider.extensions.gardener.cloud/enable-volume-attributes-class": "true",
+						},
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.31.0",
+						},
+					},
+				},
+			},
+		)
 		shootk8s131 = &gardencorev1beta1.Shoot{
 			Spec: gardencorev1beta1.ShootSpec{
 				Kubernetes: gardencorev1beta1.Kubernetes{
@@ -144,21 +160,21 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.29.0")
+			checkKubeAPIServerDeployment(dep, "1.29.0", false)
 		})
 
 		It("should add missing elements to kube-apiserver deployment (k8s = 1.30)", func() {
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s130, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.30.1")
+			checkKubeAPIServerDeployment(dep, "1.30.1", false)
 		})
 
 		It("should add missing elements to kube-apiserver deployment (k8s >= 1.31)", func() {
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s131, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.31.1")
+			checkKubeAPIServerDeployment(dep, "1.31.1", false)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -190,7 +206,16 @@ var _ = Describe("Ensurer", func() {
 			}
 
 			Expect(ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s130, dep, nil)).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, "1.30.1")
+			checkKubeAPIServerDeployment(dep, "1.30.1", false)
+		})
+
+		Context("VolumeAttributesClass", func() {
+			It("should add missing elements to kube-apiserver deployment (k8s >= 1.31 with VolumeAttributeClass)", func() {
+				err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s131WithVAC, dep, nil)
+				Expect(err).To(Not(HaveOccurred()))
+
+				checkKubeAPIServerDeployment(dep, "1.31.1", true)
+			})
 		})
 	})
 
@@ -218,21 +243,21 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.29.0")
+			checkKubeControllerManagerDeployment(dep, "1.29.0", false)
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (k8s = 1.30)", func() {
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s130, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.30.1")
+			checkKubeControllerManagerDeployment(dep, "1.30.1", false)
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.30)", func() {
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s131, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.31.1")
+			checkKubeControllerManagerDeployment(dep, "1.31.1", false)
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
@@ -258,7 +283,17 @@ var _ = Describe("Ensurer", func() {
 
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s130, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeControllerManagerDeployment(dep, "1.30.1")
+			checkKubeControllerManagerDeployment(dep, "1.30.1", false)
+		})
+
+		Context("VolumeAttributesClass", func() {
+			It("should add missing elements to kube-controller-manager deployment (k8s >= 1.31 with VolumeAttributeClass)", func() {
+				err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s131WithVAC, dep, nil)
+				Expect(err).To(Not(HaveOccurred()))
+
+				checkKubeControllerManagerDeployment(dep, "1.31.1", true)
+			})
+
 		})
 	})
 
@@ -286,21 +321,30 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.29.0")
+			checkKubeSchedulerDeployment(dep, "1.29.0", false)
 		})
 
 		It("should add missing elements to kube-scheduler deployment (k8s = 1.30)", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s130, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.30.1")
+			checkKubeSchedulerDeployment(dep, "1.30.1", false)
 		})
 
 		It("should add missing elements to kube-scheduler deployment (k8s >= 1.31)", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s131, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.31.1")
+			checkKubeSchedulerDeployment(dep, "1.31.1", false)
+		})
+
+		Context("VolumeAttributesClass", func() {
+			It("should add missing elements to kube-scheduler deployment (k8s >= 1.31 with VolumeAttributeClass)", func() {
+				err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s131WithVAC, dep, nil)
+				Expect(err).To(Not(HaveOccurred()))
+
+				checkKubeSchedulerDeployment(dep, "1.31.1", true)
+			})
 		})
 	})
 
@@ -328,21 +372,30 @@ var _ = Describe("Ensurer", func() {
 			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, "1.29.0")
+			checkClusterAutoscalerDeployment(dep, "1.29.0", false)
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (k8s = 1.30)", func() {
 			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s130, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, "1.30.1")
+			checkClusterAutoscalerDeployment(dep, "1.30.1", false)
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.31)", func() {
 			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s131, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, "1.31.0")
+			checkClusterAutoscalerDeployment(dep, "1.31.0", false)
+		})
+
+		Context("VolumeAttributesClass", func() {
+			It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.31 with VolumeAttributeClass)", func() {
+				err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s131WithVAC, dep, nil)
+				Expect(err).To(Not(HaveOccurred()))
+
+				checkClusterAutoscalerDeployment(dep, "1.31.1", true)
+			})
 		})
 	})
 
@@ -599,9 +652,10 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string) {
+func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string, volumeAttributesClassEnabled bool) {
 	k8sVersionAtLeast130, _ := version.CompareVersions(k8sVersion, ">=", "1.30")
 	k8sVersionAtLeast131, _ := version.CompareVersions(k8sVersion, ">=", "1.31")
+	k8sVersionLess134, _ := version.CompareVersions(k8sVersion, "<", "1.34")
 
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -609,6 +663,9 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 	Expect(c).To(Not(BeNil()))
 
 	switch {
+	case k8sVersionAtLeast131 && k8sVersionLess134 && volumeAttributesClassEnabled:
+		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--feature-gates=", "VolumeAttributesClass=true", ","))
+		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--runtime-config=", "storage.k8s.io/v1beta1=true", ","))
 	case k8sVersionAtLeast131:
 		Expect(c.Command).NotTo(ContainElement(HavePrefix("--feature-gates")))
 	case k8sVersionAtLeast130:
@@ -628,9 +685,10 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 	Expect(dep.Spec.Template.Annotations).To(BeNil())
 }
 
-func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion string) {
+func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion string, volumeAttributesClassEnabled bool) {
 	k8sVersionAtLeast130, _ := version.CompareVersions(k8sVersion, ">=", "1.30")
 	k8sVersionAtLeast131, _ := version.CompareVersions(k8sVersion, ">=", "1.31")
+	k8sVersionLess134, _ := version.CompareVersions(k8sVersion, "<", "1.34")
 
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -640,6 +698,8 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion str
 	Expect(c.Command).To(ContainElement("--cloud-provider=external"))
 
 	switch {
+	case k8sVersionAtLeast131 && k8sVersionLess134 && volumeAttributesClassEnabled:
+		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--feature-gates=", "VolumeAttributesClass=true", ","))
 	case k8sVersionAtLeast131:
 		Expect(c.Command).NotTo(ContainElement(HavePrefix("--feature-gates")))
 	case k8sVersionAtLeast130:
@@ -660,15 +720,18 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion str
 	Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(usrShareCaCertsVolume))
 }
 
-func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string) {
+func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string, volumeAttributesClassEnabled bool) {
 	k8sVersionAtLeast130, _ := version.CompareVersions(k8sVersion, ">=", "1.30")
 	k8sVersionAtLeast131, _ := version.CompareVersions(k8sVersion, ">=", "1.31")
+	k8sVersionLess134, _ := version.CompareVersions(k8sVersion, "<", "1.34")
 
 	// Check that the kube-scheduler container still exists and contains all needed command line args.
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-scheduler")
 	Expect(c).To(Not(BeNil()))
 
 	switch {
+	case k8sVersionAtLeast131 && k8sVersionLess134 && volumeAttributesClassEnabled:
+		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--feature-gates=", "VolumeAttributesClass=true", ","))
 	case k8sVersionAtLeast131:
 		Expect(c.Command).NotTo(ContainElement(HavePrefix("--feature-gates")))
 	case k8sVersionAtLeast130:
@@ -678,15 +741,18 @@ func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 	}
 }
 
-func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sVersion string) {
+func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sVersion string, volumeAttributesClassEnabled bool) {
 	k8sVersionAtLeast130, _ := version.CompareVersions(k8sVersion, ">=", "1.30")
 	k8sVersionAtLeast131, _ := version.CompareVersions(k8sVersion, ">=", "1.31")
+	k8sVersionLess134, _ := version.CompareVersions(k8sVersion, "<", "1.34")
 
 	// Check that the cluster-autoscaler container still exists and contains all needed command line args.
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "cluster-autoscaler")
 	Expect(c).To(Not(BeNil()))
 
 	switch {
+	case k8sVersionAtLeast131 && k8sVersionLess134 && volumeAttributesClassEnabled:
+		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--feature-gates=", "VolumeAttributesClass=true", ","))
 	case k8sVersionAtLeast131:
 		Expect(c.Command).NotTo(ContainElement(HavePrefix("--feature-gates")))
 	case k8sVersionAtLeast130:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue that would prevent cluster-autoscaler from considering `VolumeAttributesClasses` for scaling on shoot `< v1.34`
```
