### PR TITLE
Use v2 of the azure cloud controller and cloud node manager images

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -31,7 +31,7 @@ images:
   targetVersion: 1.31.x
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager
   tag: v1.32.11
   labels:
   - name: gardener.cloud/cve-categorisation
@@ -46,7 +46,7 @@ images:
   targetVersion: 1.32.x
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager
+  repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager
   tag: v1.33.6
   labels:
   - name: gardener.cloud/cve-categorisation
@@ -121,7 +121,7 @@ images:
   targetVersion: 1.31.x
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
+  repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager
   tag: v1.32.11
   labels:
   - name: gardener.cloud/cve-categorisation
@@ -136,7 +136,7 @@ images:
   targetVersion: 1.32.x
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
-  repository: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager
+  repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager
   tag: v1.33.6
   labels:
   - name: gardener.cloud/cve-categorisation


### PR DESCRIPTION
for images with version >= 1.32.11 following
https://github.com/kubernetes-sigs/cloud-provider-azure/pull/9792.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind cleanup
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated Azure `cloud-controller-manager` and `cloud-node-manager` image repositories to `mcr.microsoft.com/oss/v2/kubernetes` for Kubernetes versions `>= 1.32` to align with upstream Dalec build system changes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image repository paths to reference current version endpoints for cloud infrastructure management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->