### PR TITLE
add support for diskControllerType

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -108,6 +108,9 @@ providerSpec:
             securityEncryptionType: {{ $machineClass.osDisk.securityProfile.securityEncryptionType }}
 {{- end }}
         createOption: FromImage
+{{- if hasKey $machineClass.osDisk "diskControllerType" }}
+      diskControllerType: {{ $machineClass.osDisk.diskControllerType }}
+{{- end }}
 {{- if $machineClass.dataDisks }}
       dataDisks: {{- toYaml $machineClass.dataDisks | nindent 6 }}
 {{- end }}

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -108,8 +108,8 @@ providerSpec:
             securityEncryptionType: {{ $machineClass.osDisk.securityProfile.securityEncryptionType }}
 {{- end }}
         createOption: FromImage
-{{- if hasKey $machineClass.osDisk "diskControllerType" }}
-      diskControllerType: {{ $machineClass.osDisk.diskControllerType }}
+{{- if hasKey $machineClass "diskControllerType" }}
+      diskControllerType: {{ $machineClass.diskControllerType }}
 {{- end }}
 {{- if $machineClass.dataDisks }}
       dataDisks: {{- toYaml $machineClass.dataDisks | nindent 6 }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -47,6 +47,7 @@ machineClasses:
 #      uefiSettings:
 #        vtpmEnabled: false
     caching: None # TODO remove default after https://github.com/gardener/machine-controller-manager-provider-azure/issues/214
+#  diskControllerType: SCSI
   sshPublicKey: ssh-rsa AAAAB3...
 - name: class-3-vmo
   region: westeurope

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -459,7 +459,8 @@ dataVolumes:
 #      id: /Subscriptions/2ebd38b6-270b-48a2-8e0b-2077106dc615/Providers/Microsoft.Compute/Locations/westeurope/Publishers/sap/ArtifactTypes/VMImage/Offers/gardenlinux/Skus/greatest/Versions/1443.10.0
 #      urn: sap:gardenlinux:greatest:1443.10.0
 volume:
-  cachingType: ReadWrite
+  caching: ReadWrite
+  diskControllerType: NVMe
 ```
 
 The `.nodeTemplate` is used to specify resource information of the machine during runtime. This then helps in Scale-from-Zero.
@@ -487,6 +488,9 @@ The `.volume` field is used to add provider specific configurations for a osDisk
 The OS disk is the disk that contains the operating system and is mounted as `/` in the machine.
 You can configure the host caching type by specifying `.volume.caching` in the workerConfig.
 The default value is `None`, current supported values are `None`, `ReadOnly`, `ReadWrite`.
+You can configure the disk controller type by specifying `.volume.diskControllerType` in the workerConfig.
+Current supported values are `SCSI` and `NVMe`.
+If omitted, Azure chooses the default disk controller type based on the VM size and image capabilities.
 
 ## Example `Shoot` manifest (non-zoned)
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -463,7 +463,8 @@ dataVolumes:
 #      id: /Subscriptions/2ebd38b6-270b-48a2-8e0b-2077106dc615/Providers/Microsoft.Compute/Locations/westeurope/Publishers/sap/ArtifactTypes/VMImage/Offers/gardenlinux/Skus/greatest/Versions/1443.10.0
 #      urn: sap:gardenlinux:greatest:1443.10.0
 volume:
-  cachingType: ReadWrite
+  caching: ReadWrite
+  diskControllerType: NVMe
 ```
 
 The `.nodeTemplate` is used to specify resource information of the machine during runtime. This then helps in Scale-from-Zero.
@@ -491,6 +492,9 @@ The `.volume` field is used to add provider specific configurations for a osDisk
 The OS disk is the disk that contains the operating system and is mounted as `/` in the machine.
 You can configure the host caching type by specifying `.volume.caching` in the workerConfig.
 The default value is `None`, current supported values are `None`, `ReadOnly`, `ReadWrite`.
+You can configure the disk controller type by specifying `.volume.diskControllerType` in the workerConfig.
+Current supported values are `SCSI` and `NVMe`.
+If omitted, Azure chooses the default disk controller type based on the VM size and image capabilities.
 
 ## Example `Shoot` manifest (non-zoned)
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -496,6 +496,8 @@ You can configure the disk controller type by specifying `.volume.diskController
 Current supported values are `SCSI` and `NVMe`.
 If omitted, Azure chooses the default disk controller type based on the VM size and image capabilities.
 
+> **Note:** `diskControllerType` requires a Generation 2 (Gen2) VM image. Azure will reject the VM creation with an `InvalidParameter` error if the image is not Gen2. In the cloud profile, Gen2 image versions are identified by the `-gen2` suffix (e.g. `2150.4.0-gen2`). Ensure the worker pool's `machineImage.version` references a Gen2 image when setting `diskControllerType`.
+
 ## Example `Shoot` manifest (non-zoned)
 
 Please find below an example `Shoot` manifest for a non-zoned cluster:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -118,3 +118,4 @@ spec:
 #        storageURI: https://<storage-account-name>.blob.core.windows.net/
 #      volume:
 #        caching: None
+#        diskControllerType: NVMe # Valid values: SCSI, NVMe

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -2310,6 +2310,19 @@ string
 <p>Caching specifies the caching type for the OS disk.<br />Valid values are 'None', 'ReadOnly', and 'ReadWrite'.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>diskControllerType</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DiskControllerType specifies the disk controller type configured for the VM.
+Valid values are &lsquo;SCSI&rsquo; and &lsquo;NVMe&rsquo;.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -2319,8 +2319,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>DiskControllerType specifies the disk controller type configured for the VM.
-Valid values are &lsquo;SCSI&rsquo; and &lsquo;NVMe&rsquo;.</p>
+<p>DiskControllerType specifies the disk controller type configured for the VM.<br />Valid values are 'SCSI' and 'NVMe'.</p>
 </td>
 </tr>
 

--- a/pkg/apis/azure/types_worker.go
+++ b/pkg/apis/azure/types_worker.go
@@ -99,6 +99,9 @@ type Volume struct {
 	// Caching specifies the caching type for the OS disk.
 	// Valid values are 'None', 'ReadOnly', and 'ReadWrite'.
 	Caching *string
+	// DiskControllerType specifies the disk controller type configured for the VM.
+	// Valid values are 'SCSI' and 'NVMe'.
+	DiskControllerType *string
 }
 
 // CapacityReservation represents the configuration for capacity reservations on Azure.

--- a/pkg/apis/azure/v1alpha1/types_worker.go
+++ b/pkg/apis/azure/v1alpha1/types_worker.go
@@ -113,6 +113,10 @@ type Volume struct {
 	// Valid values are 'None', 'ReadOnly', and 'ReadWrite'.
 	// +optional
 	Caching *string `json:"caching,omitempty"`
+	// DiskControllerType specifies the disk controller type configured for the VM.
+	// Valid values are 'SCSI' and 'NVMe'.
+	// +optional
+	DiskControllerType *string `json:"diskControllerType,omitempty"`
 }
 
 // CapacityReservation represents the configuration for capacity reservations on Azure.

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -1325,6 +1325,7 @@ func Convert_azure_VmoDependency_To_v1alpha1_VmoDependency(in *azure.VmoDependen
 
 func autoConvert_v1alpha1_Volume_To_azure_Volume(in *Volume, out *azure.Volume, s conversion.Scope) error {
 	out.Caching = (*string)(unsafe.Pointer(in.Caching))
+	out.DiskControllerType = (*string)(unsafe.Pointer(in.DiskControllerType))
 	return nil
 }
 
@@ -1335,6 +1336,7 @@ func Convert_v1alpha1_Volume_To_azure_Volume(in *Volume, out *azure.Volume, s co
 
 func autoConvert_azure_Volume_To_v1alpha1_Volume(in *azure.Volume, out *Volume, s conversion.Scope) error {
 	out.Caching = (*string)(unsafe.Pointer(in.Caching))
+	out.DiskControllerType = (*string)(unsafe.Pointer(in.DiskControllerType))
 	return nil
 }
 

--- a/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.deepcopy.go
@@ -974,6 +974,11 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DiskControllerType != nil {
+		in, out := &in.DiskControllerType, &out.DiskControllerType
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/azure/validation/worker.go
+++ b/pkg/apis/azure/validation/worker.go
@@ -21,6 +21,8 @@ import (
 	apiazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 )
 
+var supportedDiskControllerTypes = []string{"SCSI", "NVMe"}
+
 // ValidateWorkerConfig validates a WorkerConfig object.
 func ValidateWorkerConfig(workerConfig *apiazure.WorkerConfig, dataVolumes []core.DataVolume, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -121,6 +123,21 @@ func validateOSDiskConf(osDiskConf *apiazure.Volume, fldPath *field.Path) field.
 	}
 
 	allErrs = append(allErrs, validateOsDiskCaching(osDiskConf.Caching, fldPath.Child("caching"))...)
+	allErrs = append(allErrs, validateDiskControllerType(osDiskConf.DiskControllerType, fldPath.Child("diskControllerType"))...)
+
+	return allErrs
+}
+
+func validateDiskControllerType(diskControllerType *string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if diskControllerType == nil {
+		return nil
+	}
+
+	if !slices.Contains(supportedDiskControllerTypes, *diskControllerType) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, *diskControllerType, supportedDiskControllerTypes))
+	}
 
 	return allErrs
 }

--- a/pkg/apis/azure/validation/worker_test.go
+++ b/pkg/apis/azure/validation/worker_test.go
@@ -300,5 +300,26 @@ var _ = Describe("ValidateWorkerConfig", func() {
 
 			Expect(validateOSDiskConf(osDiskConf, nil)).To(BeEmpty())
 		})
+
+		It("should deny invalid disk controller type", func() {
+			osDiskConf := &apisazure.Volume{
+				DiskControllerType: ptr.To("unknown"),
+			}
+
+			Expect(validateOSDiskConf(osDiskConf, nil)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("diskControllerType"),
+				})),
+			))
+		})
+
+		It("should allow valid disk controller type", func() {
+			osDiskConf := &apisazure.Volume{
+				DiskControllerType: ptr.To("NVMe"),
+			}
+
+			Expect(validateOSDiskConf(osDiskConf, nil)).To(BeEmpty())
+		})
 	})
 })

--- a/pkg/apis/azure/zz_generated.deepcopy.go
+++ b/pkg/apis/azure/zz_generated.deepcopy.go
@@ -974,6 +974,11 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DiskControllerType != nil {
+		in, out := &in.DiskControllerType, &out.DiskControllerType
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -481,6 +481,9 @@ func computeDisks(pool extensionsv1alpha1.WorkerPool, dataVolumesConfig []azurea
 	if osDiskConfig != nil && osDiskConfig.Caching != nil {
 		osDisk["caching"] = *osDiskConfig.Caching
 	}
+	if osDiskConfig != nil && osDiskConfig.DiskControllerType != nil {
+		osDisk["diskControllerType"] = *osDiskConfig.DiskControllerType
+	}
 
 	disks := map[string]any{
 		"osDisk": osDisk,

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -481,12 +481,13 @@ func computeDisks(pool extensionsv1alpha1.WorkerPool, dataVolumesConfig []azurea
 	if osDiskConfig != nil && osDiskConfig.Caching != nil {
 		osDisk["caching"] = *osDiskConfig.Caching
 	}
-	if osDiskConfig != nil && osDiskConfig.DiskControllerType != nil {
-		osDisk["diskControllerType"] = *osDiskConfig.DiskControllerType
-	}
 
 	disks := map[string]any{
 		"osDisk": osDisk,
+	}
+
+	if osDiskConfig != nil && osDiskConfig.DiskControllerType != nil {
+		disks["diskControllerType"] = *osDiskConfig.DiskControllerType
 	}
 
 	// handle data disks
@@ -633,6 +634,9 @@ func appendHashDataForWorkerConfig(hashData []string, workerConfig *azureapi.Wor
 	if workerConfig.Volume != nil {
 		if workerConfig.Volume.Caching != nil {
 			hashData = append(hashData, *workerConfig.Volume.Caching)
+		}
+		if workerConfig.Volume.DiskControllerType != nil {
+			hashData = append(hashData, *workerConfig.Volume.DiskControllerType)
 		}
 	}
 	if workerConfig.DataVolumes != nil {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -232,7 +232,8 @@ var _ = Describe("Machines", func() {
 				}
 
 				osDiskConfig = apiv1alpha1.Volume{
-					Caching: ptr.To(string(armcompute.CachingTypesReadOnly)),
+					Caching:            ptr.To(string(armcompute.CachingTypesReadOnly)),
+					DiskControllerType: ptr.To("NVMe"),
 				}
 
 				diagnosticProfile = apiv1alpha1.DiagnosticsProfile{
@@ -624,8 +625,9 @@ var _ = Describe("Machines", func() {
 						},
 					}
 					machineClassPool1["osDisk"] = map[string]any{
-						"size":    volumeSize,
-						"caching": *osDiskConfig.Caching,
+						"size":               volumeSize,
+						"caching":            *osDiskConfig.Caching,
+						"diskControllerType": *osDiskConfig.DiskControllerType,
 					}
 					machineClassPool2["osDisk"] = map[string]any{
 						"size":    volumeSize,

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -632,10 +632,10 @@ var _ = Describe("Machines", func() {
 						},
 					}
 					machineClassPool1["osDisk"] = map[string]any{
-						"size":               volumeSize,
-						"caching":            *osDiskConfig.Caching,
-						"diskControllerType": *osDiskConfig.DiskControllerType,
+						"size":    volumeSize,
+						"caching": *osDiskConfig.Caching,
 					}
+					machineClassPool1["diskControllerType"] = *osDiskConfig.DiskControllerType
 					machineClassPool2["osDisk"] = map[string]any{
 						"size":    volumeSize,
 						"type":    volumeType,
@@ -1292,6 +1292,16 @@ var _ = Describe("Machines", func() {
 					got, err = WorkerPoolHashDataV2(pool, &workerConfig)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(got).To(Equal(want))
+				})
+
+				It("should include DiskControllerType in hash data when k8s version >= 1.35", func() {
+					pool.KubernetesVersion = ptr.To("1.35.0")
+					workerConfig.Volume = &apisazure.Volume{
+						DiskControllerType: ptr.To("NVMe"),
+					}
+					got, err := WorkerPoolHashDataV2(pool, &workerConfig)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(got).To(ContainElement("NVMe"))
 				})
 
 				It("should return the expected hash data for Rolling update strategy", func() {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -229,7 +229,8 @@ var _ = Describe("Machines", func() {
 				}
 
 				osDiskConfig = apiv1alpha1.Volume{
-					Caching: ptr.To(string(armcompute.CachingTypesReadOnly)),
+					Caching:            ptr.To(string(armcompute.CachingTypesReadOnly)),
+					DiskControllerType: ptr.To("NVMe"),
 				}
 
 				diagnosticProfile = apiv1alpha1.DiagnosticsProfile{
@@ -631,8 +632,9 @@ var _ = Describe("Machines", func() {
 						},
 					}
 					machineClassPool1["osDisk"] = map[string]any{
-						"size":    volumeSize,
-						"caching": *osDiskConfig.Caching,
+						"size":               volumeSize,
+						"caching":            *osDiskConfig.Caching,
+						"diskControllerType": *osDiskConfig.DiskControllerType,
 					}
 					machineClassPool2["osDisk"] = map[string]any{
 						"size":    volumeSize,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind api-change
/platform azure

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes gardener/machine-controller-manager-provider-azure#232

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
feature user
Add support for specifying the diskControllerType in the provider spec of the node pool. This allows user to use NVMe for VM types that default to SCSI but support NVME
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring OS disk controller type for Azure VMs (`SCSI` or `NVMe`). Default selection remains automatic when omitted.

* **Documentation**
  * Updated usage guide and API reference with disk controller type details, supported values, Gen2-image note, and example configs.

* **Tests**
  * Added validation tests to ensure supported values are accepted and unsupported values are rejected.

* **Configuration**
  * Templates and example values updated to include the optional diskControllerType setting (commented examples included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->