### PR TITLE
Switch to OIDC Federation Service instead of GitHub App

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,8 @@ jobs:
       version-operation: ${{ inputs.release-version }}
       version-commit-callback-action-path: .github/actions/prepare-release
     permissions:
-      contents: read
-      pull-requests: write
+      id-token: write
+      pull-requests: write # required until https://github.com/gardener/cc-utils/pull/1529 is merged
 
   oci-images:
     name: Build OCI-Images

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -28,7 +28,7 @@ jobs:
       mode: snapshot
     secrets: inherit
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
       pull-requests: write
@@ -38,7 +38,6 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
-    secrets: inherit
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pullrequest-trust-helper.yaml
+++ b/.github/workflows/pullrequest-trust-helper.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   pullrequest-trusted-helper:
     permissions:
-      pull-requests: write
-    secrets: inherit # access to `GitHub-Actions`-App is needed to read teams
+      id-token: write
     uses: gardener/cc-utils/.github/workflows/pullrequest-trust-helper.yaml@master
     with:
       trusted-teams: 'core,gardener-extension-provider-azure-maintainers'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    secrets: inherit
     permissions:
-      contents: write
+      contents: read
       id-token: write
       packages: write
       pull-requests: write
@@ -49,7 +50,6 @@ jobs:
       contents: write
       id-token: write
       packages: write
-      pull-requests: write
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -13,8 +13,6 @@ on:
 jobs:
   update-images:
     uses: gardener/cc-utils/.github/workflows/update-extension-provider-images.yaml@master
-    # Pass all available secrets (like the private key)
-    secrets: inherit
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   upgrade-pullrequests:
     uses: gardener/cc-utils/.github/workflows/upgrade-dependencies.yaml@master
-    secrets: inherit
     permissions:
-      contents: write
+      contents: read
       id-token: write


### PR DESCRIPTION
**How to categorize this PR?**
/area delivery
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Currently, the [Gardener GitHub-Actions App](https://github.com/apps/gardener-github-actions) is used to provide more privileged access than available via the default `GITHUB_TOKEN`, for example to circumvent branch protection rules (GitHub Apps can be configured as bypassers) or cross repository privileges. To prevent sharing the GitHub App secret with each and every repository/workflow which requires usage of it, the [GitHub OIDC Federation Service](https://github.com/gardener/github-oidc-federation) has been developed. In essence, it holds the credentials for a central GitHub App and creates short-lived access tokens with a configured scope based on a centrally configured OIDC configuration. See related changes which have been necessary for this repository:

- https://github.com/gardener/.github-oidc/commit/d61ffaa78e14a336da27b287323e6180f3d0fe16

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions and secret handling across automated pipelines to adjust authentication scopes and reduce secret inheritance; these are internal infrastructure changes with no impact on application functionality or end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->