### PR TITLE
fix: add missing get nodes permission to csi-driver-controller-disk

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver-controller-disk.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver-controller-disk.yaml
@@ -16,3 +16,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:

This PR adds missing permissions to get `Nodes` to `csi-driver-controller-disk`. Without the permission the csi-driver-controller-disk fails with 
```
  E azure_controller_common.go:239 failed to get node info from labels:
  get node(...) failed with nodes "..." is forbidden:
  User "system:serviceaccount:kube-system:csi-driver-controller-disk"
  cannot get resource "nodes" in API group "" at the cluster scope
```
Error originates here: 
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/9a3763e7d9d546c98aa81f011ccf25a762bd7224/pkg/azuredisk/azure_controller_common.go#L236-L255

Adding the permission slightly changes the behavior in case more disks are attempted to be attached in a batch than luns are available on the node.

Before patch:
- node cannot be retrieved
- instance type is unknown
- max luns are unknown
- cannot get luns for all disks
- entire batch fails

After patch:
- retrieve instance type from  node labels
- get max luns for instance type
- get num attached disks on node
- calculate available luns
- reduce batch to num available luns
- attach the remaining disks

The network calls to the kube-apiserver or the provider API should not really change. The get nodes call to kube-apiserver will now succeed instead of fail. The `GetNodeDataDisks` to the provider API is now done earlier but since it is cached, this should not be an additional call.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix a RBAC permission issues that prevented batched disk attachments from partially succeeding if not enough free luns are available
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSI driver node controller now has appropriate permissions to access node information for improved disk management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/gardener-extension-provider-azure/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->