### PR TITLE
[GEP-33] rename networking capability terminology 

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -27,7 +27,7 @@ With the introduction of `spec.machineCapabilities` in Gardener *v1.131.0*, you 
 **Purpose and Behavior:**
 
 The `machineCapabilities` feature allows you to:
-- Define available capabilities and their values in the CloudProfile (e.g., `architecture`, `gardener-azure-networking`)
+- Define available capabilities and their values in the CloudProfile (e.g., `architecture`, `azure-networking`)
 - Associate machine images with specific capability combinations via `capabilityFlavors`
 - Optionally restrict machine types to specific capabilities via `machineTypes.capabilities`
 
@@ -35,7 +35,7 @@ The `machineCapabilities` feature allows you to:
 
 The capability system uses **automatic defaulting** from `.spec.machineCapabilities`:
 
-- **`.spec.machineCapabilities`**: Defines all available capability keys and their possible values (e.g., `architecture: [amd64, arm64]`, `gardener-azure-networking: [basic, accelerated]`)
+- **`.spec.machineCapabilities`**: Defines all available capability keys and their possible values (e.g., `architecture: [amd64, arm64]`, `azure-networking: [basic, accelerated]`)
 - Any capability **not explicitly specified** in `.spec.machineImages[].versions[].capabilityFlavors[].capabilities` or `.spec.machineTypes[].capabilities` automatically gets **all values** from `.spec.machineCapabilities`
 - If no capabilities are defined all will be defaulted.
 
@@ -45,7 +45,7 @@ Always required is the architecture capability:
 - `architecture`: `amd64` and `arm64` (specifies the CPU architecture of the machine on which given machine image can be used)
 
 But any other capability can be mapped here as well, e.g.:
-- `gardener-azure-networking`: `basic` and `accelerated` (specifies if the machine image supports [Azure Accelerated Networking](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli))
+- `azure-networking`: `basic` and `accelerated` (specifies if the machine image supports [Azure Accelerated Networking](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli))
 
 An example `CloudProfileConfig` for the Azure extension looks as follows:
 
@@ -66,7 +66,7 @@ machineImages:
     - urn: "CoreOS:CoreOS:Stable:2135.6.0"
       capabilities:
         architecture: [amd64]
-        gardener-azure-networking: [basic,accelerated]
+        azure-networking: [basic,accelerated]
 - name: ImageWithMultipleCapabilityFlavors
   versions:
   - version: 1.0.0
@@ -74,15 +74,15 @@ machineImages:
     - id: "/subscriptions/<subscription ID where the gallery is located>/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0"
       capabilities:
         architecture: [amd64]
-        gardener-azure-networking: [basic]
+        azure-networking: [basic]
     - communityGalleryImageID: "/CommunityGalleries/gardenlinux-567905d8-921f-4a85-b423-1fbf4e249d90/Images/gardenlinux/Versions/576.1.1"
       capabilities:
         architecture: [amd64]
-        gardener-azure-networking: [accelerated]
+        azure-networking: [accelerated]
     - sharedGalleryImageID: "/SharedGalleries/sharedGalleryName/Images/sharedGalleryImageName/Versions/sharedGalleryImageVersionName"
       capabilities:
         architecture: [arm64]
-        gardener-azure-networking: [accelerated]
+        azure-networking: [accelerated]
 ```
 
 #### Old format
@@ -153,7 +153,7 @@ spec:
       values:
         - amd64
         - arm64
-#    - name: gardener-azure-networking # optional
+#    - name: azure-networking # optional
 #      values:
 #        - basic
 #        - accelerated
@@ -168,11 +168,11 @@ spec:
     - version: 2135.6.0
       capabilityFlavors:
 #      - architecture: [amd64] # optional
-#        gardener-azure-networking: [accelerated]
+#        azure-networking: [accelerated]
       - architecture: [amd64]
-#        gardener-azure-networking: [basic]
+#        azure-networking: [basic]
       - architecture: [arm64]
-#        gardener-azure-networking: [basic, accelerated]
+#        azure-networking: [basic, accelerated]
   machineTypes:
   - name: Standard_D3_v2
     cpu: "4"
@@ -180,14 +180,14 @@ spec:
     memory: 14Gi
     capabilities:
       architecture: [amd64]
-      # gardener-azure-networking: [accelerated] # optional
+      # azure-networking: [accelerated] # optional
   - name: Standard_D4_v3
     cpu: "4"
     gpu: "0"
     memory: 16Gi
     capabilities:
       architecture: [amd64]
-      # gardener-azure-networking: [accelerated] # optional
+      # azure-networking: [accelerated] # optional
   volumeTypes:
   - name: Standard_LRS
     class: standard
@@ -221,15 +221,15 @@ spec:
 #          - id: "/subscriptions/<subscription ID where the gallery is located>/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0"
 #            capabilities:
 #              architecture: [amd64]
-#              gardener-azure-networking: [accelerated] # optional
+#              azure-networking: [accelerated] # optional
           - communityGalleryImageID: "/CommunityGalleries/gardenlinux-567905d8-921f-4a85-b423-1fbf4e249d90/Images/gardenlinux/Versions/576.1.1"
             capabilities:
               architecture: [amd64]
-#              gardener-azure-networking: [basic] # optional
+#              azure-networking: [basic] # optional
           - sharedGalleryImageID: "/SharedGalleries/sharedGalleryName/Images/sharedGalleryImageName/Versions/sharedGalleryImageVersionName"
             capabilities:
               architecture: [arm64]
-#              gardener-azure-networking: [basic,accelerated] # optional
+#              azure-networking: [basic,accelerated] # optional
 ```
 
 #### Without `spec.machineCapabilities`:

