### PR TITLE
Add directives to images.yaml to enhance auto-updates

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -74,6 +74,7 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
+# max-supported-k8s
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager
@@ -164,6 +165,7 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
+# max-supported-k8s
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
  /area dev-productivity
  /kind enhancement
  /platform azure

  **What this PR does / why we need it**:

  This PR adds directives to `imagevector/images.yaml` to leverage the new update-images script functionality introduced in https://github.com/gardener/cc-utils/pull/1572.

  The directives control how image entries are automatically updated:
  - `max-supported-k8s`: Added to entries with `>= 1.35` targetVersion to prevent creating entries for Kubernetes versions not yet supported by Gardener

  **Which issue(s) this PR fixes**:
  Fixes #

  **Special notes for your reviewer**:

  - CSI provisioner and resizer entries have explicit k8s version constraints (require k8s 1.34+). This means based on the changes in https://github.com/gardener/cc-utils/pull/1572, they get updates to the highest available version. The fallback image without the k8s version constraint will only get patch updates.
  - Once a new k8s version is supported in Gardener, the `max-supported-k8s` directive can be removed, and the update workflow triggered. After the new image versions for the new k8s version are added, the directive should be added to the latest version again. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added annotation markers identifying maximum supported Kubernetes versions for cloud infrastructure management components to enhance configuration clarity and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->