### PR TITLE
Add support for (local) multiplatform container images build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.26.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-azure
 
@@ -11,8 +11,10 @@ RUN go mod download
 COPY . .
 
 ARG EFFECTIVE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
+RUN make build GOOS=$TARGETOS GOARCH=$TARGETARCH EFFECTIVE_VERSION=$EFFECTIVE_VERSION BUILD_OUTPUT_FILE="/output/bin/"
 
 ############# base
 FROM gcr.io/distroless/static-debian12:nonroot AS base
@@ -21,12 +23,12 @@ FROM gcr.io/distroless/static-debian12:nonroot AS base
 FROM base AS gardener-extension-provider-azure
 WORKDIR /
 
-COPY --from=builder /go/bin/gardener-extension-provider-azure /gardener-extension-provider-azure
+COPY --from=builder /output/bin/gardener-extension-provider-azure /gardener-extension-provider-azure
 ENTRYPOINT ["/gardener-extension-provider-azure"]
 
 ############# gardener-extension-admission-azure
 FROM base AS gardener-extension-admission-azure
 WORKDIR /
 
-COPY --from=builder /go/bin/gardener-extension-admission-azure /gardener-extension-admission-azure
+COPY --from=builder /output/bin/gardener-extension-admission-azure /gardener-extension-admission-azure
 ENTRYPOINT ["/gardener-extension-admission-azure"]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(EXTENSION_PREFIX))"
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := true
-PLATFORM 					:= linux/amd64
+TARGET_PLATFORMS            ?= linux/$(shell go env GOARCH)
 TEST_RECONCILER             := tf
 EXTENSION_NAMESPACE         := garden
 
@@ -101,17 +101,25 @@ install:
 	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
 	bash $(GARDENER_HACK_DIR)/install.sh ./...
 
+BUILD_OUTPUT_FILE ?= .
+BUILD_PACKAGES ?= ./...
+
+.PHONY: build
+build:
+	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
+		bash $(GARDENER_HACK_DIR)/build.sh -o $(BUILD_OUTPUT_FILE) $(BUILD_PACKAGES)
+
 .PHONY: docker-login
 docker-login:
 	@gcloud auth activate-service-account --key-file .kube-secrets/gcr/gcr-readwrite.json
 
 .PHONY: docker-image-provider
 docker-image-provider:
-	@docker buildx build --load --platform=$(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
+	@docker buildx build --load --platform=$(TARGET_PLATFORMS) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
 
 .PHONY: docker-image-admission
 docker-image-admission:
-	@docker buildx build --load --platform $(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker buildx build --load --platform $(TARGET_PLATFORMS) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
 
 .PHONY: docker-images
 docker-images: docker-image-provider docker-image-admission


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Add support for (local) multiplatform container images build.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Same as https://github.com/gardener/gardener-extension-provider-gcp/pull/1322

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Gardener extension provider-azure container images now can be built for multiple platforms locally via the variable `TARGET_PLATFORMS`, e.g. `make docker-images TARGET_PLATFORMS=linux/amd64,linux/arm64`. If the variable is unset, the container images are built for the platform `linux/<host-arch>` only.
```

```breaking developer
The `PLATFORM` makefile variable has been replaced by `TARGET_PLATFORM`. 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multi-architecture build support so images and binaries can be produced for different OS/CPU targets.
  * Introduced a unified public build entry point plus variables to control target platforms, packages, and build output location.
  * Updated image build flow and output layout to use the new platform handling while keeping runtime entrypoints unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->