### PR TITLE
Add --kube-api-qps and --kube-api-burst flags to CSI driver controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment.tpl
@@ -59,6 +59,8 @@ spec:
         - --nodeid=dummy
         - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
         {{- end }}
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         - --v=5
         securityContext:
           allowPrivilegeEscalation: false

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -138,7 +138,7 @@ images:
 - name: csi-driver-disk
   sourceRepository: github.com/kubernetes-sigs/azuredisk-csi-driver
   repository: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi
-  tag: v1.34.3
+  tag: v1.34.4
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
## What this PR does

Adds `--kube-api-qps=100` and `--kube-api-burst=200` to the CSI driver controller container (`azure-csi-driver` in the seed-controlplane deployment template).

## Why

The CSI driver controller uses a kube client for the migration monitor to update labels and create events. At scale (thousands of disks), the default client-go rate limits (QPS=5, Burst=10) cause delays in updates and can add several minutes of delay to show events, which is critical for customers migrating many disks.

The sidecar containers (provisioner, attacher, snapshotter, resizer, snapshot-controller) already pass these flags with the same values.

## Image bump

Bumps `csi-driver-disk` (azuredisk-csi-driver) from **v1.34.3** to **v1.34.4**. This is required because the `--kube-api-qps` and `--kube-api-burst` flags were only added upstream in [kubernetes-sigs/azuredisk-csi-driver#3628](https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3628), cherry-picked to release-1.34 in [#3629](https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3629), and released in v1.34.4 (May 25, 2026).

### v1.34.4 changelog (no breaking changes):
- fix: helm chart index
- chore: upgrade Azure cloud provider lib
- test: set explicit ginkgo parallelism
- chore: bump Go version to 1.25.10 in trivy workflow
- **perf: option for qps and burst to handle client throttling scenario**
- fix: wrong NVMe disk LUN mapping on Windows D4ads_v7 SKU VM
- chore: update max disk count map with latest VM sizes
- chore(deps): bump build-image/debian-base from bookworm-v1.0.7 to bookworm-v1.0.8

## Note

Only the **controller** component needs these flags (not the node daemonset). The node component's kube client is only used for low-volume operations (taint removal, CSINode checks) that don't require elevated QPS/burst.

/kind enhancement
/platform azure

**Special notes for your reviewer**:
As the capability feature is in alpha state the change is done without migration. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add --kube-api-qps and --kube-api-burst flags to CSI driver controller
```
