### PR TITLE
feat: Add support for VirtualCapacity and prevent rollout when modified

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -28,6 +28,9 @@ metadata:
 nodeTemplate:
   architecture: {{ $machineClass.nodeTemplate.architecture }}
   capacity: {{- toYaml $machineClass.nodeTemplate.capacity | nindent 4 }}
+  {{- if $machineClass.nodeTemplate.virtualCapacity }}
+  virtualCapacity: {{- toYaml $machineClass.nodeTemplate.virtualCapacity | nindent 4 }}
+  {{- end }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}
   region: {{ $machineClass.nodeTemplate.region }}
   zone: {{ $machineClass.nodeTemplate.zone }}

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -468,6 +468,11 @@ Some points to note for this field:
 - a change in the value lead to a rolling update of the machine in the worker pool
 - all the resources needs to be specified
 
+The `nodeTemplate.virtualCapacity` can be used to specify [node extended resources](https://kubernetes.io/docs/tasks/administer-cluster/extended-resource-node/) that are _hot-updated_ on nodes belonging to the pool. There are currently some caveats wrt rollouts:
+- If the `providerConfig` section has not yet been defined for the pool, then a rollout is unavoidable.
+- If the `providerConfig` is already present for the pool, then `nodeTemplate.virtualCapacity` can be added without triggering a rollout as long as the `virtualCapacity` is either the only element of the `nodeTemplate` or the last element.
+- If the `providerConfig` is already present for the pool along with a previously defined `nodeTemplate.virtualCapacity`, then further extended resource attributes may be freely added/modified within `virtualCapacity` without triggering a rollout.
+
 The `.diagnosticsProfile` is used to enable [machine boot diagnostics](https://learn.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics) (disabled per default).
 A storage account is used for storing vm's boot console output and screenshots.
 If `.diagnosticsProfile.StorageURI` is not specified azure managed storage will be used (recommended way).

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -5,8 +5,10 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,4 +60,55 @@ func (w *workerDelegate) updateWorkerProviderStatusWithError(ctx context.Context
 		return fmt.Errorf("%s: %w", err.Error(), statusUpdateErr)
 	}
 	return err
+}
+
+// Precompiled regexes used by stripVirtualCapacity for efficiency
+var (
+	// reOnlyVirtualCapacity matches the entire providerConfig.nodeTemplate object when it contains
+	// ONLY the virtualCapacity field. The match is done regardless of whitespace and newlines.
+	// Example of Matched structure:
+	//     "nodeTemplate": {
+	//         "virtualCapacity" : { ...simple map contents... }
+	//     }
+	reOnlyVirtualCapacity = regexp.MustCompile(
+		`(?s)"nodeTemplate"\s*:\s*\{\s*"virtualCapacity"\s*:\s*\{[^{}]*\}\s*\}\s*,?`,
+	)
+
+	// reTrailingVirtualCapacity matches only the virtualCapacity field when it is the last field inside providerConfig.nodeTemplate and "capacity" appears before it.
+	// Example of matched structure:
+	//      ,"virtualCapacity": { ... simple map contents ... }
+	reTrailingVirtualCapacity = regexp.MustCompile(
+		`(?s),\s*"virtualCapacity"\s*:\s*\{[^{}]*\}\s*`,
+	)
+
+	// reDanglingComma removes any comma followed by optional whitespace followed by closing brace
+	reDanglingComma = regexp.MustCompile(`,\s*}`)
+)
+
+// stripVirtualCapacity removes virtualCapacity (and optionally nodeTemplate)
+// from the given inProviderConfig using regex logic under strict structural assumptions.
+//
+// Assumptions:
+//   - nodeTemplate contains only "capacity" and/or "virtualCapacity"
+//   - Both fields are simple maps { key: int/string }
+//   - virtualCapacity is either:
+//     B) the last field
+//     C) the only field
+//   - No nested objects inside these maps.
+//
+// It preserves all whitespace, indentation, newlines, and key ordering. A final cleanup step removes any illegal trailing ",}" created when removing the
+// last field inside an object.
+func stripVirtualCapacity(inProviderConfig []byte) (outProviderConfig []byte) {
+	outProviderConfig = inProviderConfig
+
+	// Case A: virtualCapacity is the only field -> remove entire nodeTemplate
+	outProviderConfig = reOnlyVirtualCapacity.ReplaceAll(outProviderConfig, []byte(""))
+
+	// Case B: virtualCapacity is the last field -> remove only the virtualCapacity field
+	outProviderConfig = reTrailingVirtualCapacity.ReplaceAll(outProviderConfig, []byte(""))
+
+	// fix any dangling commas after nodeTemplate removal
+	outProviderConfig = reDanglingComma.ReplaceAll(outProviderConfig, []byte("}"))
+
+	return bytes.TrimSpace(outProviderConfig)
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -576,7 +576,7 @@ func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 	return worker.WorkerPoolHash(pool, w.cluster, additionalHashData, additionalHashDataV2, []string{})
 }
 
-// workerPoolHashDataV2 adds additional provider-specific data points to consider to the given data.
+// WorkerPoolHashDataV2 adds additional provider-specific data points to consider to the given data.
 // Addition or Change in VirtualCapacity should NOT cause existing hash to change to prevent trigger of rollout.
 // TODO: once the MCM supports Machine Hot-Update from the WorkerConfig, this hash data logic can be made smarter.
 func WorkerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azureapi.WorkerConfig) ([]string, error) {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -297,7 +297,12 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				}
 				if workerConfig.NodeTemplate != nil {
 					// Support providerConfig extended resources by copying into node template capacity and virtualCapacity
-					maps.Copy(nodeTemplate.Capacity, workerConfig.NodeTemplate.Capacity)
+					if workerConfig.NodeTemplate.Capacity != nil {
+						if nodeTemplate.Capacity == nil {
+							nodeTemplate.Capacity = corev1.ResourceList{}
+						}
+						maps.Copy(nodeTemplate.Capacity, workerConfig.NodeTemplate.Capacity)
+					}
 					if workerConfig.NodeTemplate.VirtualCapacity != nil {
 						if nodeTemplate.VirtualCapacity == nil {
 							nodeTemplate.VirtualCapacity = corev1.ResourceList{}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -7,13 +7,16 @@ package worker
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Masterminds/semver/v3"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -23,7 +26,9 @@ import (
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -282,23 +287,25 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					zoneName = w.worker.Spec.Region + "-" + zone.name
 				}
 
+				nodeTemplate := machinev1alpha1.NodeTemplate{
+					Capacity:        pool.NodeTemplate.Capacity,
+					VirtualCapacity: pool.NodeTemplate.VirtualCapacity,
+					InstanceType:    pool.MachineType,
+					Region:          w.worker.Spec.Region,
+					Zone:            zoneName,
+					Architecture:    &arch,
+				}
 				if workerConfig.NodeTemplate != nil {
-					machineClassSpec["nodeTemplate"] = machinev1alpha1.NodeTemplate{
-						Capacity:     workerConfig.NodeTemplate.Capacity,
-						InstanceType: pool.MachineType,
-						Region:       w.worker.Spec.Region,
-						Zone:         zoneName,
-						Architecture: &arch,
-					}
-				} else if pool.NodeTemplate != nil {
-					machineClassSpec["nodeTemplate"] = machinev1alpha1.NodeTemplate{
-						Capacity:     pool.NodeTemplate.Capacity,
-						InstanceType: pool.MachineType,
-						Region:       w.worker.Spec.Region,
-						Zone:         zoneName,
-						Architecture: &arch,
+					// Support providerConfig extended resources by copying into node template capacity and virtualCapacity
+					maps.Copy(nodeTemplate.Capacity, workerConfig.NodeTemplate.Capacity)
+					if workerConfig.NodeTemplate.VirtualCapacity != nil {
+						if nodeTemplate.VirtualCapacity == nil {
+							nodeTemplate.VirtualCapacity = corev1.ResourceList{}
+						}
+						maps.Copy(nodeTemplate.VirtualCapacity, workerConfig.NodeTemplate.VirtualCapacity)
 					}
 				}
+				machineClassSpec["nodeTemplate"] = nodeTemplate
 			}
 
 			if machineSet != nil {
@@ -361,7 +368,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			return machineDeployment, machineClassSpec
 		}
 
-		workerPoolHash, err := w.generateWorkerPoolHash(pool, infrastructureStatus, vmoDependency, nil)
+		workerPoolHash, err := w.generateWorkerPoolHash(pool, infrastructureStatus, vmoDependency, nil, &workerConfig)
 		if err != nil {
 			return err
 		}
@@ -387,12 +394,12 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				}
 
 				if nodesSubnet.Migrated {
-					workerPoolHash, err = w.generateWorkerPoolHash(pool, infrastructureStatus, vmoDependency, nil)
+					workerPoolHash, err = w.generateWorkerPoolHash(pool, infrastructureStatus, vmoDependency, nil, &workerConfig)
 					if err != nil {
 						return err
 					}
 				} else {
-					workerPoolHash, err = w.generateWorkerPoolHash(pool, infrastructureStatus, vmoDependency, &nodesSubnet.Name)
+					workerPoolHash, err = w.generateWorkerPoolHash(pool, infrastructureStatus, vmoDependency, &nodesSubnet.Name, &workerConfig)
 					if err != nil {
 						return err
 					}
@@ -530,7 +537,7 @@ func addTopologyLabel(labels map[string]string, region string, zone *zoneInfo) m
 	return labels
 }
 
-func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPool, infrastructureStatus *azureapi.InfrastructureStatus, vmoDependency *azureapi.VmoDependency, subnetName *string) (string, error) {
+func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPool, infrastructureStatus *azureapi.InfrastructureStatus, vmoDependency *azureapi.VmoDependency, subnetName *string, workerConfig *azureapi.WorkerConfig) (string, error) {
 	var additionalHashData []string
 
 	// Integrate data disks/volumes in the hash.
@@ -560,20 +567,91 @@ func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 
 	// Include additional data for new worker-pool hash generation.
 	// See https://github.com/gardener/gardener/issues/9699 for more details
-	additionalHashDataV2 := append(additionalHashData, w.workerPoolHashDataV2(pool)...)
+	hashDataV2, err := workerPoolHashDataV2(pool, workerConfig)
+	if err != nil {
+		return "", err
+	}
+	additionalHashDataV2 := append(additionalHashData, hashDataV2...)
 
 	return worker.WorkerPoolHash(pool, w.cluster, additionalHashData, additionalHashDataV2, []string{})
 }
 
 // workerPoolHashDataV2 adds additional provider-specific data points to consider to the given data.
