### PR TITLE
[GEP-26] Cleanup usage of the deprecated `shoot.spec.dns.providers[].secretName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ This extension controller supports the following Kubernetes versions:
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 
+## Compatibility
+
+The following lists known compatibility issues of this extension controller with other Gardener components.
+
+| Azure Extension | Gardener | Action | Notes |
+| --------------- | -------- | ------ | ----- |
+| `>= 1.61.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is migrated to use the new field only in `1.61.0`. |
+
 ----
 
 ## How to start using or developing this extension controller locally

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -206,12 +206,9 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 
 		providerFldPath := providersPath.Index(i)
 
-		// TODO(vpnachev): Enable this validation once the extension does not support github.com/gardener/gardener < v1.135.0
-		// if p.CredentialsRef == nil {
-		// 	allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
-		// }
-
-		if p.CredentialsRef != nil {
+		if p.CredentialsRef == nil {
+			allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
+		} else {
 			credentialsFldPath := providerFldPath.Child("credentialsRef")
 
 			credentials, err := kubernetes.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.GetNamespace())
@@ -235,29 +232,6 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 				}
 			default:
 				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials types are Secret and WorkloadIdentity"))
-			}
-		} else { // TODO(vpnachev): Remove the else block once the extension does not support github.com/gardener/gardener < v1.135.0
-			secretNameFldPath := providerFldPath.Child("secretName")
-			if p.SecretName == nil || *p.SecretName == "" {
-				allErrs = append(allErrs, field.Required(secretNameFldPath,
-					fmt.Sprintf("secretName must be specified for %v provider", azure.DNSType)))
-				continue
-			}
-
-			secret := &corev1.Secret{}
-			key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
-			if err := s.apiReader.Get(ctx, key, secret); err != nil {
-				if apierrors.IsNotFound(err) {
-					allErrs = append(allErrs, field.Invalid(secretNameFldPath,
-						*p.SecretName, "referenced secret not found"))
-				} else {
-					allErrs = append(allErrs, field.InternalError(secretNameFldPath, err))
-				}
-				continue
-			}
-
-			if errList := azurevalidation.ValidateDNSProviderSecret(secret, field.NewPath("secret")); len(errList) != 0 {
-				allErrs = append(allErrs, field.Invalid(secretNameFldPath, *p.SecretName, errList.ToAggregate().Error()))
 			}
 		}
 	}

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -285,91 +285,19 @@ var _ = Describe("Shoot validator", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				})
 
-				Context("#secretName", func() {
-					It("should return error when azure-dns provider has no secretName", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), Primary: ptr.To(true)}, // secretName missing
-							},
-						}
-
-						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeRequired),
-							"Field": Equal("spec.dns.providers[0].secretName"),
-						}))))
-					})
-
-					It("should return error when azure-dns provider secret not found", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-							},
-						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
-
-						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeInvalid),
-							"Field": Equal("spec.dns.providers[0].secretName"),
-						}))))
-					})
-
-					It("should return error when azure-dns secret is invalid (missing subscriptionID)", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-							},
-						}
-						invalidSecret := &corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-							Data: map[string][]byte{
-								azure.DNSTenantIDKey:     []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-								azure.DNSClientIDKey:     []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-								azure.DNSClientSecretKey: []byte("secret"),
-							},
-						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							SetArg(2, *invalidSecret).
-							Return(nil)
-
-						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.dns.providers[0].secretName"),
-							"Detail": ContainSubstring("missing required field \"AZURE_SUBSCRIPTION_ID\" in secret"),
-						}))))
-					})
-
-					It("should succeed with valid azure-dns provider secret", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-							},
-						}
-						validSecret := &corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-							Data: map[string][]byte{
-								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
-								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-								azure.DNSClientSecretKey:   []byte("secret"),
-							},
-						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-								*obj = *validSecret
-								return nil
-							})
-
-						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
-					})
-
+				Context("#primaryProviders", func() {
 					It("should skip validation for non-primary azure-dns provider", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(false)},
+								{
+									Primary: ptr.To(false),
+									Type:    ptr.To(azure.DNSType),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
 							},
 						}
 						// No secret lookup should happen for non-primary providers
@@ -380,8 +308,24 @@ var _ = Describe("Shoot validator", func() {
 					It("should validate only primary provider when multiple azure-dns providers exist", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-1"), Primary: ptr.To(true)},
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-2"), Primary: ptr.To(false)},
+								{
+									Primary: ptr.To(true),
+									Type:    ptr.To(azure.DNSType),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret-1",
+									},
+								},
+								{
+									Primary: ptr.To(false),
+									Type:    ptr.To(azure.DNSType),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret-2",
+									},
+								},
 							},
 						}
 						validSecret := &corev1.Secret{
@@ -405,8 +349,24 @@ var _ = Describe("Shoot validator", func() {
 					It("should skip all providers when none are primary", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-1"), Primary: ptr.To(false)},
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret-2"), Primary: ptr.To(false)},
+								{
+									Primary: ptr.To(false),
+									Type:    ptr.To(azure.DNSType),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret-1",
+									},
+								},
+								{
+									Primary: ptr.To(false),
+									Type:    ptr.To(azure.DNSType),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret-2",
+									},
+								},
 							},
 						}
 						// No secret lookups should happen
@@ -417,9 +377,33 @@ var _ = Describe("Shoot validator", func() {
 					It("should validate mixed provider types with primary azure-dns", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
-								{Type: ptr.To("aws-route53"), SecretName: ptr.To("aws-secret"), Primary: ptr.To(false)},
-								{Type: ptr.To(azure.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-								{Type: ptr.To("google-clouddns"), SecretName: ptr.To("gcp-secret"), Primary: ptr.To(false)},
+								{
+									Primary: ptr.To(false),
+									Type:    ptr.To("aws-route53"),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "aws-secret",
+									},
+								},
+								{
+									Primary: ptr.To(true),
+									Type:    ptr.To(azure.DNSType),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
+								{
+									Primary: ptr.To(false),
+									Type:    ptr.To("google-clouddns"),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "gcp-secret",
+									},
+								},
 							},
 						}
 						validSecret := &corev1.Secret{
@@ -442,6 +426,19 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				Context("#credentialsRef", func() {
+					It("should return error when azure-dns provider has no credentialsRef", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{Type: ptr.To(azure.DNSType), Primary: ptr.To(true)}, // credentialsRef missing
+							},
+						}
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeRequired),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+						}))))
+					})
+
 					It("should return error when azure-dns provider Secret not found", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind cleanup
/label ipcei/workload-identity
/platform azure

**What this PR does / why we need it**:
Cleanup usage of the deprecated `shoot.spec.dns.providers[].secretName`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up on https://github.com/gardener/gardener-extension-provider-azure/pull/1477
Part of https://github.com/gardener/gardener/issues/9586

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ This extension no longer support Gardener installation running with `github.com/gardener/gardener < v1.135.0`, kindly update `github.com/gardener/gardener` to version `>= v1.135.0` before updating the extension.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a compatibility section documenting version constraints between the Azure extension and Gardener components, including migration instructions for DNS provider credential configurations.

* **Bug Fixes**
  * Updated DNS provider validation for Azure primary providers to enforce credentials reference configuration, removing support for legacy credential handling approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/gardener-extension-provider-azure/pull/1545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->