### PR TITLE
update azuredisk-csi-driver

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -166,7 +166,7 @@ images:
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver
   repository: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi
-  tag: v1.34.0
+  tag: v1.34.1
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Update container image versions defined in `imagevector/images.yaml`.


**Release note**:
```other dependency
The following container images have been updated:
  - csi-driver-disk: v1.34.0 -> v1.34.1 (minor)
```