### PR TITLE
[GEP-26] Allow shoots to use WorkloadIdentity as DNS credentials

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -13,7 +13,9 @@ import (
 	gardencorehelper "github.com/gardener/gardener/pkg/api/core/helper"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -204,25 +206,60 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 
 		providerFldPath := providersPath.Index(i)
 
-		if p.SecretName == nil || *p.SecretName == "" {
-			allErrs = append(allErrs, field.Required(providerFldPath.Child("secretName"),
-				fmt.Sprintf("secretName must be specified for %v provider", azure.DNSType)))
-			continue
-		}
+		// TODO(vpnachev): Enable this validation once the extension does not support github.com/gardener/gardener < v1.135.0
+		// if p.CredentialsRef == nil {
+		// 	allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
+		// }
 
-		secret := &corev1.Secret{}
-		key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
-		if err := s.apiReader.Get(ctx, key, secret); err != nil {
-			if apierrors.IsNotFound(err) {
-				allErrs = append(allErrs, field.Invalid(providerFldPath.Child("secretName"),
-					*p.SecretName, "referenced secret not found"))
-			} else {
-				allErrs = append(allErrs, field.InternalError(providerFldPath.Child("secretName"), err))
+		if p.CredentialsRef != nil {
+			credentialsFldPath := providerFldPath.Child("credentialsRef")
+
+			credentials, err := kubernetes.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.GetNamespace())
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.NotFound(credentialsFldPath, p.CredentialsRef.String()))
+				} else {
+					allErrs = append(allErrs, field.InternalError(credentialsFldPath, err))
+				}
+				continue
 			}
-			continue
-		}
 
-		allErrs = append(allErrs, azurevalidation.ValidateDNSProviderSecret(secret, providerFldPath)...)
+			switch creds := credentials.(type) {
+			case *securityv1alpha1.WorkloadIdentity:
+				if err := ValidateWorkloadIdentity(creds, nil); err != nil {
+					allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), err.Error()))
+				}
+			case *corev1.Secret:
+				if errList := azurevalidation.ValidateDNSProviderSecret(creds, field.NewPath("secret")); len(errList) != 0 {
+					allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), errList.ToAggregate().Error()))
+				}
+			default:
+				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials types are Secret and WorkloadIdentity"))
+			}
+		} else { // TODO(vpnachev): Remove the else block once the extension does not support github.com/gardener/gardener < v1.135.0
+			secretNameFldPath := providerFldPath.Child("secretName")
+			if p.SecretName == nil || *p.SecretName == "" {
+				allErrs = append(allErrs, field.Required(secretNameFldPath,
+					fmt.Sprintf("secretName must be specified for %v provider", azure.DNSType)))
+				continue
+			}
+
+			secret := &corev1.Secret{}
+			key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
+			if err := s.apiReader.Get(ctx, key, secret); err != nil {
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.Invalid(secretNameFldPath,
+						*p.SecretName, "referenced secret not found"))
+				} else {
+					allErrs = append(allErrs, field.InternalError(secretNameFldPath, err))
+				}
+				continue
+			}
+
+			if errList := azurevalidation.ValidateDNSProviderSecret(secret, field.NewPath("secret")); len(errList) != 0 {
+				allErrs = append(allErrs, field.Invalid(secretNameFldPath, *p.SecretName, errList.ToAggregate().Error()))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -11,12 +11,14 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -278,173 +280,424 @@ var _ = Describe("Shoot validator", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should return error when azure-dns provider has no secretName", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), Primary: ptr.To(true)}, // secretName missing
-					},
-				}
+			Context("Shoot with custom DNS provider", func() {
+				BeforeEach(func() {
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+				})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.providers[0].secretName"),
-				}))))
-			})
+				Context("#secretName", func() {
+					It("should return error when azure-dns provider has no secretName", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), Primary: ptr.To(true)}, // secretName missing
+							},
+						}
 