-func (w workerDelegate) workerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool) []string {
-	// in the future, we may not calculate a hash for the whole ProviderConfig
-	// for example volume field changes could be done in place, but MCM needs to support it
-	if pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
-		return []string{string(pool.ProviderConfig.Raw)}
+// Addition or Change in VirtualCapacity should NOT cause existing hash to change to prevent trigger of rollout.
+// TODO: once the MCM supports Machine Hot-Update from the WorkerConfig, this hash data logic can be made smarter.
+func workerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azureapi.WorkerConfig) ([]string, error) {
+	var useNewHashData bool
+	if pool.KubernetesVersion != nil {
+		poolK8sVersion, err := semver.NewVersion(*pool.KubernetesVersion)
+		if err != nil {
+			return nil, err
+		}
+		useNewHashData = versionutils.ConstraintK8sGreaterEqual134.Check(poolK8sVersion)
 	}
 
-	return nil
+	if useNewHashData && workerConfig != nil {
+		return appendHashDataForWorkerConfig(nil, workerConfig), nil
+	}
+
+	if pool.ProviderConfig == nil || pool.ProviderConfig.Raw == nil {
+		return nil, nil
+	}
+
+	// Addition or Change in VirtualCapacity should NOT cause existing hash to change to prevent trigger of rollout.
+	if workerConfig != nil && workerConfig.NodeTemplate != nil && workerConfig.NodeTemplate.VirtualCapacity != nil {
+		modifiedProviderConfig := stripVirtualCapacity(pool.ProviderConfig.Raw)
+		return []string{string(modifiedProviderConfig)}, nil
+	}
+
+	// preserve legacy behaviour
+	return []string{string(pool.ProviderConfig.Raw)}, nil
+}
+
+// appendHashDataForWorkerConfig appends individual WorkerConfig fields to hash data.
+func appendHashDataForWorkerConfig(hashData []string, workerConfig *azureapi.WorkerConfig) []string {
+	if workerConfig.NodeTemplate != nil {
+		keys := slices.Sorted(maps.Keys(workerConfig.NodeTemplate.Capacity)) // ensure order
+		for _, k := range keys {
+			q := workerConfig.NodeTemplate.Capacity[k]
+			hashData = append(hashData, fmt.Sprintf("%s=%d", k, q.Value()))
+		}
+	}
+	if workerConfig.Volume != nil {
+		if workerConfig.Volume.Caching != nil {
+			hashData = append(hashData, *workerConfig.Volume.Caching)
+		}
+	}
+	if workerConfig.DataVolumes != nil {
+		for _, dv := range workerConfig.DataVolumes {
+			hashData = append(hashData, dv.Name)
+			if dv.ImageRef != nil {
+				if dv.ImageRef.URN != nil {
+					hashData = append(hashData, *dv.ImageRef.URN)
+				}
+				if dv.ImageRef.ID != nil {
+					hashData = append(hashData, *dv.ImageRef.ID)
+				}
+				if dv.ImageRef.CommunityGalleryImageID != nil {
+					hashData = append(hashData, *dv.ImageRef.CommunityGalleryImageID)
+				}
+				if dv.ImageRef.SharedGalleryImageID != nil {
+					hashData = append(hashData, *dv.ImageRef.SharedGalleryImageID)
+				}
+			}
+		}
+	}
+	if workerConfig.DiagnosticsProfile != nil {
+		hashData = append(hashData, strconv.FormatBool(workerConfig.DiagnosticsProfile.Enabled))
+		if workerConfig.DiagnosticsProfile.StorageURI != nil {
+			hashData = append(hashData, *workerConfig.DiagnosticsProfile.StorageURI)
+		}
+	}
+	if workerConfig.CapacityReservation != nil {
+		if workerConfig.CapacityReservation.CapacityReservationGroupID != nil {
+			hashData = append(hashData, *workerConfig.CapacityReservation.CapacityReservationGroupID)
+		}
+	}
+	return hashData
 }
 
 // TODO: Remove when we have support for VM Capabilities

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -591,7 +591,7 @@ func WorkerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azur
 		if err != nil {
 			return nil, err
 		}