--- a/pkg/admission/mutator/cloudprofile.go
+++ b/pkg/admission/mutator/cloudprofile.go
@@ -132,9 +132,7 @@ func convertVersionsToCapabilityFlavors(versions []v1alpha1.MachineImageVersion)
 		}
 
 		// Convert AcceleratedNetworking to networking capability
-		if key.acceleratedNetworking {
-			capabilities[azure.CapabilityNetworkName] = []string{azure.CapabilityNetworkBasic, azure.CapabilityNetworkAccelerated}
-		} else {
+		if !key.acceleratedNetworking {
 			capabilities[azure.CapabilityNetworkName] = []string{azure.CapabilityNetworkBasic}
 		}
 

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-azure/pkg/admission/mutator"
 	api "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/install"
+	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 )
 
 var _ = Describe("NamespacedCloudProfile Mutator", func() {
@@ -115,9 +116,52 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 
 				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
 
-				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).ToNot(BeEmpty())
-				// Should have flavors for both amd64 and arm64
-				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(HaveLen(2))
+				// Should have flavors for both amd64 and arm64. Since acceleratedNetworking
+				// is not set (defaults to false), the network capability is set to "basic".
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{
+						"architecture":              []string{"amd64"},
+						azure.CapabilityNetworkName: []string{azure.CapabilityNetworkBasic},
+					}},
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{
+						"architecture":              []string{"arm64"},
+						azure.CapabilityNetworkName: []string{azure.CapabilityNetworkBasic},
+					}},
+				))
+			})
+
+			It("should populate capabilityFlavors from old format provider config with acceleratedNetworking", func() {
+				Expect(fakeClient.Create(ctx, parentProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"ubuntu","versions":[
+    {"version":"22.04","acceleratedNetworking":true,"id":"canonical:ubuntu:22.04:latest"},
+    {"version":"22.04","acceleratedNetworking":false,"id":"canonical:ubuntu:22.04:basic"}
+  ]}
+]}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+						{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}},
+					}},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// When acceleratedNetworking=true the network capability is omitted from the flavor
+				// (meaning any networking is acceptable). When acceleratedNetworking=false the
+				// network capability is restricted to "basic".
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{
+						"architecture": []string{"amd64"},
+					}},
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{
+						"architecture":              []string{"amd64"},
+						azure.CapabilityNetworkName: []string{azure.CapabilityNetworkBasic},
+					}},
+				))
 			})
 
 			It("should populate capabilityFlavors from new format provider config", func() {

--- a/pkg/azure/types.go
+++ b/pkg/azure/types.go
@@ -181,7 +181,7 @@ const (
 	StorageAccountKeyMustRotate = "azure.provider.extensions.gardener.cloud/rotate"
 
 	// CapabilityNetworkName is the name for the Azure specific capability networking.
-	CapabilityNetworkName = "gardener-azure-networking"
+	CapabilityNetworkName = "azure-networking"
 	// CapabilityNetworkAccelerated is a constant for the accelerated networking capability.
 	CapabilityNetworkAccelerated = "accelerated"
 	// CapabilityNetworkBasic is a constant for the standard networking capability.


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind enhancement
/platform azure

**What this PR does / why we need it**:

Changing capability related to accelerated networking from gardener-azure-networking to azure-networking. 

This is due to respect the consideration in [GEP-54 ](https://github.com/gardener/enhancements/pull/53)to reserve the `gardener-` namespace for capabilities.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As the capability feature is in alpha state the change is done without migration. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Rename azure specific capability name `gardener-azure-networking` to `azure-networking`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure operations and usage docs for the machine image capability system, including clearer matching behavior and defaulting.
  * Expanded CloudProfileConfig examples with multiple capability flavor entries and refreshed example capability names to the standardized `azure-networking` format.

* **Bug Fixes**
  * Corrected networking capability flavor assignment so accelerated vs. non-accelerated networking configurations map to the intended capability sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->