-			It("should return error when azure-dns provider secret not found", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-					},
-				}
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-					&corev1.Secret{}).
-					Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
-
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns.providers[0].secretName"),
-				}))))
-			})
-
-			It("should return error when azure-dns secret is invalid (missing subscriptionID)", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-					},
-				}
-				invalidSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-					Data: map[string][]byte{
-						azure.DNSTenantIDKey:     []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-						azure.DNSClientIDKey:     []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-						azure.DNSClientSecretKey: []byte("secret"),
-					},
-				}
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-					&corev1.Secret{}).
-					SetArg(2, *invalidSecret).
-					Return(nil)
-
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.providers[0].data[AZURE_SUBSCRIPTION_ID]"),
-				}))))
-			})
-
-			It("should succeed with valid azure-dns provider secret", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-					},
-				}
-				validSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-					Data: map[string][]byte{
-						azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
-						azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-						azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-						azure.DNSClientSecretKey:   []byte("secret"),
-					},
-				}
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-					&corev1.Secret{}).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-						*obj = *validSecret
-						return nil
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeRequired),
+							"Field": Equal("spec.dns.providers[0].secretName"),
+						}))))
 					})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					It("should return error when azure-dns provider secret not found", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
 
-			It("should skip validation for non-primary azure-dns provider", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(false)},
-					},
-				}
-				// No secret lookup should happen for non-primary providers
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeInvalid),
+							"Field": Equal("spec.dns.providers[0].secretName"),
+						}))))
+					})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					It("should return error when azure-dns secret is invalid (missing subscriptionID)", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
+							},
+						}
+						invalidSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSTenantIDKey:     []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:     []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey: []byte("secret"),
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							SetArg(2, *invalidSecret).
+							Return(nil)
 
-			It("should validate only primary provider when multiple azure-dns providers exist", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-1"), Primary: ptr.To(true)},
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-2"), Primary: ptr.To(false)},
-					},
-				}
-				validSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "dns-secret-1", Namespace: namespace},
-					Data: map[string][]byte{
-						azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
-						azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-						azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-						azure.DNSClientSecretKey:   []byte("secret"),
-					},
-				}
-				// Only the primary provider's secret should be validated
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret-1"},
-					&corev1.Secret{}).
-					SetArg(2, *validSecret).
-					Return(nil)
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.dns.providers[0].secretName"),
+							"Detail": ContainSubstring("missing required field \"AZURE_SUBSCRIPTION_ID\" in secret"),
+						}))))
+					})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					It("should succeed with valid azure-dns provider secret", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
+							},
+						}
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
+								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey:   []byte("secret"),
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+								*obj = *validSecret
+								return nil
+							})
 
-			It("should skip all providers when none are primary", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-1"), Primary: ptr.To(false)},
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-2"), Primary: ptr.To(false)},
-					},
-				}
-				// No secret lookups should happen
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					It("should skip validation for non-primary azure-dns provider", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(false)},
+							},
+						}
+						// No secret lookup should happen for non-primary providers
 