-		useNewHashData = versionutils.ConstraintK8sGreaterEqual134.Check(poolK8sVersion)
+		useNewHashData = versionutils.ConstraintK8sGreaterEqual135.Check(poolK8sVersion)
 	}
 
 	if useNewHashData && workerConfig != nil {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -567,7 +567,7 @@ func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 
 	// Include additional data for new worker-pool hash generation.
 	// See https://github.com/gardener/gardener/issues/9699 for more details
-	hashDataV2, err := workerPoolHashDataV2(pool, workerConfig)
+	hashDataV2, err := WorkerPoolHashDataV2(pool, workerConfig)
 	if err != nil {
 		return "", err
 	}
@@ -579,7 +579,7 @@ func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 // workerPoolHashDataV2 adds additional provider-specific data points to consider to the given data.
 // Addition or Change in VirtualCapacity should NOT cause existing hash to change to prevent trigger of rollout.
 // TODO: once the MCM supports Machine Hot-Update from the WorkerConfig, this hash data logic can be made smarter.
-func workerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azureapi.WorkerConfig) ([]string, error) {
+func WorkerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azureapi.WorkerConfig) ([]string, error) {
 	var useNewHashData bool
 	if pool.KubernetesVersion != nil {
 		poolK8sVersion, err := semver.NewVersion(*pool.KubernetesVersion)

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -598,10 +598,6 @@ func WorkerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azur
 		return appendHashDataForWorkerConfig(nil, workerConfig), nil
 	}
 
-	if pool.ProviderConfig == nil || pool.ProviderConfig.Raw == nil {
-		return nil, nil
-	}
-
 	// Addition or Change in VirtualCapacity should NOT cause existing hash to change to prevent trigger of rollout.
 	if workerConfig != nil && workerConfig.NodeTemplate != nil && workerConfig.NodeTemplate.VirtualCapacity != nil {
 		modifiedProviderConfig := stripVirtualCapacity(pool.ProviderConfig.Raw)
@@ -609,7 +605,11 @@ func WorkerPoolHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig *azur
 	}
 
 	// preserve legacy behaviour
-	return []string{string(pool.ProviderConfig.Raw)}, nil
+	if pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
+		return []string{string(pool.ProviderConfig.Raw)}, nil
+	}
+
+	return []string{}, nil
 }
 
 // appendHashDataForWorkerConfig appends individual WorkerConfig fields to hash data.

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1254,8 +1254,8 @@ var _ = Describe("Machines", func() {
 					}
 				})
 
