### PR TITLE
Make csi-provider-disk flags configurable via shoot annotation

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.tpl
@@ -60,6 +60,14 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --nodeid=$(KUBE_NODE_NAME)
         - --metrics-address=0.0.0.0:{{ include (print "csi-driver-node.daemonset.ports.metrics." .role) . }}
+        {{- if eq .role "disk" }}
+        {{- if .Values.driver.volumeAttachLimit }}
+        - --volume-attach-limit={{ .Values.driver.volumeAttachLimit }}
+        {{- end }}
+        {{- if .Values.driver.reservedDataDiskSlotNum }}
+        - --reserved-data-disk-slot-num={{ .Values.driver.reservedDataDiskSlotNum }}
+        {{- end }}
+        {{- end }}
         - --v=5
         env:
         - name: CSI_ENDPOINT

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -2,6 +2,10 @@ podAnnotations: {}
 cloudProviderConfig: |
   <azure-cloud-provider-config>
 
+driver: {}
+  # volumeAttachLimit: -1
+  # reservedDataDiskSlotNum: -1
+
 images:
   csi-driver-disk: image-repository:image-tag
   csi-driver-file: image-repository:image-tag

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -21,6 +21,12 @@ const (
 	ShootDiskConvertRWCachingModeAnnotation = "azure.provider.extensions.gardener.cloud/convert-rw-caching-mode-for-intree-pv"
 	// NetworkLayoutZoneMigrationAnnotation is used when migrating from a single subnet network layout to a multiple subnet network layout to indicate the zone that the existing subnet should be assigned to.
 	NetworkLayoutZoneMigrationAnnotation = "migration.azure.provider.extensions.gardener.cloud/zone"
+	// VolumeAttachLimit is the key for an annotation on a Shoot object whose value represents the maximum number of
+	// volumes attachable for all nodes.
+	VolumeAttachLimit = "azure.provider.extensions.gardener.cloud/volume-attach-limit"
+	// ReservedVolumeAttachments is the key for an annotation on a Shoot object whose value represents a number of reserved
+	// slots for volume-attachments (in effect an offset to use when calculating available volume-attachments).
+	ReservedVolumeAttachments = "azure.provider.extensions.gardener.cloud/reserved-data-disk-slot-num"
 
 	// DisableDefaultOutboundAccessAnnotation is used to disable the default outbound access for the shoot's subnet.
 	// Deprecated: This annotation is deprecated and will only used for testing until the deprecation by Azure.

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -704,7 +704,27 @@ func getControlPlaneShootChartValues(
 	disableRemedyController := cluster.Shoot.Annotations[azure.DisableRemedyControllerAnnotation] == "true" ||
 		features.ExtensionFeatureGate.Enabled(features.DisableRemedyController)
 
-	return map[string]interface{}{
+	driver := map[string]interface{}{}
+	if value, ok := cluster.Shoot.Annotations[azure.VolumeAttachLimit]; ok {
+		driver["volumeAttachLimit"] = value
+	}
+	if value, ok := cluster.Shoot.Annotations[azure.ReservedVolumeAttachments]; ok {
+		driver["reservedDataDiskSlotNum"] = value
+	}
+
+	csiNodeConfig := map[string]interface{}{
+		"enabled": true,
+		"podAnnotations": map[string]interface{}{
+			"checksum/configmap-" + azure.CloudProviderDiskConfigName: cloudProviderDiskConfigChecksum,
+		},
+		"cloudProviderConfig": cloudProviderDiskConfig,
+	}
+
+	if len(driver) != 0 {
+		csiNodeConfig["driver"] = driver
+	}
+
+	values := map[string]interface{}{
 		// the allow-egress chart is enabled in all cases **except**:
 		// - when the shoot is using AVSets due to using basic loadbalancers (see https://github.com/gardener/gardener-extension-provider-azure/issues/1).
 		// - when the outbound connectivity is done via a NATGateway (currently meaning that all worker subnets have a NATGateway attached).
@@ -715,17 +735,13 @@ func getControlPlaneShootChartValues(
 			"enabled":    true,
 			"vpaEnabled": gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 		},
-		azure.CSINodeName: map[string]interface{}{
-			"enabled": true,
-			"podAnnotations": map[string]interface{}{
-				"checksum/configmap-" + azure.CloudProviderDiskConfigName: cloudProviderDiskConfigChecksum,
-			},
-			"cloudProviderConfig": cloudProviderDiskConfig,
-		},
+		azure.CSINodeName: csiNodeConfig,
 		azure.RemedyControllerName: map[string]interface{}{
 			"enabled": !disableRemedyController,
 		},
-	}, err
+	}
+
+	return values, err
 }
 
 func cleanupSeedLegacyCSISnapshotValidation(

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -551,6 +551,25 @@ var _ = Describe("ValuesProvider", func() {
 			}))
 		})
 
+		It("should return correct control plane chart values when configuring CSI-Driver flags", func() {
+			shootAnnotations := map[string]string{
+				azure.VolumeAttachLimit:         "42",
+				azure.ReservedVolumeAttachments: "2",
+			}
+			cluster = generateCluster(cidr, k8sVersion, false, shootAnnotations, nil, &gardencorev1beta1.Seed{})
+
+			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
+			values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, nil, checksums)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(values).To(HaveKey(azure.CSINodeName))
+			Expect(values[azure.CSINodeName]).To(HaveKey("driver"))
+			csiConfig := values[azure.CSINodeName].(map[string]any)
+			driverConfig := csiConfig["driver"].(map[string]any)
+			Expect(driverConfig).To(HaveKeyWithValue("volumeAttachLimit", "42"))
+			Expect(driverConfig).To(HaveKeyWithValue("reservedDataDiskSlotNum", "2"))
+		})
+
 		It("should return false if allowEgress behavior is overwritten by user", func() {
 			infrastructureStatus.Zoned = true
 			cluster.Shoot.GetAnnotations()[azure.ShootSkipAllowEgressDeployment] = "true"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement
/platform azure

**What this PR does / why we need it**: Allows setting the `--volume-attach-limit` and `--reserved-data-disk-slot-num` flags via shoot annotations `azure.provider.extensions.gardener.cloud/volume-attach-limit` and `azure.provider.extensions.gardener.cloud/reserved-data-disk-slot-num` respectively.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The '--volume-attach-limit' flag of the azuredisk-csi-driver can now be set for a shoot by using the 'azure.provider.extensions.gardener.cloud/volume-attach-limit' annotation.
The '--reserved-data-disk-slot-num' flag of the azuredisk-csi-driver can now be set for a shoot by using the 'azure.provider.extensions.gardener.cloud/reserved-data-disk-slot-num' annotation.
```
