### PR TITLE
[GEP-33] Add NamespacedCloudProfile spec capabilityFlavors mutation and fix expirationDate-only override validation

### DIFF
--- a/pkg/admission/mutator/cloudprofile.go
+++ b/pkg/admission/mutator/cloudprofile.go
@@ -53,15 +53,16 @@ func (p *cloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error 
 		return fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", profile.Name, err)
 	}
 
-	overwriteMachineImageCapabilityFlavors(profile, specConfig)
+	mutateMachineImageCapabilityFlavors(profile.Spec.MachineImages, specConfig)
 	return nil
 }
 
-// overwriteMachineImageCapabilityFlavors updates the capability flavors of machine images in the CloudProfile
-func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProfile, config *v1alpha1.CloudProfileConfig) {
+// mutateMachineImageCapabilityFlavors populates capabilityFlavors on the given machineImages
+// slice from the provider config. Used by both CloudProfile and NamespacedCloudProfile mutators.
+func mutateMachineImageCapabilityFlavors(machineImages []gardencorev1beta1.MachineImage, config *v1alpha1.CloudProfileConfig) {
+	// Find the corresponding machine image in the CloudProfile
 	for _, providerMachineImage := range config.MachineImages {
-		// Find the corresponding machine image in the CloudProfile
-		imageIdx := slices.IndexFunc(profile.Spec.MachineImages, func(mi gardencorev1beta1.MachineImage) bool {
+		imageIdx := slices.IndexFunc(machineImages, func(mi gardencorev1beta1.MachineImage) bool {
 			return mi.Name == providerMachineImage.Name
 		})
 		if imageIdx == -1 {
@@ -73,7 +74,7 @@ func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProf
 
 		for versionStr, providerVersions := range groupedVersions {
 			// Find the corresponding version in the CloudProfile's machine image
-			versionIdx := slices.IndexFunc(profile.Spec.MachineImages[imageIdx].Versions, func(miv gardencorev1beta1.MachineImageVersion) bool {
+			versionIdx := slices.IndexFunc(machineImages[imageIdx].Versions, func(miv gardencorev1beta1.MachineImageVersion) bool {
 				return miv.Version == versionStr
 			})
 			if versionIdx == -1 {
@@ -96,7 +97,7 @@ func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProf
 				capabilityFlavors = convertVersionsToCapabilityFlavors(providerVersions)
 			}
 
-			profile.Spec.MachineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = capabilityFlavors
+			machineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = capabilityFlavors
 		}
 	}
 }

--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -36,62 +36,84 @@ type namespacedCloudProfile struct {
 }
 
 // Mutate mutates the given NamespacedCloudProfile object.
-func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error {
+// This handles both the main resource (spec mutation) and the status subresource (status merge).
+func (p *namespacedCloudProfile) Mutate(ctx context.Context, newObj, _ client.Object) error {
 	profile, ok := newObj.(*gardencorev1beta1.NamespacedCloudProfile)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)
 	}
 
-	if shouldSkipMutation(profile) {
+	if profile.DeletionTimestamp != nil || profile.Spec.ProviderConfig == nil {
 		return nil
 	}
 
-	specConfig, statusConfig, err := p.decodeConfigs(profile)
-	if err != nil {
+	specConfig := &v1alpha1.CloudProfileConfig{}
+	if _, _, err := p.decoder.Decode(profile.Spec.ProviderConfig.Raw, nil, specConfig); err != nil {
+		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile spec: %w", err)
+	}
+
+	// Mutation 1: Populate capabilityFlavors on spec.machineImages (fires on main resource create/update)
+	if err := p.mutateSpecCapabilityFlavors(ctx, profile, specConfig); err != nil {
 		return err
+	}
+
+	// Mutation 2: Merge spec providerConfig into status (fires on status subresource updates)
+	if err := p.mergeStatusProviderConfig(profile, specConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// mutateSpecCapabilityFlavors populates spec.machineImages[].versions[].capabilityFlavors
+// from the provider config, so that Gardener core validation passes when machineCapabilities
+// is defined on the parent CloudProfile.
+func (p *namespacedCloudProfile) mutateSpecCapabilityFlavors(ctx context.Context, profile *gardencorev1beta1.NamespacedCloudProfile, specConfig *v1alpha1.CloudProfileConfig) error {
+	// Guards to prevent failures in tests and edge cases
+	if profile.Spec.Parent.Name == "" || len(profile.Spec.MachineImages) == 0 {
+		return nil
+	}
+
+	parentProfile := &gardencorev1beta1.CloudProfile{}
+	if err := p.client.Get(ctx, client.ObjectKey{Name: profile.Spec.Parent.Name}, parentProfile); err != nil {
+		return fmt.Errorf("could not get parent CloudProfile %q: %w", profile.Spec.Parent.Name, err)
+	}
+
+	if len(parentProfile.Spec.MachineCapabilities) == 0 {
+		return nil
+	}
+
+	mutateMachineImageCapabilityFlavors(profile.Spec.MachineImages, specConfig)
+	return nil
+}
+
+// mergeStatusProviderConfig merges the spec providerConfig into the status providerConfig.
+// This only runs when the status has been populated by the NCP reconciler.
+func (p *namespacedCloudProfile) mergeStatusProviderConfig(profile *gardencorev1beta1.NamespacedCloudProfile, specConfig *v1alpha1.CloudProfileConfig) error {
+	if !shouldMergeStatus(profile) {
+		return nil
+	}
+
+	statusConfig := &v1alpha1.CloudProfileConfig{}
+	if _, _, err := p.decoder.Decode(profile.Status.CloudProfileSpec.ProviderConfig.Raw, nil, statusConfig); err != nil {
+		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status: %w", err)
 	}
 
 	statusConfig.MachineImages = mergeMachineImages(specConfig.MachineImages, statusConfig.MachineImages)
 	statusConfig.MachineTypes = mergeMachineTypes(specConfig.MachineTypes, statusConfig.MachineTypes)
 
-	return p.updateProfileStatus(profile, statusConfig)
-}
-
-func shouldSkipMutation(profile *gardencorev1beta1.NamespacedCloudProfile) bool {
-	// Ignore NamespacedCloudProfiles being deleted and wait for core mutator to patch the status.
-	return profile.DeletionTimestamp != nil ||
-		profile.Generation != profile.Status.ObservedGeneration ||
-		profile.Spec.ProviderConfig == nil ||
-		profile.Status.CloudProfileSpec.ProviderConfig == nil
-}
-
-func (p *namespacedCloudProfile) decodeConfigs(profile *gardencorev1beta1.NamespacedCloudProfile) (*v1alpha1.CloudProfileConfig, *v1alpha1.CloudProfileConfig, error) {
-	specConfig := &v1alpha1.CloudProfileConfig{}
-	statusConfig := &v1alpha1.CloudProfileConfig{}
-	if err := p.decodeProviderConfig(profile.Spec.ProviderConfig.Raw, specConfig, "spec"); err != nil {
-		return nil, nil, err
-	}
-	if err := p.decodeProviderConfig(profile.Status.CloudProfileSpec.ProviderConfig.Raw, statusConfig, "status"); err != nil {
-		return nil, nil, err
-	}
-
-	return specConfig, statusConfig, nil
-}
-
-func (p *namespacedCloudProfile) decodeProviderConfig(raw []byte, into *v1alpha1.CloudProfileConfig, configType string) error {
-	if _, _, err := p.decoder.Decode(raw, nil, into); err != nil {
-		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile %s: %w", configType, err)
-	}
-	return nil
-}
-
-func (p *namespacedCloudProfile) updateProfileStatus(profile *gardencorev1beta1.NamespacedCloudProfile, config *v1alpha1.CloudProfileConfig) error {
-	modifiedStatusConfig, err := json.Marshal(config)
+	modifiedStatusConfig, err := json.Marshal(statusConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal status config: %w", err)
 	}
 	profile.Status.CloudProfileSpec.ProviderConfig.Raw = modifiedStatusConfig
 	return nil
+}
+
+// shouldMergeStatus returns true when the status subresource has been populated by the NCP reconciler.
+func shouldMergeStatus(profile *gardencorev1beta1.NamespacedCloudProfile) bool {
+	return profile.Generation == profile.Status.ObservedGeneration &&
+		profile.Status.CloudProfileSpec.ProviderConfig != nil
 }
 
 func mergeMachineImages(specMachineImages, statusMachineImages []v1alpha1.MachineImages) []v1alpha1.MachineImages {

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -76,6 +76,132 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 			Expect(namespacedCloudProfile).To(DeepEqual(expectedProfile))
 		})
 
+		Describe("populate spec capabilityFlavors from provider config", func() {
+			var parentProfile *v1beta1.CloudProfile
+
+			BeforeEach(func() {
+				parentProfile = &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "parent-profile"},
+					Spec: v1beta1.CloudProfileSpec{
+						MachineCapabilities: []v1beta1.CapabilityDefinition{{
+							Name:   "architecture",
+							Values: []string{"amd64", "arm64"},
+						}},
+					},
+				}
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "parent-profile",
+				}
+			})
+
+			It("should populate capabilityFlavors from old format provider config", func() {
+				Expect(fakeClient.Create(ctx, parentProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"ubuntu","versions":[
+    {"version":"22.04","id":"canonical:ubuntu:22.04:latest"},
+    {"version":"22.04","architecture":"arm64","id":"canonical:ubuntu:22.04:arm64"}
+  ]}
+]}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+						{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}},
+					}},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).ToNot(BeEmpty())
+				// Should have flavors for both amd64 and arm64
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(HaveLen(2))
+			})
+
+			It("should populate capabilityFlavors from new format provider config", func() {
+				Expect(fakeClient.Create(ctx, parentProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"ubuntu","versions":[{"version":"22.04","capabilityFlavors":[
+    {"capabilities":{"architecture":["amd64"]},"id":"canonical:ubuntu:22.04:latest"},
+    {"capabilities":{"architecture":["arm64"]},"id":"canonical:ubuntu:22.04:arm64"}
+  ]}]}
+]}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+						{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}},
+					}},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{"architecture": []string{"amd64"}}},
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{"architecture": []string{"arm64"}}},
+				))
+			})
+
+			It("should skip spec mutation when parent has no machineCapabilities", func() {
+				parentProfile.Spec.MachineCapabilities = nil
+				Expect(fakeClient.Create(ctx, parentProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"ubuntu","versions":[{"version":"22.04","id":"canonical:ubuntu:22.04:latest"}]}
+]}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+						{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}},
+					}},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// capabilityFlavors should NOT be populated
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(BeEmpty())
+			})
+
+			It("should skip spec mutation when Spec.Parent.Name is empty", func() {
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"ubuntu","versions":[{"version":"22.04","id":"canonical:ubuntu:22.04:latest"}]}
+]}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+						{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}},
+					}},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// capabilityFlavors should NOT be populated
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(BeEmpty())
+			})
+
+			It("should skip spec mutation when Spec.MachineImages is empty", func() {
+				Expect(fakeClient.Create(ctx, parentProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"ubuntu","versions":[{"version":"22.04","id":"canonical:ubuntu:22.04:latest"}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+			})
+		})
+
 		Describe("merge the provider configurations from a NamespacedCloudProfile and the parent CloudProfile", func() {
 			It("should correctly merge extended machineImages", func() {
 				namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -32,7 +32,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:     "/webhooks/mutate",
 		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
 			NewShootMutator(mgr):                  {{Obj: &gardencorev1beta1.Shoot{}}},
-			NewNamespacedCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},
+			NewNamespacedCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.NamespacedCloudProfile{}}, {Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},
 			NewCloudProfileMutator(mgr):           {{Obj: &gardencorev1beta1.CloudProfile{}}},
 		},
 		Target: extensionswebhook.TargetSeed,

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -151,6 +151,11 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 				// Support mixed format: group provider versions by version string
 				providerVersions, versionExists := providerVersionsMap[machineImage.Name][version.Version]
 				if !versionExists || len(providerVersions) == 0 {
+					// If the version exists in the parent, it's an expirationDate-only override
+					// that doesn't change image mappings — skip validation.
+					if _, existsInParentVersion := parentImages.GetImageVersion(machineImage.Name, version.Version); existsInParentVersion {
+						continue
+					}
 					allErrs = append(allErrs, field.Required(imagesPath,
 						fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
 					))

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -372,6 +372,65 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile Validator", func(isCapabili
 			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should succeed for expirationDate-only override of a parent version without providerConfig entry", func() {
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+					{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}, Architectures: []string{"amd64"}},
+				}},
+			}
+			if isCapabilitiesCloudProfile {
+				cloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors = []v1beta1.MachineImageFlavor{
+					{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+				}
+			}
+
+			// NCP overrides only the expirationDate, no providerConfig entry for ubuntu
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "ubuntu",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "22.04", ExpirationDate: ptr.To(metav1.Now())}, Architectures: []string{"amd64"},
+							CapabilityFlavors: []core.MachineImageFlavor{
+								{Capabilities: core.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+							}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should fail for new version NOT in parent AND not in providerConfig", func() {
+			// When the image doesn't exist at all in the parent, a new version
+			// without providerConfig entry should be rejected.
+			// NCP defines image "new-image" version "1.0" that is NOT in parent and NOT in providerConfig
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "new-image",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.0"}, Architectures: []string{"amd64"},
+							CapabilityFlavors: []core.MachineImageFlavor{
+								{Capabilities: core.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+							}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 },
 	Entry("CloudProfile uses NO capabilities", false),


### PR DESCRIPTION
/area control-plane
/kind enhancement
/platform azure

**What this PR does / why we need it**:

Fixes `NamespacedCloudProfile` admission to:
1. Populate `capabilityFlavors` on `spec.machineImages` from providerConfig (required by Gardener core validation when parent uses `machineCapabilities`)
2. Allow expirationDate-only overrides of parent versions without requiring a providerConfig entry


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fix `NamespacedCloudProfile` admission to populate `capabilityFlavors` on spec machine images and allow expirationDate-only overrides of parent versions without requiring a providerConfig entry.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed capability flavor mutation for NamespacedCloudProfile resources with a parent CloudProfile.
  * Improved validation for machine image version overrides containing only expiration date changes.

* **Tests**
  * Added comprehensive test coverage for capability flavor population from provider configurations.
  * Added test cases validating machine image version override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->