-				It("should return the expected hash data when k8s version >= 1.34", func() {
-					pool.KubernetesVersion = ptr.To("1.34.0") // new hash data strategy for ProviderConfig beginning from 1.34.0 onwards
+				It("should return the expected hash data when k8s version >= 1.35", func() {
+					pool.KubernetesVersion = ptr.To("1.35.0") // new hash data strategy for ProviderConfig beginning from 1.35.0 onwards
 					workerConfig.NodeTemplate = &extensionsv1alpha1.NodeTemplate{
 						Capacity: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
@@ -1285,7 +1285,7 @@ var _ = Describe("Machines", func() {
 				})
 
 				It("should return the expected hash data for Rolling update strategy", func() {
-					pool.KubernetesVersion = ptr.To("1.33.0") // old hash data strategy for ProviderConfig for k8s < 1.34
+					pool.KubernetesVersion = ptr.To("1.34.0") // old hash data strategy for ProviderConfig for k8s < 1.35
 					workerConfig.NodeTemplate = &extensionsv1alpha1.NodeTemplate{
 						Capacity: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),

--- a/pkg/controller/worker/testdata/worker-a1.yaml
+++ b/pkg/controller/worker/testdata/worker-a1.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: Worker
+spec:
+  pools:
+  - architecture: amd64
+    kubernetesVersion: 1.33.8
+    labels:
+      kubernetes.io/arch: amd64
+      networking.gardener.cloud/node-local-dns-enabled: "true"
+      node.kubernetes.io/role: node
+      worker.garden.sapcloud.io/group: tst
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/gardener-node-agent-secret-name: fake
+      worker.gardener.cloud/pool: tst
+      worker.gardener.cloud/system-components: "true"
+    machineImage:
+      name: gardenlinux
+      version: 1877.10.0
+    machineType: Standard_DS2_v2
+    maxSurge: 1
+    maxUnavailable: 0
+    maximum: 2
+    minimum: 1
+    name: tst
+    nodeAgentSecretName: fake
+    nodeTemplate:
+      capacity:
+        cpu: "2"
+        gpu: "0"
+        memory: 7Gi
+    providerConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: WorkerConfig
+    updateStrategy: AutoRollingUpdate
+    volume:
+      size: 50Gi
+      type: Standard_LRS
+    zones:
+    - "2"
+  region: westeurope
+  type: azure

--- a/pkg/controller/worker/testdata/worker-a2.yaml
+++ b/pkg/controller/worker/testdata/worker-a2.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: Worker
+spec:
+  pools:
+  - architecture: amd64
+    kubernetesVersion: 1.33.8
+    labels:
+      kubernetes.io/arch: amd64
+      networking.gardener.cloud/node-local-dns-enabled: "true"
+      node.kubernetes.io/role: node
+      worker.garden.sapcloud.io/group: tst
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/gardener-node-agent-secret-name: fake
+      worker.gardener.cloud/pool: tst
+      worker.gardener.cloud/system-components: "true"
+    machineImage:
+      name: gardenlinux
+      version: 1877.10.0
+    machineType: Standard_DS2_v2
+    maxSurge: 1
+    maxUnavailable: 0
+    maximum: 2
+    minimum: 1
+    name: tst
+    nodeAgentSecretName: fake
+    nodeTemplate:
+      capacity:
+        cpu: "2"
+        gpu: "0"
+        memory: 7Gi
+    providerConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: WorkerConfig
+      nodeTemplate:
+        virtualCapacity:
+            security.com/bangle: 10
+            subdomain.domain.com/cpu: "3"
+            subdomain.domain.com/memory: 2048Mi
+    updateStrategy: AutoRollingUpdate
+    volume:
+      size: 50Gi
+      type: Standard_LRS
+    zones:
+    - "2"
+  region: westeurope
+  type: azure

--- a/pkg/controller/worker/testdata/worker-b1.yaml
+++ b/pkg/controller/worker/testdata/worker-b1.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: Worker
+spec:
+  pools:
+  - architecture: amd64
+    kubernetesVersion: 1.33.8
+    labels:
+      kubernetes.io/arch: amd64
+      networking.gardener.cloud/node-local-dns-enabled: "true"
+      node.kubernetes.io/role: node
+      worker.garden.sapcloud.io/group: tst
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/gardener-node-agent-secret-name: fake
+      worker.gardener.cloud/pool: tst
+      worker.gardener.cloud/system-components: "true"
+    machineImage:
+      name: gardenlinux
+      version: 1877.10.0
+    machineType: Standard_DS2_v2
+    maxSurge: 1
+    maxUnavailable: 0
+    maximum: 2
+    minimum: 1
+    name: tst
+    nodeAgentSecretName: fake
+    nodeTemplate:
+      capacity:
+        cpu: "2"
+        gpu: "0"
+        memory: 7Gi
+    providerConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: WorkerConfig
+      nodeTemplate:
+        capacity:
+          cpu: "2"
+          gpu: "0"
+          memory: 7Gi
+    updateStrategy: AutoRollingUpdate
+    volume:
+      size: 50Gi
+      type: Standard_LRS
+    zones:
+    - "2"
+  region: westeurope
+  type: azure

--- a/pkg/controller/worker/testdata/worker-b2.yaml
+++ b/pkg/controller/worker/testdata/worker-b2.yaml
@@ -1,0 +1,50 @@
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: Worker
+spec:
+  pools:
+  - architecture: amd64
+    kubernetesVersion: 1.33.8
+    labels:
+      kubernetes.io/arch: amd64
+      networking.gardener.cloud/node-local-dns-enabled: "true"
+      node.kubernetes.io/role: node
+      worker.garden.sapcloud.io/group: tst
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/gardener-node-agent-secret-name: fake
+      worker.gardener.cloud/pool: tst
+      worker.gardener.cloud/system-components: "true"
+    machineImage:
+      name: gardenlinux
+      version: 1877.10.0
+    machineType: Standard_DS2_v2
+    maxSurge: 1
+    maxUnavailable: 0
+    maximum: 2
+    minimum: 1
+    name: tst
+    nodeAgentSecretName: fake
+    nodeTemplate:
+      capacity:
+        cpu: "2"
+        gpu: "0"
+        memory: 7Gi
+    providerConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: WorkerConfig
+      nodeTemplate:
+        capacity:
+          cpu: "2"
+          gpu: "0"
+          memory: 7Gi   
+        virtualCapacity:
+          security.com/bangle: 10
+          subdomain.domain.com/cpu: "3"
+          subdomain.domain.com/memory: 2048Mi
+    updateStrategy: AutoRollingUpdate
+    volume:
+      size: 50Gi
+      type: Standard_LRS
+    zones:
+    - "2"
+  region: westeurope
+  type: azure

--- a/pkg/controller/worker/testdata/worker-c1.yaml
+++ b/pkg/controller/worker/testdata/worker-c1.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: Worker
+spec:
+  pools:
+  - architecture: amd64
+    kubernetesVersion: 1.33.8
+    labels:
+      kubernetes.io/arch: amd64
+      networking.gardener.cloud/node-local-dns-enabled: "true"
+      node.kubernetes.io/role: node
+      worker.garden.sapcloud.io/group: tst
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/gardener-node-agent-secret-name: fake
+      worker.gardener.cloud/pool: tst
+      worker.gardener.cloud/system-components: "true"
+    machineImage:
+      name: gardenlinux
+      version: 1877.10.0
+    machineType: Standard_DS2_v2
+    maxSurge: 1
+    maxUnavailable: 0
+    maximum: 2
+    minimum: 1
+    name: tst
+    nodeAgentSecretName: fake
+    nodeTemplate:
+      capacity:
+        cpu: "2"
+        gpu: "0"
+        memory: 7Gi
+    providerConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: WorkerConfig
+      volume:
+        caching: ReadWrite
+    updateStrategy: AutoRollingUpdate
+    volume:
+      size: 50Gi
+      type: Standard_LRS
+    zones:
+    - "2"
+  region: westeurope
+  type: azure

--- a/pkg/controller/worker/testdata/worker-c2.yaml
+++ b/pkg/controller/worker/testdata/worker-c2.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: Worker
+spec:
+  pools:
+  - architecture: amd64
+    kubernetesVersion: 1.33.8
+    labels:
+      kubernetes.io/arch: amd64
+      networking.gardener.cloud/node-local-dns-enabled: "true"
+      node.kubernetes.io/role: node
+      worker.garden.sapcloud.io/group: tst
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/gardener-node-agent-secret-name: fake
+      worker.gardener.cloud/pool: tst
+      worker.gardener.cloud/system-components: "true"
+    machineImage:
+      name: gardenlinux
+      version: 1877.10.0
+    machineType: Standard_DS2_v2
+    maxSurge: 1
+    maxUnavailable: 0
+    maximum: 2
+    minimum: 1
+    name: tst
+    nodeAgentSecretName: fake
+    nodeTemplate:
+      capacity:
+        cpu: "2"
+        gpu: "0"
+        memory: 7Gi
+    providerConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: WorkerConfig
+      volume:
+        caching: ReadWrite
+      nodeTemplate:
+        virtualCapacity:
+          security.com/bangle: 10
+          subdomain.domain.com/cpu: "3"
+          subdomain.domain.com/memory: 2048Mi
+    updateStrategy: AutoRollingUpdate
+    volume:
+      size: 50Gi
+      type: Standard_LRS
+    zones:
+    - "2"
+  region: westeurope
+  type: azure


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Introduces support for specifying extended resources via new `virtualCapacity` field in the `nodeTemplate`, allowing for hot-updates of node resources without triggering rollouts. 
Updates the worker pool hash calculation to ensure that changes to `virtualCapacity` do not cause rolling updates and added new tests for the controller logic.

- Added support for specifying `virtualCapacity` in the `nodeTemplate`, added documentation to its usage in the user guide. 
- Changes to  the worker controller to correctly propagate `virtualCapacity` from both pool and provider config to the generated machine class.

**Which issue(s) this PR fixes**:
Fixes #1375 

**Special notes for your reviewer**:
cc: @elankath

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
No rollout hot-update of ProviderConfig.NodeTemplate.VirtualCapacity with/without already existing ProviderConfig.
New hash strategy adopted for ProviderConfig for k8s versions >= 1.35
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional virtualCapacity support for extended/virtual node resources in worker configs.

* **Documentation**
  * Usage guidance for virtualCapacity and rollout behavior caveats added.

* **Improvements**
  * Validation tightened for virtual resources (must be whole-number quantities); capacity acceptance extended to allow vendor/extended resource names.

* **Tests**
  * Expanded tests and sample manifests to verify virtualCapacity handling and worker-hash behavior across versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->