-			It("should validate mixed provider types with primary azure-dns", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{Type: ptr.To("aws-route53"), SecretName: ptr.To("aws-secret"), Primary: ptr.To(false)},
-						{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-						{Type: ptr.To("google-clouddns"), SecretName: ptr.To("gcp-secret"), Primary: ptr.To(false)},
-					},
-				}
-				validSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-					Data: map[string][]byte{
-						azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
-						azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-						azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-						azure.DNSClientSecretKey:   []byte("secret"),
-					},
-				}
-				// Only azure-dns primary provider should be validated
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-					&corev1.Secret{}).
-					SetArg(2, *validSecret).
-					Return(nil)
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
+					It("should validate only primary provider when multiple azure-dns providers exist", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-1"), Primary: ptr.To(true)},
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-2"), Primary: ptr.To(false)},
+							},
+						}
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret-1", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
+								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey:   []byte("secret"),
+							},
+						}
+						// Only the primary provider's secret should be validated
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret-1"},
+							&corev1.Secret{}).
+							SetArg(2, *validSecret).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should skip all providers when none are primary", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-1"), Primary: ptr.To(false)},
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-2"), Primary: ptr.To(false)},
+							},
+						}
+						// No secret lookups should happen
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should validate mixed provider types with primary azure-dns", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To("aws-route53"), SecretName: ptr.To("aws-secret"), Primary: ptr.To(false)},
+								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
+								{Type: ptr.To("google-clouddns"), SecretName: ptr.To("gcp-secret"), Primary: ptr.To(false)},
+							},
+						}
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
+								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey:   []byte("secret"),
+							},
+						}
+						// Only azure-dns primary provider should be validated
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							SetArg(2, *validSecret).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+				})
+
+				Context("#credentialsRef", func() {
+					It("should return error when azure-dns provider Secret not found", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeNotFound),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+						}))))
+					})
+
+					It("should return error when azure-dns provider WorkloadIdentity not found", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "dns-workload-identity",
+									},
+								},
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
+							&securityv1alpha1.WorkloadIdentity{}).
+							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "workloadidentities"}, "dns-workload-identity"))
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeNotFound),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+						}))))
+					})
+
+					It("should succeed with valid azure-dns Secret", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
+							},
+						}
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
+								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey:   []byte("secret"),
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							SetArg(2, *validSecret).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should return error with invalid azure-dns Secret", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
+							},
+						}
+						invalidSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"foo": []byte("bar"),
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
+							&corev1.Secret{}).
+							SetArg(2, *invalidSecret).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeInvalid),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": And(
+								ContainSubstring("missing required field \"subscriptionID\""),
+								ContainSubstring("missing required field \"tenantID\""),
+								ContainSubstring("missing required field \"clientID\""),
+								ContainSubstring("missing required field \"clientSecret\""),
+							),
+						}))))
+					})
+
+					It("should succeed with valid azure-dns WorkloadIdentity", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "dns-workload-identity",
+									},
+								},
+							},
+						}
+						validWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-workload-identity", Namespace: namespace},
+							Spec: securityv1alpha1.WorkloadIdentitySpec{
+								TargetSystem: securityv1alpha1.TargetSystem{
+									Type: "azure",
+									ProviderConfig: &runtime.RawExtension{
+										Raw: []byte(`
+apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkloadIdentityConfig
+clientID: "11111c4e-db61-17fa-a141-ed39b34aa561"
+tenantID: "44444c4e-db61-17fa-a141-ed39b34aa561"
+subscriptionID: "44444c4e-db61-17fa-a141-ed39b34aa561"
+`),
+									},
+								},
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
+							&securityv1alpha1.WorkloadIdentity{}).
+							SetArg(2, *validWorkloadIdentity).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should return error with invalid azure-dns WorkloadIdentity", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "dns-workload-identity",
+									},
+								},
+							},
+						}
+						invalidWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-workload-identity", Namespace: namespace},
+							Spec: securityv1alpha1.WorkloadIdentitySpec{
+								TargetSystem: securityv1alpha1.TargetSystem{
+									Type: "azure",
+									ProviderConfig: &runtime.RawExtension{
+										Raw: []byte(`
+apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkloadIdentityConfig
+clientID: "client-id"
+tenantID: "tenant-id"
+subscriptionID: "subscription-id"
+`),
+									},
+								},
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
+							&securityv1alpha1.WorkloadIdentity{}).
+							SetArg(2, *invalidWorkloadIdentity).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeInvalid),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": And(
+								ContainSubstring("clientID should be a valid GUID"),
+								ContainSubstring("tenantID should be a valid GUID"),
+								ContainSubstring("subscriptionID should be a valid GUID"),
+							),
+						}))))
+					})
+
+					It("should return error with unsupported credentials type", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "foo.bar/v1",
+										Kind:       "Baz",
+										Name:       "dns-baz-ref",
+									},
+								},
+							},
+						}
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInternal),
+							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": ContainSubstring("unsupported credentials reference: garden-dev/dns-baz-ref, foo.bar/v1, Kind=Baz"),
+						}))))
+					})
+
+					It("should return error with InternalSecret type", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "core.gardener.cloud/v1beta1",
+										Kind:       "InternalSecret",
+										Name:       "dns-internal-secret-ref",
+									},
+								},
+							},
+						}
+						internalSecret := &gardencorev1beta1.InternalSecret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-internal-secret-ref", Namespace: namespace},
+							Data: map[string][]byte{
+								"foo": []byte("bar"),
+							},
+						}
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret-ref"},
+							&gardencorev1beta1.InternalSecret{}).
+							SetArg(2, *internalSecret).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": ContainSubstring("supported credentials types are Secret and WorkloadIdentity"),
+						}))))
+					})
+				})
 			})
 		})
 

--- a/pkg/admission/validator/workloadidentity.go
+++ b/pkg/admission/validator/workloadidentity.go
@@ -28,6 +28,11 @@ func NewWorkloadIdentityValidator() extensionswebhook.Validator {
 
 // Validate checks whether the given new workloadidentity contains a valid Azure configuration.
 func (wi *workloadIdentity) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	return ValidateWorkloadIdentity(newObj, oldObj)
+}
+
+// ValidateWorkloadIdentity checks whether the given new workloadidentity contains a valid Azure configuration.
+func ValidateWorkloadIdentity(newObj, oldObj client.Object) error {
 	workloadIdentity, ok := newObj.(*securityv1alpha1.WorkloadIdentity)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind bug
/label ipcei/workload-identity
/platform azure

**What this PR does / why we need it**:
Allow shoots to use WorkloadIdentity as DNS credentials

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
similar to https://github.com/gardener/gardener-extension-provider-aws/pull/1730

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
It is again allowed shoots to use `WorkloadIdentity` as credentials for DNS management, e.g. via the `shoot.spec.dns.providers[].credentialsRef` field.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DNS providers now support WorkloadIdentity credentials in addition to Secrets.
  * Enhanced validation for DNS provider configurations with improved credential reference handling.

* **Tests**
  * Expanded test coverage for DNS provider scenarios, including Azure DNS and credential reference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->