### PR TITLE
docs: Add note about Flexible federated identity 

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -93,10 +93,10 @@ kubectl -n garden-myproj get wi azure -o=jsonpath={.status.sub}
 As a second step users should configure [Workload Identity Federation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp#other-identity-providers) so that their application trusts Gardener's Workload Identity Issuer.
 
 > [!TIP]
-> You can retrieve Gardener's Workload Identity Issuer URL directly from the Garden cluster by reading the contents of the [Gardener Info ConfigMap](https://gardener.cloud/docs/gardener/gardener/gardener_info_configmap/).
+> You can retrieve Gardener's Workload Identity Issuer URL directly from the Garden cluster by reading the contents of the [Gardener Info ConfigMap](https://gardener.cloud/docs/gardener/configmap/).
 >
 > ```bash
-> kubectl -n gardener-system-public get configmap -o yaml
+> kubectl -n gardener-system-public get configmap gardener-info -o yaml
 > ```
 
 In the shown example a `WorkloadIdentity` with name `azure` with id `00000000-0000-0000-0000-000000000000` from the `garden-myproj` namespace will be trusted by the Azure application.

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -106,6 +106,10 @@ In the shown example a `WorkloadIdentity` with name `azure` with id `00000000-00
 
 ![Federated Credential](images/federated_credential.png)
 
+> [!NOTE]
+> Flexible federated identity credentials currently support only few well-known [public services issuing tokens](https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-flexible-federated-identity-credentials?tabs=github#how-do-flexible-federated-identity-credentials-work).
+> Gardener Workload identity can be configured as (standard) federated identity credentials only.
+
 Please ensure that the Azure application (spn) has the proper [IAM actions](azure-permissions.md) assigned.
 If no fine-grained permissions/actions required then simply assign the [Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) role.
 


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Add note that Flexible federated identity has restricted support for few public well-known services issuing tokens. 
Fix the link to the gardener-info configmap documentation. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced instructions for retrieving Gardener's Workload Identity Issuer URL with more specific ConfigMap references and refined kubectl command guidance.
  * Added clarifications on federated identity credential limitations, specifying which public token issuers are supported.
  * Documented that Gardener's Workload Identity uses standard federated identity credentials configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/gardener-extension-provider-azure/pull/1531)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->