### PR TITLE
Update g/g v1.137.4 -> v1.137.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/gardener/etcd-druid/api v0.35.1
 	github.com/gardener/gardener v1.137.5
-	github.com/gardener/gardener/pkg/apis v1.137.4
+	github.com/gardener/gardener/pkg/apis v1.137.5
 	github.com/gardener/machine-controller-manager v0.61.2
 	github.com/gardener/remedy-controller v0.14.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/gardener/etcd-druid/api v0.35.1 h1:hkd+5iV4xb7glnlo8rCqeXFIy9KmXF958x
 github.com/gardener/etcd-druid/api v0.35.1/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
 github.com/gardener/gardener v1.137.5 h1:rnpkiWL3MR13D9Z2stTL4GvmXWzfCn+Nn6DcA17m1+Q=
 github.com/gardener/gardener v1.137.5/go.mod h1:Gw5+R2G+Agg33mAgzANZYJuJfWHuK5Eo44Ou+B/9w3A=
-github.com/gardener/gardener/pkg/apis v1.137.4 h1:I9nW1yGdTMcMBGp/gkt/xdlrnkXoiw33sTnDcUa3TDA=
-github.com/gardener/gardener/pkg/apis v1.137.4/go.mod h1:QUINW0KPDxMiYQ5bAmIKnsK3oWpseuqMrHnLrMEC5W4=
+github.com/gardener/gardener/pkg/apis v1.137.5 h1:E52DyLS4od0/3MoYtpp43z6SVq24RdG28Zs0UY4fsZI=
+github.com/gardener/gardener/pkg/apis v1.137.5/go.mod h1:QUINW0KPDxMiYQ5bAmIKnsK3oWpseuqMrHnLrMEC5W4=
 github.com/gardener/machine-controller-manager v0.61.2 h1:kG8DgmOqqlljWqxa4x0ER4+L5zg1lxNd1dQXT9gKbvA=
 github.com/gardener/machine-controller-manager v0.61.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/gardener/remedy-controller v0.14.0 h1:KQv6HXka/jWcnb0Bsl99iAEmu4X0mEWLkoywYsF0uI8=


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind bug
/platform azure

**What this PR does / why we need it**:
Fixes an issue where CA scale-downs were getting stuck, see https://github.com/gardener/gardener/pull/14293

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update gardener/gardener v1.137.4 -> v1.137.5
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Gardener platform dependencies to v1.137.5 to ensure compatibility and stability.
  * Bumped Go networking library (golang.org/x/net) to v0.51.0 for improved reliability and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->