### PR TITLE
Migrate mock client usages to fakeclient in tests

### DIFF
--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -6,20 +6,19 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/admission/validator"
 	azureapi "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
@@ -37,31 +36,28 @@ var _ = Describe("CredentialsBinding validator", func() {
 		var (
 			credentialsBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			mgr       testutils.FakeManager
-			apiReader *mockclient.MockReader
+			scheme *runtime.Scheme
 
 			ctx                                = context.TODO()
 			credentialsBindingSecret           *security.CredentialsBinding
 			credentialsBindingWorkloadIdentity *security.CredentialsBinding
-
-			fakeErr = fmt.Errorf("fake err")
 		)
 
+		newValidator := func(objs ...client.Object) {
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			mgr := testutils.FakeManager{APIReader: apiReader}
+			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
+		}
+
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			mgr = testutils.FakeManager{}
-
-			apiReader = mockclient.NewMockReader(ctrl)
-			mgr.APIReader = apiReader
-			scheme := runtime.NewScheme()
+			scheme = runtime.NewScheme()
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
 			Expect(securityv1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(azureapi.AddToScheme(scheme)).To(Succeed())
 			Expect(azureapiv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
-			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
+			newValidator()
 
 			credentialsBindingSecret = &security.CredentialsBinding{
 				CredentialsRef: corev1.ObjectReference{
@@ -81,10 +77,6 @@ var _ = Describe("CredentialsBinding validator", func() {
 			}
 		})
 
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
 		It("should return err when obj is not a CredentialsBinding", func() {
 			err := credentialsBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
 			Expect(err).To(MatchError("wrong object type *v1.Secret"))
@@ -102,38 +94,31 @@ var _ = Describe("CredentialsBinding validator", func() {
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			// Secret not pre-populated → fake client returns not-found
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding Secret is not valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						"foo": []byte("bar"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should succeed when the corresponding Secret is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						azure.SubscriptionIDKey: []byte("b7ad693a-028a-422c-b064-d76c4586f2b3"),
-						azure.TenantIDKey:       []byte("ee16e592-3035-41b9-a217-958f8f75b740"),
-						azure.ClientIDKey:       []byte("7fc4685d-3c33-40e6-b6bf-7857cab04300"),
-						azure.ClientSecretKey:   []byte("clientSecret"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					azure.SubscriptionIDKey: []byte("b7ad693a-028a-422c-b064-d76c4586f2b3"),
+					azure.TenantIDKey:       []byte("ee16e592-3035-41b9-a217-958f8f75b740"),
+					azure.ClientIDKey:       []byte("7fc4685d-3c33-40e6-b6bf-7857cab04300"),
+					azure.ClientSecretKey:   []byte("clientSecret"),
+				},
+			})
 
 			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)).To(Succeed())
 		})
@@ -159,130 +144,110 @@ var _ = Describe("CredentialsBinding validator", func() {
 			})
 
 			It("should return err if it fails to get the corresponding InternalSecret", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fakeErr)
-
+				// InternalSecret not pre-populated → fake client returns not-found
 				err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
-				Expect(err).To(MatchError(fakeErr))
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("should return err when the corresponding InternalSecret is not valid", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
-						obj.Data = map[string][]byte{"foo": []byte("bar")}
-						return nil
-					})
+				newValidator(&gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       map[string][]byte{"foo": []byte("bar")},
+				})
 
 				err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should succeed when the corresponding InternalSecret is valid", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
-						obj.Data = map[string][]byte{
-							azure.SubscriptionIDKey: []byte("b7ad693a-028a-422c-b064-d76c4586f2b3"),
-							azure.TenantIDKey:       []byte("ee16e592-3035-41b9-a217-958f8f75b740"),
-						}
-						return nil
-					})
+				newValidator(&gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						azure.SubscriptionIDKey: []byte("b7ad693a-028a-422c-b064-d76c4586f2b3"),
+						azure.TenantIDKey:       []byte("ee16e592-3035-41b9-a217-958f8f75b740"),
+					},
+				})
 
 				Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)).To(Succeed())
 			})
 		})
 
 		It("should succeed when the corresponding WorkloadIdentity is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "azure",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-clientID: "11111c4e-db61-17fa-a141-ed39b34aa561"
-tenantID: "44444c4e-db61-17fa-a141-ed39b34aa561"
-subscriptionID: "44444c4e-db61-17fa-a141-ed39b34aa561"
-`),
-								},
-							},
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "azure",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "azure.provider.extensions.gardener.cloud/v1alpha1",
+								"kind": "WorkloadIdentityConfig",
+								"clientID": "11111c4e-db61-17fa-a141-ed39b34aa561",
+								"tenantID": "44444c4e-db61-17fa-a141-ed39b34aa561",
+								"subscriptionID": "44444c4e-db61-17fa-a141-ed39b34aa561"
+							}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+					},
+				},
+			})
 
 			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)).To(Succeed())
 		})
 
 		It("should return err if it fails to get the corresponding WorkloadIdentity", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).Return(fakeErr)
-
+			// WorkloadIdentity not pre-populated → fake client returns not-found
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding WorkloadIdentity is missing config for target system", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "azure",
-							},
-						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "azure",
+					},
+				},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err).To(MatchError("the target system is missing configuration"))
 		})
 
 		It("should return err when the corresponding WorkloadIdentity has empty config for target system", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type:           "azure",
-								ProviderConfig: &runtime.RawExtension{},
-							},
-						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type:           "azure",
+						ProviderConfig: &runtime.RawExtension{Raw: []byte(`{}`)},
+					},
+				},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring("target system's configuration is not valid"))
 		})
 
 		It("should return err when the corresponding WorkloadIdentity has invalid target system configuration", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "azure",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-`),
-								},
-							},
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "azure",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "azure.provider.extensions.gardener.cloud/v1alpha1",
+								"kind": "WorkloadIdentityConfig"
+							}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+					},
+				},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring("referenced workload identity garden-dev/my-provider-account is not valid"))

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -6,17 +6,17 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
@@ -33,9 +33,7 @@ var _ = Describe("SecretBinding validator", func() {
 		var (
 			secretBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			apiReader *mockclient.MockReader
-			mgr       testutils.FakeManager
+			scheme *runtime.Scheme
 
 			ctx           = context.TODO()
 			secretBinding = &core.SecretBinding{
@@ -44,20 +42,19 @@ var _ = Describe("SecretBinding validator", func() {
 					Namespace: namespace,
 				},
 			}
-			fakeErr = fmt.Errorf("fake err")
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			apiReader = mockclient.NewMockReader(ctrl)
-
-			mgr = testutils.FakeManager{APIReader: apiReader}
-
+		newValidator := func(objs ...client.Object) {
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			mgr := testutils.FakeManager{APIReader: apiReader}
 			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
-		})
+		}
 
-		AfterEach(func() {
-			ctrl.Finish()
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			newValidator()
 		})
 
 		It("should return err when obj is not a SecretBinding", func() {
@@ -71,38 +68,31 @@ var _ = Describe("SecretBinding validator", func() {
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			// Secret not pre-populated → fake client returns not-found
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding Secret is not valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						"foo": []byte("bar"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			})
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return nil when the corresponding Secret is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						azure.SubscriptionIDKey: []byte("b7ad693a-028a-422c-b064-d76c4586f2b3"),
-						azure.TenantIDKey:       []byte("ee16e592-3035-41b9-a217-958f8f75b740"),
-						azure.ClientIDKey:       []byte("7fc4685d-3c33-40e6-b6bf-7857cab04300"),
-						azure.ClientSecretKey:   []byte("clientSecret"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					azure.SubscriptionIDKey: []byte("b7ad693a-028a-422c-b064-d76c4586f2b3"),
+					azure.TenantIDKey:       []byte("ee16e592-3035-41b9-a217-958f8f75b740"),
+					azure.ClientIDKey:       []byte("7fc4685d-3c33-40e6-b6bf-7857cab04300"),
+					azure.ClientSecretKey:   []byte("clientSecret"),
+				},
+			})
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -13,20 +13,17 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/admission/validator"
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
@@ -41,17 +38,12 @@ var _ = Describe("Shoot validator", func() {
 		var (
 			shootValidator extensionswebhook.Validator
 
-			ctrl                   *gomock.Controller
-			mgr                    testutils.FakeManager
-			c                      *mockclient.MockClient
-			reader                 *mockclient.MockReader
+			scheme                 *runtime.Scheme
 			cloudProfile           *gardencorev1beta1.CloudProfile
 			namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 			shoot                  *core.Shoot
 
-			ctx                       = context.Background()
-			cloudProfileKey           = client.ObjectKey{Name: "azure"}
-			namespacedCloudProfileKey = client.ObjectKey{Name: "azure-nscpfl", Namespace: namespace}
+			ctx = context.Background()
 
 			regionName   = "westus"
 			imageName    = "Foo"
@@ -59,19 +51,23 @@ var _ = Describe("Shoot validator", func() {
 			architecture = ptr.To("analog")
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
+		// buildValidator creates the shoot validator with the given objects pre-populated in the
+		// main client (for CloudProfile/NamespacedCloudProfile lookups) and the APIReader (for
+		// Secret/WorkloadIdentity lookups during DNS validation).
+		buildValidator := func(clientObjs []client.Object, readerObjs []client.Object) {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(clientObjs...).Build()
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(readerObjs...).Build()
+			mgr := testutils.FakeManager{Scheme: scheme, Client: c, APIReader: apiReader}
+			shootValidator = validator.NewShootValidator(mgr)
+		}
 
-			scheme := runtime.NewScheme()
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
 			Expect(apisazure.AddToScheme(scheme)).To(Succeed())
 			Expect(apisazurev1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
-
-			c = mockclient.NewMockClient(ctrl)
-			reader = mockclient.NewMockReader(ctrl)
-			mgr = testutils.FakeManager{Scheme: scheme, Client: c, APIReader: reader}
-
-			shootValidator = validator.NewShootValidator(mgr)
+			Expect(securityv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 			cloudProfile = &gardencorev1beta1.CloudProfile{
 				ObjectMeta: metav1.ObjectMeta{
@@ -114,7 +110,8 @@ var _ = Describe("Shoot validator", func() {
 
 			namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "azure-nscpfl",
+					Name:      "azure-nscpfl",
+					Namespace: namespace,
 				},
 				Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
 					Parent: gardencorev1beta1.CloudProfileReference{
@@ -177,6 +174,8 @@ var _ = Describe("Shoot validator", func() {
 					},
 				},
 			}
+
+			buildValidator([]client.Object{cloudProfile}, nil)
 		})
 
 		Context("Shoot creation (old is nil)", func() {
@@ -186,7 +185,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when networking is configured to use dual-stack", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -197,7 +195,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when networking is configured to use IPv6-only", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -208,7 +205,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when infrastructureConfig is nil", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.InfrastructureConfig = nil
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -219,7 +215,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when infrastructureConfig fails to be decoded", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte("foo")}
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -230,7 +225,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker is invalid", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.Workers = []core.Worker{
 					{
 						Name:   "worker-1",
@@ -250,8 +244,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should succeed for valid Shoot", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -259,7 +251,6 @@ var _ = Describe("Shoot validator", func() {
 			It("should also work for cloudProfileName instead of CloudProfile reference in Shoot", func() {
 				shoot.Spec.CloudProfileName = ptr.To("azure")
 				shoot.Spec.CloudProfile = nil
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -270,17 +261,13 @@ var _ = Describe("Shoot validator", func() {
 					Kind: "NamespacedCloudProfile",
 					Name: "azure-nscpfl",
 				}
-				c.EXPECT().Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{}).SetArg(2, *namespacedCloudProfile)
+				buildValidator([]client.Object{namespacedCloudProfile}, nil)
 
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			Context("Shoot with custom DNS provider", func() {
-				BeforeEach(func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				})
-
 				Context("#primaryProviders", func() {
 					It("should skip validation for non-primary azure-dns provider", func() {
 						shoot.Spec.DNS = &core.DNS{
@@ -302,6 +289,17 @@ var _ = Describe("Shoot validator", func() {
 					})
 
 					It("should validate only primary provider when multiple azure-dns providers exist", func() {
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret-1", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
+								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey:   []byte("secret"),
+							},
+						}
+						buildValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
+
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -324,21 +322,7 @@ var _ = Describe("Shoot validator", func() {
 								},
 							},
 						}
-						validSecret := &corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret-1", Namespace: namespace},
-							Data: map[string][]byte{
-								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
-								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-								azure.DNSClientSecretKey:   []byte("secret"),
-							},
-						}
 						// Only the primary provider's secret should be validated
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret-1"},
-							&corev1.Secret{}).
-							SetArg(2, *validSecret).
-							Return(nil)
-
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 
@@ -371,6 +355,17 @@ var _ = Describe("Shoot validator", func() {
 					})
 
 					It("should validate mixed provider types with primary azure-dns", func() {
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
+								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
+								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
+								azure.DNSClientSecretKey:   []byte("secret"),
+							},
+						}
+						buildValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
+
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -402,21 +397,7 @@ var _ = Describe("Shoot validator", func() {
 								},
 							},
 						}
-						validSecret := &corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-							Data: map[string][]byte{
-								azure.DNSSubscriptionIDKey: []byte("a6ad693a-028a-422c-b064-d76a4586f2b3"),
-								azure.DNSTenantIDKey:       []byte("ee16e593-3035-41b9-a217-958f8f75b750"),
-								azure.DNSClientIDKey:       []byte("7fc4685e-3c33-40e6-b6bf-7857cab04390"),
-								azure.DNSClientSecretKey:   []byte("secret"),
-							},
-						}
 						// Only azure-dns primary provider should be validated
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							SetArg(2, *validSecret).
-							Return(nil)
-
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 				})
@@ -436,6 +417,7 @@ var _ = Describe("Shoot validator", func() {
 					})
 
 					It("should return error when azure-dns provider Secret not found", func() {
+						// Secret not pre-populated → fake client returns not-found
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -449,9 +431,6 @@ var _ = Describe("Shoot validator", func() {
 								},
 							},
 						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
 
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeNotFound),
@@ -460,6 +439,7 @@ var _ = Describe("Shoot validator", func() {
 					})
 
 					It("should return error when azure-dns provider WorkloadIdentity not found", func() {
+						// WorkloadIdentity not pre-populated → fake client returns not-found
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -473,9 +453,6 @@ var _ = Describe("Shoot validator", func() {
 								},
 							},
 						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
-							&securityv1alpha1.WorkloadIdentity{}).
-							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "workloadidentities"}, "dns-workload-identity"))
 
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeNotFound),
@@ -484,19 +461,6 @@ var _ = Describe("Shoot validator", func() {
 					})
 
 					It("should succeed with valid azure-dns Secret", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:    ptr.To(azure.DNSType),
-									Primary: ptr.To(true),
-									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
-										APIVersion: "v1",
-										Kind:       "Secret",
-										Name:       "dns-secret",
-									},
-								},
-							},
-						}
 						validSecret := &corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
 							Data: map[string][]byte{
@@ -506,15 +470,8 @@ var _ = Describe("Shoot validator", func() {
 								azure.DNSClientSecretKey:   []byte("secret"),
 							},
 						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							SetArg(2, *validSecret).
-							Return(nil)
+						buildValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
 
-						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
-					})
-
-					It("should return error with invalid azure-dns Secret", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -528,16 +485,32 @@ var _ = Describe("Shoot validator", func() {
 								},
 							},
 						}
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should return error with invalid azure-dns Secret", func() {
 						invalidSecret := &corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
 							Data: map[string][]byte{
 								"foo": []byte("bar"),
 							},
 						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-							&corev1.Secret{}).
-							SetArg(2, *invalidSecret).
-							Return(nil)
+						buildValidator([]client.Object{cloudProfile}, []client.Object{invalidSecret})
+
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
+							},
+						}
 
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeInvalid),
@@ -552,45 +525,25 @@ var _ = Describe("Shoot validator", func() {
 					})
 
 					It("should succeed with valid azure-dns WorkloadIdentity", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:    ptr.To(azure.DNSType),
-									Primary: ptr.To(true),
-									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
-										APIVersion: "security.gardener.cloud/v1alpha1",
-										Kind:       "WorkloadIdentity",
-										Name:       "dns-workload-identity",
-									},
-								},
-							},
-						}
 						validWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
 							ObjectMeta: metav1.ObjectMeta{Name: "dns-workload-identity", Namespace: namespace},
 							Spec: securityv1alpha1.WorkloadIdentitySpec{
 								TargetSystem: securityv1alpha1.TargetSystem{
 									Type: "azure",
 									ProviderConfig: &runtime.RawExtension{
-										Raw: []byte(`
-apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-clientID: "11111c4e-db61-17fa-a141-ed39b34aa561"
-tenantID: "44444c4e-db61-17fa-a141-ed39b34aa561"
-subscriptionID: "44444c4e-db61-17fa-a141-ed39b34aa561"
-`),
+										Raw: []byte(`{
+											"apiVersion": "azure.provider.extensions.gardener.cloud/v1alpha1",
+											"kind": "WorkloadIdentityConfig",
+											"clientID": "11111c4e-db61-17fa-a141-ed39b34aa561",
+											"tenantID": "44444c4e-db61-17fa-a141-ed39b34aa561",
+											"subscriptionID": "44444c4e-db61-17fa-a141-ed39b34aa561"
+										}`),
 									},
 								},
 							},
 						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
-							&securityv1alpha1.WorkloadIdentity{}).
-							SetArg(2, *validWorkloadIdentity).
-							Return(nil)
+						buildValidator([]client.Object{cloudProfile}, []client.Object{validWorkloadIdentity})
 
-						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
-					})
-
-					It("should return error with invalid azure-dns WorkloadIdentity", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -604,27 +557,43 @@ subscriptionID: "44444c4e-db61-17fa-a141-ed39b34aa561"
 								},
 							},
 						}
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should return error with invalid azure-dns WorkloadIdentity", func() {
 						invalidWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
 							ObjectMeta: metav1.ObjectMeta{Name: "dns-workload-identity", Namespace: namespace},
 							Spec: securityv1alpha1.WorkloadIdentitySpec{
 								TargetSystem: securityv1alpha1.TargetSystem{
 									Type: "azure",
 									ProviderConfig: &runtime.RawExtension{
-										Raw: []byte(`
-apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-clientID: "client-id"
-tenantID: "tenant-id"
-subscriptionID: "subscription-id"
-`),
+										Raw: []byte(`{
+											"apiVersion": "azure.provider.extensions.gardener.cloud/v1alpha1",
+											"kind": "WorkloadIdentityConfig",
+											"clientID": "client-id",
+											"tenantID": "tenant-id",
+											"subscriptionID": "subscription-id"
+										}`),
 									},
 								},
 							},
 						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
-							&securityv1alpha1.WorkloadIdentity{}).
-							SetArg(2, *invalidWorkloadIdentity).
-							Return(nil)
+						buildValidator([]client.Object{cloudProfile}, []client.Object{invalidWorkloadIdentity})
+
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To(azure.DNSType),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "dns-workload-identity",
+									},
+								},
+							},
+						}
 
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeInvalid),
@@ -660,6 +629,14 @@ subscriptionID: "subscription-id"
 					})
 
 					It("should return error with InternalSecret type", func() {
+						internalSecret := &gardencorev1beta1.InternalSecret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-internal-secret-ref", Namespace: namespace},
+							Data: map[string][]byte{
+								"foo": []byte("bar"),
+							},
+						}
+						buildValidator([]client.Object{cloudProfile}, []client.Object{internalSecret})
+
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -673,16 +650,6 @@ subscriptionID: "subscription-id"
 								},
 							},
 						}
-						internalSecret := &gardencorev1beta1.InternalSecret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-internal-secret-ref", Namespace: namespace},
-							Data: map[string][]byte{
-								"foo": []byte("bar"),
-							},
-						}
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret-ref"},
-							&gardencorev1beta1.InternalSecret{}).
-							SetArg(2, *internalSecret).
-							Return(nil)
 
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),

--- a/pkg/azure/client/auth_test.go
+++ b/pkg/azure/client/auth_test.go
@@ -7,12 +7,12 @@ package client_test
 import (
 	"context"
 
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 	. "github.com/gardener/gardener-extension-provider-azure/pkg/azure/client"
@@ -20,8 +20,6 @@ import (
 
 var _ = Describe("Azure Auth", func() {
 	var (
-		ctrl *gomock.Controller
-
 		ctx context.Context
 
 		clientAuth *ClientAuth
@@ -34,7 +32,6 @@ var _ = Describe("Azure Auth", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
 		clientSecret, clientID, tenantID, subscriptionID := "secret", "client_id", "tenant_id", "subscription_id"
 		clientAuth = &ClientAuth{
 			ClientSecret:   clientSecret,
@@ -66,10 +63,6 @@ var _ = Describe("Azure Auth", func() {
 			Namespace: namespace,
 			Name:      name,
 		}
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#NewClientAuthDataFromSecret", func() {
@@ -165,14 +158,19 @@ var _ = Describe("Azure Auth", func() {
 	})
 
 	Describe("#GetClientAuthData", func() {
+		var scheme *runtime.Scheme
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			secret.ObjectMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
+			dnsSecret.ObjectMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
+		})
+
 		Context("DNS keys are not allowed", func() {
 			It("should retrieve the client auth data if non-DNS keys ar used", func() {
-				var c = mockclient.NewMockClient(ctrl)
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *corev1.Secret, _ ...client.GetOption) error {
-						*actual = *secret
-						return nil
-					})
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 
 				actual, _, err := GetClientAuthData(ctx, c, secretRef, false)
 
@@ -181,12 +179,7 @@ var _ = Describe("Azure Auth", func() {
 			})
 
 			It("should fail if DNS keys ar used", func() {
-				var c = mockclient.NewMockClient(ctrl)
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *corev1.Secret, _ ...client.GetOption) error {
-						*actual = *dnsSecret
-						return nil
-					})
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(dnsSecret).Build()
 
 				actual, _, err := GetClientAuthData(ctx, c, secretRef, false)
 
@@ -197,12 +190,7 @@ var _ = Describe("Azure Auth", func() {
 
 		Context("DNS keys are allowed", func() {
 			It("should retrieve the client auth data if non-DNS keys ar used", func() {
-				var c = mockclient.NewMockClient(ctrl)
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *corev1.Secret, _ ...client.GetOption) error {
-						*actual = *secret
-						return nil
-					})
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 
 				actual, _, err := GetClientAuthData(ctx, c, secretRef, true)
 
@@ -211,12 +199,7 @@ var _ = Describe("Azure Auth", func() {
 			})
 
 			It("should retrieve the client auth data if DNS keys ar used", func() {
-				var c = mockclient.NewMockClient(ctrl)
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *corev1.Secret, _ ...client.GetOption) error {
-						*actual = *dnsSecret
-						return nil
-					})
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(dnsSecret).Build()
 
 				actual, _, err := GetClientAuthData(ctx, c, secretRef, true)
 

--- a/pkg/controller/backupbucket/actuator_test.go
+++ b/pkg/controller/backupbucket/actuator_test.go
@@ -17,18 +17,16 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
@@ -96,8 +94,8 @@ var _ = Describe("Actuator", func() {
 	var (
 		ctx                           context.Context
 		ctrl                          *gomock.Controller
-		c                             *mockclient.MockClient
-		sw                            *mockclient.MockStatusWriter
+		c                             client.Client
+		scheme                        *runtime.Scheme
 		mgr                           testutils.FakeManager
 		azureClientFactory            *mockazureclient.MockFactory
 		azureGroupClient              *mockazureclient.MockResourceGroup
@@ -117,15 +115,11 @@ var _ = Describe("Actuator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
-		sw = mockclient.NewMockStatusWriter(ctrl)
 		azureClientFactory = mockazureclient.NewMockFactory(ctrl)
 		azureGroupClient = mockazureclient.NewMockResourceGroup(ctrl)
 		azureStorageAccountClient = mockazureclient.NewMockStorageAccount(ctrl)
 		azureBlobContainersClient = mockazureclient.NewMockBlobContainers(ctrl)
 		azureManagementPoliciesClient = mockazureclient.NewMockManagementPolicies(ctrl)
-
-		c.EXPECT().Status().Return(sw).AnyTimes()
 
 		DefaultAzureClientFactoryFunc = func(_ context.Context, _ client.Client, _ corev1.SecretReference, _ bool, _ ...azclient.AzureFactoryOption) (azclient.Factory, error) {
 			return azureClientFactory, nil
@@ -134,6 +128,14 @@ var _ = Describe("Actuator", func() {
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&extensionsv1alpha1.BackupBucket{}).
+			Build()
 		mgr = testutils.FakeManager{Client: c}
 
 		a = NewActuator(mgr)
@@ -154,6 +156,9 @@ var _ = Describe("Actuator", func() {
 				},
 			},
 		}
+		// Create the backupBucket in the store so status patches succeed.
+		Expect(c.Create(ctx, backupBucket)).To(Succeed())
+
 		storageAccountKeys = []*armstorage.AccountKey{
 			{
 				KeyName: to.Ptr("key1"),
@@ -173,7 +178,6 @@ var _ = Describe("Actuator", func() {
 
 	AfterEach(func() {
 		DefaultAzureClientFactoryFunc = defaultFactory
-		ctrl.Finish()
 	})
 
 	Describe("#Reconcile", func() {
@@ -200,7 +204,7 @@ var _ = Describe("Actuator", func() {
 					storageAccountKeys[1].CreationTime = ptr.To(time.Now())
 					return storageAccountKeys, nil
 				})
-				mockGeneratedSecretUpdate(ctx, c, storageAccountName, "secret1", "newKey", backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				err := a.Reconcile(ctx, logger, backupBucket)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -213,7 +217,7 @@ var _ = Describe("Actuator", func() {
 					storageAccountKeys[1].CreationTime = ptr.To(time.Now())
 					return storageAccountKeys, nil
 				})
-				mockGeneratedSecretUpdate(ctx, c, storageAccountName, "secret1", "newKey", backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				err := a.Reconcile(ctx, logger, backupBucket)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -226,13 +230,13 @@ var _ = Describe("Actuator", func() {
 					storageAccountKeys[0].CreationTime = ptr.To(time.Now())
 					return storageAccountKeys, nil
 				})
-				mockGeneratedSecretUpdate(ctx, c, storageAccountName, "secret2", "newKey", backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret2", backupBucket)
 				err := a.Reconcile(ctx, logger, backupBucket)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 			It("should skip rotating the credentials if they are within the rotation period", func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				storageAccountKeys[0].CreationTime = ptr.To(time.Now())
 				err := a.Reconcile(ctx, logger, backupBucket)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -252,7 +256,7 @@ var _ = Describe("Actuator", func() {
 					},
 				}
 				mockEnsureResourceGroupAndStorageAccountWithParams(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket, ptr.To(int32(5)))
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				storageAccountKeys[0].CreationTime = ptr.To(time.Now())
 				err := a.Reconcile(ctx, logger, backupBucket)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -299,9 +303,6 @@ var _ = Describe("Actuator", func() {
 			It("should error if adding the lifecycle policy to the storage account fails", func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
 
-				// create generated secret
-				mockGeneratedSecretCreation(ctx, c, sw, storageAccountName, backupBucket)
-
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0).Return(fmt.Errorf("management policy addition on storage account error test"))
 
@@ -314,7 +315,7 @@ var _ = Describe("Actuator", func() {
 			BeforeEach(func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
 				// create generated secret
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
@@ -356,7 +357,7 @@ var _ = Describe("Actuator", func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
 
 				// create generated secret
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
@@ -401,7 +402,7 @@ var _ = Describe("Actuator", func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
 
 				// create generated secret
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
@@ -451,7 +452,7 @@ var _ = Describe("Actuator", func() {
 				}
 
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
 
@@ -488,7 +489,7 @@ var _ = Describe("Actuator", func() {
 					Namespace: "garden",
 				}
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				backupBucket.Spec.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{"apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1","kind":"BackupBucketConfig","immutability":{"retentionType":"bucket","retentionPeriod":"24h","locked":true}}`),
 				}
@@ -534,7 +535,7 @@ var _ = Describe("Actuator", func() {
 				}
 
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
 			})
@@ -600,7 +601,7 @@ var _ = Describe("Actuator", func() {
 		Context("when a backupbucket configured for locked immutability already exists in a locked state", func() {
 			BeforeEach(func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
 			})
@@ -628,7 +629,7 @@ var _ = Describe("Actuator", func() {
 		Context("when a backupbucket already exists in the expected state", func() {
 			BeforeEach(func() {
 				mockEnsureResourceGroupAndStorageAccount(ctx, azureClientFactory, azureGroupClient, azureStorageAccountClient, storageAccountName, backupBucket)
-				mockGeneratedSecretNoop(ctx, c, storageAccountName, backupBucket)
+				ensureGeneratedSecret(ctx, c, storageAccountName, "secret1", backupBucket)
 				azureClientFactory.EXPECT().ManagementPolicies().Return(azureManagementPoliciesClient, nil)
 				azureManagementPoliciesClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, storageAccountName, 0)
 			})
@@ -710,9 +711,8 @@ var _ = Describe("Actuator", func() {
 				Name:      generatedSecret.Name,
 				Namespace: generatedSecret.Namespace,
 			}
-			// passing &corev1.Secret{} here instead of generatedSecret
-			// since kutil.GetSecretByReference() uses a &corev1.Secret{} to Get()
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), &corev1.Secret{})
+			// Pre-populate the generated secret so Get can find it.
+			Expect(c.Create(ctx, generatedSecret)).To(Succeed())
 			azureClientFactory.EXPECT().BlobContainers().Return(azureBlobContainersClient, nil)
 		})
 
@@ -729,10 +729,11 @@ var _ = Describe("Actuator", func() {
 			azureClientFactory.EXPECT().Group().Return(azureGroupClient, nil)
 			azureGroupClient.EXPECT().Delete(ctx, resourceGroupName)
 
-			c.EXPECT().Delete(ctx, generatedSecret)
-
 			err := a.Delete(ctx, logger, backupBucket)
 			Expect(err).ShouldNot(HaveOccurred())
+
+			// Verify the generated secret was deleted.
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(generatedSecret), &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
 		})
 	})
 })
@@ -768,130 +769,39 @@ func mockEnsureResourceGroupAndStorageAccountWithParams(
 	azureStorageAccountClient.EXPECT().ListStorageAccountKeys(ctx, name, storageAccountName).Return(storageAccountKeys, nil)
 }
 
-func mockGeneratedSecretCreation(
+// ensureGeneratedSecret creates or updates the generated secret with the given storage key.
+func ensureGeneratedSecret(
 	ctx context.Context,
-	c *mockclient.MockClient,
-	sw *mockclient.MockStatusWriter,
+	c client.Client,
 	storageAccountName string,
+	storageKey string,
 	backupBucket *extensionsv1alpha1.BackupBucket,
 ) {
-	generatedSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("generated-bucket-%s", backupBucket.Name),
-			Namespace: "garden",
-		},
-	}
-
-	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), generatedSecret.DeepCopy()).Return(apierrors.NewNotFound(schema.GroupResource{}, generatedSecret.Name))
-	// mutateFn's side effect
-	generatedSecret.Data = map[string][]byte{
-		"domain":         []byte(azure.AzureBlobStorageDomain),
-		"storageAccount": []byte(storageAccountName),
-		"storageKey":     []byte(*(storageAccountKeys[0].Value)),
-	}
-
-	c.EXPECT().Create(ctx, generatedSecret)
-	backupBucketCopy := backupBucket.DeepCopy()
-	backupBucketCopy.Status.GeneratedSecretRef = &corev1.SecretReference{
-		Name:      generatedSecret.Name,
-		Namespace: generatedSecret.Namespace,
-	}
-
-	// gomock.Any() needs to be used here since the patch can never be the same
-	// as MergeFrom() needs a deepcopy, which creates a different base object
-	sw.EXPECT().Patch(ctx, backupBucketCopy, gomock.Any())
-}
-
-// mockGeneratedSecretNoop is a utility to ensure that the controller passes the steps for the creation of the generated secret.
-func mockGeneratedSecretNoop(
-	ctx context.Context,
-	c *mockclient.MockClient,
-	storageAccountName string,
-	backupBucket *extensionsv1alpha1.BackupBucket,
-) {
+	secretName := fmt.Sprintf("generated-bucket-%s", backupBucket.Name)
 	backupBucket.Status.GeneratedSecretRef = &corev1.SecretReference{
-		Name:      fmt.Sprintf("generated-bucket-%s", backupBucket.Name),
+		Name:      secretName,
 		Namespace: "garden",
 	}
 
 	generatedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("generated-bucket-%s", backupBucket.Name),
+			Name:      secretName,
 			Namespace: "garden",
+		},
+		Data: map[string][]byte{
+			azure.StorageDomain:  []byte(azure.AzureBlobStorageDomain),
+			azure.StorageAccount: []byte(storageAccountName),
+			azure.StorageKey:     []byte(storageKey),
 		},
 	}
 
-	secret := &corev1.Secret{}
-	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), secret).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-		*obj = *generatedSecret.DeepCopy()
-		obj.Data = map[string][]byte{
-			azure.StorageDomain:  []byte(azure.AzureBlobStorageDomain),
-			azure.StorageAccount: []byte(storageAccountName),
-			azure.StorageKey:     []byte("secret1"),
-		}
-		return nil
-	})
-
-	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), generatedSecret.DeepCopy()).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-		generatedSecret.Data = map[string][]byte{
-			azure.StorageDomain:  []byte(azure.AzureBlobStorageDomain),
-			azure.StorageAccount: []byte(storageAccountName),
-			azure.StorageKey:     []byte("secret1"),
-		}
-		*obj = *generatedSecret
-		return nil
-	})
-}
-
-func mockGeneratedSecretUpdate(
-	ctx context.Context,
-	c *mockclient.MockClient,
-	storageAccountName string,
-	oldStorageAccountKey string,
-	newStorageAccountKey string,
-	backupBucket *extensionsv1alpha1.BackupBucket,
-) {
-	backupBucket.Status.GeneratedSecretRef = &corev1.SecretReference{
-		Name:      fmt.Sprintf("generated-bucket-%s", backupBucket.Name),
-		Namespace: "garden",
+	existing := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(generatedSecret), existing); err != nil {
+		Expect(c.Create(ctx, generatedSecret)).To(Succeed())
+	} else {
+		existing.Data = generatedSecret.Data
+		Expect(c.Update(ctx, existing)).To(Succeed())
 	}
-
-	generatedSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("generated-bucket-%s", backupBucket.Name),
-			Namespace: "garden",
-		},
-	}
-
-	secret := &corev1.Secret{}
-	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), secret).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-		*obj = *generatedSecret.DeepCopy()
-		obj.Data = map[string][]byte{
-			"domain":         []byte(azure.AzureBlobStorageDomain),
-			"storageAccount": []byte(storageAccountName),
-			"storageKey":     []byte(oldStorageAccountKey),
-		}
-		return nil
-	})
-	c.EXPECT().Get(ctx, client.ObjectKeyFromObject(generatedSecret), generatedSecret.DeepCopy()).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-		secret := generatedSecret.DeepCopy()
-		secret.Data = map[string][]byte{
-			"domain":         []byte(azure.AzureBlobStorageDomain),
-			"storageAccount": []byte(storageAccountName),
-			"storageKey":     []byte(oldStorageAccountKey),
-		}
-		*obj = *secret
-		return nil
-	})
-
-	// mutateFn's side effect
-	generatedSecret.Data = map[string][]byte{
-		"domain":         []byte(azure.AzureBlobStorageDomain),
-		"storageAccount": []byte(storageAccountName),
-		"storageKey":     []byte(newStorageAccountKey),
-	}
-
-	c.EXPECT().Update(ctx, generatedSecret)
 }
 
 func mockEnsureBlobContainer(

--- a/pkg/controller/controlplane/actuator_test.go
+++ b/pkg/controller/controlplane/actuator_test.go
@@ -15,14 +15,14 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	azurev1alpha1 "github.com/gardener/remedy-controller/pkg/apis/azure/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -32,7 +32,8 @@ var _ = Describe("Actuator", func() {
 		ctx    = context.TODO()
 		logger = log.Log.WithName("test")
 
-		c        *mockclient.MockClient
+		c        client.Client
+		scheme   *runtime.Scheme
 		mgr      testutils.FakeManager
 		a        *mockcontrolplane.MockActuator
 		actuator controlplane.Actuator
@@ -53,10 +54,9 @@ var _ = Describe("Actuator", func() {
 		newPubip = func(annotations map[string]string) *azurev1alpha1.PublicIPAddress {
 			return &azurev1alpha1.PublicIPAddress{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "foo-1.2.3.4",
-					Namespace:       namespace,
-					Annotations:     annotations,
-					ResourceVersion: "1",
+					Name:        "foo-1.2.3.4",
+					Namespace:   namespace,
+					Annotations: annotations,
 				},
 				Spec: azurev1alpha1.PublicIPAddressSpec{
 					IPAddress: "1.2.3.4",
@@ -67,9 +67,8 @@ var _ = Describe("Actuator", func() {
 		newVirtualMachine = func() *azurev1alpha1.VirtualMachine {
 			return &azurev1alpha1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "node-name",
-					Namespace:       namespace,
-					ResourceVersion: "1",
+					Name:      "node-name",
+					Namespace: namespace,
 				},
 			}
 		}
@@ -77,7 +76,12 @@ var _ = Describe("Actuator", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+
+		scheme = runtime.NewScheme()
+		Expect(azurev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 		mgr = testutils.FakeManager{Client: c}
 
 		a = mockcontrolplane.NewMockActuator(ctrl)
@@ -86,49 +90,34 @@ var _ = Describe("Actuator", func() {
 		actuator = NewActuator(mgr, a, gracefulDeletionTimeout, gracefulDeletionWaitInterval)
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#Delete", func() {
 		It("should successfully delete controlplane if there are no remedy controller resources", func() {
 			cp := newControlPlane()
-			time := metav1.Now()
-			cp.DeletionTimestamp = &time
-			c.EXPECT().List(gomock.Any(), &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.PublicIPAddressList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.PublicIPAddress{}
-					return nil
-				}).Times(2)
-
-			c.EXPECT().List(ctx, &azurev1alpha1.VirtualMachineList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.VirtualMachineList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.VirtualMachine{}
-					return nil
-				})
-
-			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.PublicIPAddress{}, client.InNamespace(namespace)).Return(nil)
-			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.VirtualMachine{}, client.InNamespace(namespace)).Return(nil)
+			t := metav1.Now()
+			cp.DeletionTimestamp = &t
 
 			a.EXPECT().Delete(ctx, logger, cp, cluster).Return(nil)
 			err := actuator.Delete(ctx, logger, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Both DeleteAllOf calls must have run (store was already empty, remains empty).
+			pubipList := &azurev1alpha1.PublicIPAddressList{}
+			Expect(c.List(ctx, pubipList, client.InNamespace(namespace))).To(Succeed())
+			Expect(pubipList.Items).To(BeEmpty())
+
+			vmList := &azurev1alpha1.VirtualMachineList{}
+			Expect(c.List(ctx, vmList, client.InNamespace(namespace))).To(Succeed())
+			Expect(vmList.Items).To(BeEmpty())
 		})
 
 		It("should return RequeueAfterError if there are publicipaddresses remaining and timeout is not yet reached", func() {
 			cp := newControlPlane()
-			time := metav1.Now()
-			cp.DeletionTimestamp = &time
+			t := metav1.Now()
+			cp.DeletionTimestamp = &t
 
-			pubip := newPubip(nil)
-			pubipWithFinalizers := pubip.DeepCopy()
+			pubipWithFinalizers := newPubip(nil)
 			pubipWithFinalizers.Finalizers = append(pubipWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/publicipaddress")
-
-			c.EXPECT().List(ctx, &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.PublicIPAddressList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.PublicIPAddress{*pubipWithFinalizers}
-					return nil
-				})
+			Expect(c.Create(ctx, pubipWithFinalizers)).To(Succeed())
 
 			err := actuator.Delete(ctx, logger, cp, cluster)
 			Expect(err).To(MatchError(&reconcilerutils.RequeueAfterError{RequeueAfter: gracefulDeletionWaitInterval}))
@@ -136,36 +125,30 @@ var _ = Describe("Actuator", func() {
 
 		It("should forcefully remove remedy controller resources after grace period timeout has been reached", func() {
 			cp := newControlPlane()
-			time := metav1.NewTime(time.Now().Add(-2 * gracefulDeletionTimeout))
-			cp.DeletionTimestamp = &time
+			t := metav1.NewTime(time.Now().Add(-2 * gracefulDeletionTimeout))
+			cp.DeletionTimestamp = &t
 
-			pubip := newPubip(nil)
-			pubipWithFinalizers := pubip.DeepCopy()
+			pubipWithFinalizers := newPubip(nil)
 			pubipWithFinalizers.Finalizers = append(pubipWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/publicipaddress")
-			c.EXPECT().List(ctx, &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.PublicIPAddressList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.PublicIPAddress{*pubipWithFinalizers}
-					return nil
-				}).Times(2)
+			Expect(c.Create(ctx, pubipWithFinalizers)).To(Succeed())
 
-			testutils.EXPECTPatchWithOptimisticLock(ctx, c, pubip, pubipWithFinalizers, types.MergePatchType)
-			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.PublicIPAddress{}, client.InNamespace(namespace)).Return(nil)
-
-			vm := newVirtualMachine()
-			vmWithFinalizers := vm.DeepCopy()
+			vmWithFinalizers := newVirtualMachine()
 			vmWithFinalizers.Finalizers = append(vmWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/virtualmachine")
-			c.EXPECT().List(ctx, &azurev1alpha1.VirtualMachineList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.VirtualMachineList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.VirtualMachine{*vmWithFinalizers}
-					return nil
-				})
-			testutils.EXPECTPatchWithOptimisticLock(ctx, c, vm, vmWithFinalizers, types.MergePatchType)
-			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.VirtualMachine{}, client.InNamespace(namespace)).Return(nil)
+			Expect(c.Create(ctx, vmWithFinalizers)).To(Succeed())
 
 			a.EXPECT().Delete(ctx, logger, cp, cluster).Return(nil)
 
 			err := actuator.Delete(ctx, logger, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Finalizers removed and DeleteAllOf called — both objects must be gone.
+			pubipList := &azurev1alpha1.PublicIPAddressList{}
+			Expect(c.List(ctx, pubipList, client.InNamespace(namespace))).To(Succeed())
+			Expect(pubipList.Items).To(BeEmpty())
+
+			vmList := &azurev1alpha1.VirtualMachineList{}
+			Expect(c.List(ctx, vmList, client.InNamespace(namespace))).To(Succeed())
+			Expect(vmList.Items).To(BeEmpty())
 		})
 	})
 
@@ -174,30 +157,25 @@ var _ = Describe("Actuator", func() {
 			cp := newControlPlane()
 			a.EXPECT().Migrate(ctx, logger, cp, cluster).Return(nil)
 
-			pubip := newPubip(nil)
-			pubipWithFinalizers := pubip.DeepCopy()
+			pubipWithFinalizers := newPubip(nil)
 			pubipWithFinalizers.Finalizers = append(pubipWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/publicipaddress")
-			c.EXPECT().List(ctx, &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.PublicIPAddressList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.PublicIPAddress{*pubipWithFinalizers}
-					return nil
-				})
-			testutils.EXPECTPatchWithOptimisticLock(ctx, c, pubip, pubipWithFinalizers, types.MergePatchType)
-			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.PublicIPAddress{}, client.InNamespace(namespace)).Return(nil)
+			Expect(c.Create(ctx, pubipWithFinalizers)).To(Succeed())
 
-			vm := newVirtualMachine()
-			vmWithFinalizers := vm.DeepCopy()
+			vmWithFinalizers := newVirtualMachine()
 			vmWithFinalizers.Finalizers = append(vmWithFinalizers.Finalizers, "azure.remedy.gardener.cloud/virtualmachine")
-			c.EXPECT().List(ctx, &azurev1alpha1.VirtualMachineList{}, client.InNamespace(namespace)).
-				DoAndReturn(func(_ context.Context, list *azurev1alpha1.VirtualMachineList, _ ...client.ListOption) error {
-					list.Items = []azurev1alpha1.VirtualMachine{*vmWithFinalizers}
-					return nil
-				})
-			testutils.EXPECTPatchWithOptimisticLock(ctx, c, vm, vmWithFinalizers, types.MergePatchType)
-			c.EXPECT().DeleteAllOf(ctx, &azurev1alpha1.VirtualMachine{}, client.InNamespace(namespace)).Return(nil)
+			Expect(c.Create(ctx, vmWithFinalizers)).To(Succeed())
 
 			err := actuator.Migrate(ctx, logger, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Finalizers removed and DeleteAllOf called — both objects must be gone.
+			pubipList := &azurev1alpha1.PublicIPAddressList{}
+			Expect(c.List(ctx, pubipList, client.InNamespace(namespace))).To(Succeed())
+			Expect(pubipList.Items).To(BeEmpty())
+
+			vmList := &azurev1alpha1.VirtualMachineList{}
+			Expect(c.List(ctx, vmList, client.InNamespace(namespace))).To(Succeed())
+			Expect(vmList.Items).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -18,20 +18,15 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
@@ -47,19 +42,20 @@ const (
 
 var _ = Describe("ValuesProvider", func() {
 	var (
-		ctrl *gomock.Controller
-		ctx  = context.TODO()
+		ctx = context.TODO()
 
-		fakeClient         client.Client
 		fakeSecretsManager secretsmanager.Interface
 
-		c   *mockclient.MockClient
 		vp  genericactuator.ValuesProvider
 		mgr testutils.FakeManager
 
 		scheme = runtime.NewScheme()
 		_      = apisazure.AddToScheme(scheme)
 		_      = v1alpha1.AddToScheme(scheme)
+		_      = corev1.AddToScheme(scheme)
+		_      = appsv1.AddToScheme(scheme)
+		_      = vpaautoscalingv1.AddToScheme(scheme)
+		_      = policyv1.AddToScheme(scheme)
 
 		infrastructureStatus *v1alpha1.InfrastructureStatus
 		controlPlaneConfig   *v1alpha1.ControlPlaneConfig
@@ -122,25 +118,50 @@ var _ = Describe("ValuesProvider", func() {
 		enabledFalse   = map[string]interface{}{"enabled": false}
 		remedyDisabled = map[string]interface{}{"enabled": true, "replicas": 0}
 
-		// Azure Container Registry
-		azureContainerRegistryConfigMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: azure.CloudProviderAcrConfigName, Namespace: namespace},
-		}
-		errorAzureContainerRegistryConfigMapNotFound = apierrors.NewNotFound(schema.GroupResource{}, azure.CloudProviderAcrConfigName)
-		checksums                                    = map[string]string{
+		checksums = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 			azure.CloudProviderDiskConfigName:        "77627eb2343b9f2dc2fca3cce35f2f9eec55783aa5f7dac21c473019e5825de2",
 		}
+
+		// controlPlaneSecret is the cloud-provider secret used in GetConfigChartValues and GetControlPlaneChartValues.
+		controlPlaneSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      v1beta1constants.SecretNameCloudProvider,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"clientID":       []byte(`ClientID`),
+				"clientSecret":   []byte(`ClientSecret`),
+				"subscriptionID": []byte(`SubscriptionID`),
+				"tenantID":       []byte(`TenantID`),
+			},
+		}
+
+		// controlPlaneConfigSecret is the azure-cloudprovider-config secret used in GetControlPlaneChartValues.
+		controlPlaneConfigSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      azure.CloudProviderConfigName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{azure.CloudProviderConfigMapKey: []byte(cloudProviderConfigData)},
+		}
 	)
 
+	// buildMgr creates a fake manager with the given objects pre-populated.
+	buildMgr := func(objs ...corev1.Secret) testutils.FakeManager {
+		builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+		for i := range objs {
+			builder = builder.WithObjects(&objs[i])
+		}
+		return testutils.FakeManager{Client: builder.Build(), Scheme: scheme}
+	}
+
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
+		mgr = buildMgr(*controlPlaneSecret, *controlPlaneConfigSecret)
 
-		fakeClient = fakeclient.NewClientBuilder().Build()
-		fakeSecretsManager = fakesecretsmanager.New(fakeClient, namespace)
-
-		c = mockclient.NewMockClient(ctrl)
-		mgr = testutils.FakeManager{Client: c, Scheme: scheme}
+		fakeSecretsManagerClient := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeSecretsManager = fakesecretsmanager.New(fakeSecretsManagerClient, namespace)
 
 		vp = NewValuesProvider(mgr)
 
@@ -165,39 +186,9 @@ var _ = Describe("ValuesProvider", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#GetConfigChartValues", func() {
-		var (
-			controlPlaneSecretKey = client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}
-			controlPlaneSecret    = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      v1beta1constants.SecretNameCloudProvider,
-					Namespace: namespace,
-				},
-				Type: corev1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					"clientID":       []byte(`ClientID`),
-					"clientSecret":   []byte(`ClientSecret`),
-					"subscriptionID": []byte(`SubscriptionID`),
-					"tenantID":       []byte(`TenantID`),
-				},
-			}
-		)
-
-		BeforeEach(func() {
-			c.EXPECT().Get(ctx, controlPlaneSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(controlPlaneSecret))
-		})
-
 		Context("Error due to missing resources in the infrastructure status", func() {
-			BeforeEach(func() {
-				c.EXPECT().Delete(ctx, azureContainerRegistryConfigMap).Return(errorAzureContainerRegistryConfigMapNotFound)
-			})
-
 			It("should return error, missing subnet", func() {
-
 				infrastructureStatus.Networks.Subnets[0].Purpose = "internal"
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 
@@ -227,8 +218,6 @@ var _ = Describe("ValuesProvider", func() {
 
 		Context("Generate config chart values", func() {
 			It("should return correct config chart valued for cluser with vmo (non-zoned)", func() {
-				c.EXPECT().Delete(ctx, azureContainerRegistryConfigMap).Return(errorAzureContainerRegistryConfigMapNotFound)
-
 				infrastructureStatus.Zoned = false
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 
@@ -242,7 +231,6 @@ var _ = Describe("ValuesProvider", func() {
 			})
 
 			It("should return correct config chart values for zoned cluster", func() {
-				c.EXPECT().Delete(ctx, azureContainerRegistryConfigMap).Return(errorAzureContainerRegistryConfigMapNotFound)
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 
 				values, err := vp.GetConfigChartValues(ctx, cp, cluster)
@@ -275,11 +263,6 @@ var _ = Describe("ValuesProvider", func() {
 
 	Describe("#GetControlPlaneChartValues", func() {
 		var (
-			controlPlaneConfigSecretKey = client.ObjectKey{Namespace: namespace, Name: azure.CloudProviderConfigName}
-			controlPlaneConfigSecret    = &corev1.Secret{
-				Data: map[string][]byte{azure.CloudProviderConfigMapKey: []byte(cloudProviderConfigData)},
-			}
-
 			ccmChartValues = utils.MergeMaps(enabledTrue, map[string]interface{}{
 				"replicas":    1,
 				"clusterName": namespace,
@@ -312,24 +295,15 @@ var _ = Describe("ValuesProvider", func() {
 		)
 
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, controlPlaneConfigSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(controlPlaneConfigSecret))
-
 			By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
-			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-azure-controlplane", Namespace: namespace}})).To(Succeed())
-			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
+			fakeSmClient := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+			fakeSecretsManager = fakesecretsmanager.New(fakeSmClient, namespace)
+			Expect(fakeSmClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-azure-controlplane", Namespace: namespace}})).To(Succeed())
+			Expect(fakeSmClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
 
-			c.EXPECT().Delete(context.TODO(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-webhook-vpa", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-
-			cloudProviderSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cloudprovider",
-					Namespace: "test",
-				},
-			}
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(cloudProviderSecret), cloudProviderSecret).Return(nil)
+			// controlPlaneSecret (cloudprovider) is already included via buildMgr base objects
+			mgr = buildMgr(*controlPlaneSecret, *controlPlaneConfigSecret)
+			vp = NewValuesProvider(mgr)
 		})
 
 		It("should return correct control plane chart values without zoned infrastructure", func() {
@@ -433,6 +407,7 @@ var _ = Describe("ValuesProvider", func() {
 				azure.RemedyControllerName: remedyDisabled,
 			}))
 		})
+
 		It("should return correct control plane chart values when forcing read cache for in-tree PVs", func() {
 			shootAnnotations := map[string]string{
 				azure.ShootDiskConvertRWCachingModeAnnotation: "true",
@@ -456,7 +431,7 @@ var _ = Describe("ValuesProvider", func() {
 						Settings: seedSettings,
 					},
 				}
-				cluster = generateCluster(cidr, k8sVersion, true, nil, shootControlPlane, seed)
+				cluster := generateCluster(cidr, k8sVersion, true, nil, shootControlPlane, seed)
 
 				infrastructureStatus.Zoned = false
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
@@ -509,17 +484,8 @@ var _ = Describe("ValuesProvider", func() {
 				"enabled":    true,
 				"vpaEnabled": false,
 			}
-		)
 
-		BeforeEach(func() {
-			By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
-			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-azure-controlplane", Namespace: namespace}})).To(Succeed())
-			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
-		})
-
-		var (
-			cpDiskConfigKey = client.ObjectKey{Namespace: namespace, Name: azure.CloudProviderDiskConfigName}
-			cpDiskConfig    = &corev1.Secret{
+			cpDiskConfig = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      azure.CloudProviderDiskConfigName,
 					Namespace: namespace,
@@ -531,11 +497,18 @@ var _ = Describe("ValuesProvider", func() {
 		)
 
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, cpDiskConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpDiskConfig))
-			cluster = generateCluster(cidr, k8sVersion, true, nil, nil, nil)
+			By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
+			fakeSmClient := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+			fakeSecretsManager = fakesecretsmanager.New(fakeSmClient, namespace)
+			Expect(fakeSmClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-azure-controlplane", Namespace: namespace}})).To(Succeed())
+			Expect(fakeSmClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
+
+			mgr = buildMgr(*controlPlaneSecret, *controlPlaneConfigSecret, *cpDiskConfig)
+			vp = NewValuesProvider(mgr)
 		})
 
 		It("should return correct control plane shoot chart values for zoned cluster", func() {
+			cluster = generateCluster(cidr, k8sVersion, true, nil, nil, nil)
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 			csiNode := csiNodeEnabled
 
@@ -569,6 +542,7 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should return false if allowEgress behavior is overwritten by user", func() {
+			cluster = generateCluster(cidr, k8sVersion, true, nil, nil, nil)
 			infrastructureStatus.Zoned = true
 			cluster.Shoot.GetAnnotations()[azure.ShootSkipAllowEgressDeployment] = "true"
 			cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
@@ -585,14 +559,11 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		Context("remedy controller is disabled", func() {
-			BeforeEach(func() {
+			It("should return correct control plane shoot chart values for zoned cluster", func() {
 				shootAnnotations := map[string]string{
 					azure.DisableRemedyControllerAnnotation: "true",
 				}
 				cluster = generateCluster(cidr, k8sVersion, false, shootAnnotations, nil, nil)
-			})
-
-			It("should return correct control plane shoot chart values for zoned cluster", func() {
 				cp := generateControlPlane(controlPlaneConfig, infrastructureStatus)
 				csiNode := csiNodeEnabled
 
@@ -654,18 +625,6 @@ var _ = Describe("ValuesProvider", func() {
 func encode(obj runtime.Object) []byte {
 	data, _ := json.Marshal(obj)
 	return data
-}
-
-func clientGet(result runtime.Object) interface{} {
-	return func(_ context.Context, _ client.ObjectKey, obj runtime.Object, _ ...client.GetOption) error {
-		switch obj.(type) {
-		case *corev1.Secret:
-			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
-		case *corev1.ConfigMap:
-			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
-		}
-		return nil
-	}
 }
 
 func generateControlPlane(controlPlaneConfig *v1alpha1.ControlPlaneConfig, infrastructureStatus *v1alpha1.InfrastructureStatus) *extensionsv1alpha1.ControlPlane {

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -10,15 +10,16 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
@@ -39,9 +40,8 @@ const (
 var _ = Describe("Actuator", func() {
 	var (
 		ctrl                    *gomock.Controller
-		c                       *mockclient.MockClient
+		c                       client.Client
 		mgr                     testutils.FakeManager
-		sw                      *mockclient.MockStatusWriter
 		azureClientFactory      *mockazureclient.MockFactory
 		azureDNSZoneClient      *mockazureclient.MockDNSZone
 		azureDNSRecordSetClient *mockazureclient.MockDNSRecordSet
@@ -56,13 +56,9 @@ var _ = Describe("Actuator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
-		sw = mockclient.NewMockStatusWriter(ctrl)
 		azureClientFactory = mockazureclient.NewMockFactory(ctrl)
 		azureDNSZoneClient = mockazureclient.NewMockDNSZone(ctrl)
 		azureDNSRecordSetClient = mockazureclient.NewMockDNSRecordSet(ctrl)
-
-		c.EXPECT().Status().Return(sw).AnyTimes()
 
 		DefaultAzureClientFactoryFunc = func(_ context.Context, _ client.Client, _ corev1.SecretReference, _ bool, _ ...azclient.AzureFactoryOption) (azclient.Factory, error) {
 			return azureClientFactory, nil
@@ -71,6 +67,13 @@ var _ = Describe("Actuator", func() {
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
+		scheme := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&extensionsv1alpha1.DNSRecord{}).
+			Build()
 		mgr = testutils.FakeManager{Client: c}
 
 		a = NewActuator(mgr)
@@ -94,6 +97,7 @@ var _ = Describe("Actuator", func() {
 				Region:     ptr.To("Foobar"),
 			},
 		}
+		Expect(c.Create(ctx, dns)).To(Succeed())
 
 		zones = map[string]string{
 			shootDomain:   zone,
@@ -104,7 +108,6 @@ var _ = Describe("Actuator", func() {
 
 	AfterEach(func() {
 		DefaultAzureClientFactoryFunc = defaultFactory
-		ctrl.Finish()
 	})
 
 	Describe("#Reconcile", func() {
@@ -113,17 +116,10 @@ var _ = Describe("Actuator", func() {
 			azureClientFactory.EXPECT().DNSRecordSet().Return(azureDNSRecordSetClient, nil)
 			azureDNSZoneClient.EXPECT().List(ctx).Return(zones, nil)
 			azureDNSRecordSetClient.EXPECT().CreateOrUpdate(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).Return(nil)
-			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, obj *extensionsv1alpha1.DNSRecord, _ client.Patch, _ ...client.PatchOption) error {
-					Expect(obj.Status).To(Equal(extensionsv1alpha1.DNSRecordStatus{
-						Zone: ptr.To(zone),
-					}))
-					return nil
-				},
-			)
 
 			err := a.Reconcile(ctx, logger, dns, nil)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(dns.Status.Zone).To(Equal(ptr.To(zone)))
 		})
 	})
 

--- a/pkg/controller/worker/machine_dependencies_test.go
+++ b/pkg/controller/worker/machine_dependencies_test.go
@@ -16,14 +16,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	azureapi "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
@@ -34,10 +36,9 @@ import (
 
 var _ = Describe("MachinesDependencies", func() {
 	var (
-		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
-		statusWriter *mockclient.MockStatusWriter
-		factory      *factorymock.MockFactory
+		ctrl    *gomock.Controller
+		c       client.Client
+		factory *factorymock.MockFactory
 
 		ctx context.Context
 
@@ -46,12 +47,18 @@ var _ = Describe("MachinesDependencies", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-		statusWriter = mockclient.NewMockStatusWriter(ctrl)
 		factory = factorymock.NewMockFactory(ctrl)
 
-		// Let the seed client always the mocked status writer when Status() is called.
-		c.EXPECT().Status().AnyTimes().Return(statusWriter)
+		scheme := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(azureapi.AddToScheme(scheme)).To(Succeed())
+
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&extensionsv1alpha1.Worker{}).
+			Build()
 
 		ctx = context.TODO()
 		namespace = "control-plane-namespace"
@@ -108,11 +115,10 @@ var _ = Describe("MachinesDependencies", func() {
 				workerDelegate := wrapNewWorkerDelegate(c, nil, w, cluster, factory)
 
 				expectVmoCreateToSucceed(ctx, vmoClient, resourceGroupName, vmoName, vmoID)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoID),
 					"Name":     Equal(vmoName),
@@ -126,11 +132,10 @@ var _ = Describe("MachinesDependencies", func() {
 				workerDelegate := wrapNewWorkerDelegate(c, nil, w, cluster, factory)
 
 				expectVmoGetToSucceed(ctx, vmoClient, resourceGroupName, vmoName, vmoID, faultDomainCount)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoDependency.ID),
 					"Name":     Equal(vmoDependency.Name),
@@ -146,11 +151,10 @@ var _ = Describe("MachinesDependencies", func() {
 				var oldFaultDomainCoaunt int32 = 2
 				expectVmoGetToSucceed(ctx, vmoClient, resourceGroupName, vmoName, vmoID, oldFaultDomainCoaunt)
 				expectVmoCreateToSucceed(ctx, vmoClient, resourceGroupName, vmoName, vmoID)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoDependency.ID),
 					"Name":     Equal(vmoDependency.Name),
@@ -176,7 +180,6 @@ var _ = Describe("MachinesDependencies", func() {
 				vmoClient.EXPECT().List(ctx, resourceGroupName).Return(nil, &azcore.ResponseError{
 					StatusCode: http.StatusNotFound,
 				})
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -187,11 +190,10 @@ var _ = Describe("MachinesDependencies", func() {
 				workerDelegate := wrapNewWorkerDelegate(c, nil, w, cluster, factory)
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(vmoName, vmoID))
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoDependency.ID),
 					"Name":     Equal(vmoDependency.Name),
@@ -206,11 +208,10 @@ var _ = Describe("MachinesDependencies", func() {
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(vmoName, vmoID), generateExpectedVmo("orphan-managed-vmss", "/some/orphan/vmss/id"))
 				expectVmoDeleteToSucceed(ctx, vmoClient, resourceGroupName)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoDependency.ID),
 					"Name":     Equal(vmoDependency.Name),
@@ -234,11 +235,10 @@ var _ = Describe("MachinesDependencies", func() {
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(deletedPoolVmoName, deletedPoolVmoID))
 				expectVmoDeleteToSucceed(ctx, vmoClient, resourceGroupName)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(BeEmpty())
 			})
 
@@ -251,11 +251,10 @@ var _ = Describe("MachinesDependencies", func() {
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(vmoName, vmoID))
 				expectVmoDeleteToSucceed(ctx, vmoClient, resourceGroupName)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(BeEmpty())
 			})
 		})
@@ -277,7 +276,6 @@ var _ = Describe("MachinesDependencies", func() {
 				vmoClient.EXPECT().List(ctx, resourceGroupName).Return(nil, &azcore.ResponseError{
 					StatusCode: http.StatusNotFound,
 				})
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -288,11 +286,10 @@ var _ = Describe("MachinesDependencies", func() {
 				workerDelegate := wrapNewWorkerDelegate(c, nil, w, cluster, factory)
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(vmoName, vmoID))
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoDependency.ID),
 					"Name":     Equal(vmoDependency.Name),
@@ -307,11 +304,10 @@ var _ = Describe("MachinesDependencies", func() {
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(vmoName, vmoID), generateExpectedVmo("orphan-managed-vmss", "/some/orphan/vmss/id"))
 				expectVmoDeleteToSucceed(ctx, vmoClient, resourceGroupName)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(ContainElements(MatchFields(IgnoreExtras, Fields{
 					"ID":       Equal(vmoDependency.ID),
 					"Name":     Equal(vmoDependency.Name),
@@ -335,11 +331,10 @@ var _ = Describe("MachinesDependencies", func() {
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(deletedPoolVmoName, deletedPoolVmoID))
 				expectVmoDeleteToSucceed(ctx, vmoClient, resourceGroupName)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(BeEmpty())
 			})
 
@@ -352,11 +347,10 @@ var _ = Describe("MachinesDependencies", func() {
 
 				expectVmoListToSucceed(ctx, vmoClient, resourceGroupName, generateExpectedVmo(vmoName, vmoID))
 				expectVmoDeleteToSucceed(ctx, vmoClient, resourceGroupName)
-				expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := decodeWorkerProviderStatus(w)
+				workerStatus := readBackWorkerStatus(ctx, c, w)
 				Expect(workerStatus.VmoDependencies).To(BeEmpty())
 			})
 		})

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/utils"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-azure/charts"
 	apisazure "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure"
@@ -49,8 +49,7 @@ var _ = Describe("Machines", func() {
 		ctx = context.Background()
 
 		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
-		statusWriter *mockclient.MockStatusWriter
+		c            client.Client
 		chartApplier *mockkubernetes.MockChartApplier
 		scheme       *runtime.Scheme
 
@@ -62,19 +61,19 @@ var _ = Describe("Machines", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
 		chartApplier = mockkubernetes.NewMockChartApplier(ctrl)
-		statusWriter = mockclient.NewMockStatusWriter(ctrl)
-
-		// Let the seed client always the mocked status writer when Status() is called.
-		c.EXPECT().Status().AnyTimes().Return(statusWriter)
 
 		// Initialize scheme for decoding
 		scheme = runtime.NewScheme()
 		_ = apiv1alpha1.AddToScheme(scheme)
 		_ = apisazure.AddToScheme(scheme)
 		_ = extensionsv1alpha1.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
 
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&extensionsv1alpha1.Worker{}).
+			Build()
 		namespace = "control-plane-namespace"
 		technicalID = "shoot--foobar--azure"
 		region = "westeurope"
@@ -82,10 +81,6 @@ var _ = Describe("Machines", func() {
 		zone2 = "2"
 		regionAndZone1 = region + "-" + zone1
 		regionAndZone2 = region + "-" + zone2
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Context("workerDelegate", func() {
@@ -525,12 +520,18 @@ var _ = Describe("Machines", func() {
 			})
 
 			expectedUserDataSecretRefRead := func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: userDataSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{userDataSecretDataKey: userData}
-						return nil
-					},
-				).AnyTimes()
+				// Pre-populate the userdata secret in the fake client so the worker delegate can read it.
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: userDataSecretName},
+					Data:       map[string][]byte{userDataSecretDataKey: userData},
+				}
+				existing := &corev1.Secret{}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(secret), existing); err != nil {
+					Expect(c.Create(ctx, secret)).To(Succeed())
+				} else {
+					existing.Data = secret.Data
+					Expect(c.Update(ctx, existing)).To(Succeed())
+				}
 			}
 
 			Describe("machine images", func() {
@@ -790,7 +791,6 @@ var _ = Describe("Machines", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						// Test workerDelegate.UpdateMachineImagesStatus()
-						expectWorkerProviderStatusUpdateToSucceed(ctx, statusWriter)
 						err = workerDelegate.UpdateMachineImagesStatus(ctx)
 						Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/controller/worker/utils_test.go
+++ b/pkg/controller/worker/utils_test.go
@@ -13,9 +13,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,44 +26,92 @@ import (
 	. "github.com/gardener/gardener-extension-provider-azure/pkg/controller/worker"
 )
 
-func wrapNewWorkerDelegate(client *mockclient.MockClient, seedChartApplier *mockkubernetes.MockChartApplier, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, factory azureclient.Factory) genericactuator.WorkerDelegate {
-	expectGetSecretCallToWork(client, worker)
+func wrapNewWorkerDelegate(c client.Client, seedChartApplier *mockkubernetes.MockChartApplier, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, factory azureclient.Factory) genericactuator.WorkerDelegate {
+	// Pre-populate the secret referenced by the worker in the client.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: worker.Spec.SecretRef.Namespace,
+			Name:      worker.Spec.SecretRef.Name,
+		},
+		Data: map[string][]byte{
+			azure.ClientIDKey:       []byte("seedClient-id"),
+			azure.ClientSecretKey:   []byte("seedClient-secret"),
+			azure.SubscriptionIDKey: []byte("1234"),
+			azure.TenantIDKey:       []byte("1234"),
+		},
+	}
+	// Use Create or Update to handle multiple wrapNewWorkerDelegate calls in the same test.
+	existing := &corev1.Secret{}
+	if err := c.Get(context.TODO(), client.ObjectKeyFromObject(secret), existing); err != nil {
+		Expect(c.Create(context.TODO(), secret)).To(Succeed())
+	}
+
+	// Create a minimal worker in the fake client so status patches can succeed.
+	// Assign a synthetic name if the worker doesn't have one.
+	if worker.Name == "" {
+		worker.Name = "worker"
+	}
+	minimalWorker := &extensionsv1alpha1.Worker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      worker.Name,
+			Namespace: worker.Namespace,
+		},
+	}
+	existingWorker := &extensionsv1alpha1.Worker{}
+	if err := c.Get(context.TODO(), client.ObjectKeyFromObject(minimalWorker), existingWorker); err != nil {
+		Expect(c.Create(context.TODO(), minimalWorker)).To(Succeed())
+	}
+	// Also mirror the existing status into the store so merge-patches produce a non-empty diff.
+	if worker.Status.ProviderStatus != nil {
+		statusPatch := client.MergeFrom(minimalWorker.DeepCopy())
+		minimalWorker.Status = worker.Status
+		Expect(c.Status().Patch(context.TODO(), minimalWorker, statusPatch)).To(Succeed())
+	}
 
 	scheme := runtime.NewScheme()
 	_ = apiazure.AddToScheme(scheme)
 	_ = v1alpha1.AddToScheme(scheme)
 
-	workerDelegate, err := NewWorkerDelegate(client, scheme, seedChartApplier, "", worker, cluster, factory)
+	workerDelegate, err := NewWorkerDelegate(c, scheme, seedChartApplier, "", worker, cluster, factory)
 	Expect(err).NotTo(HaveOccurred())
 	return workerDelegate
 }
 
 func decodeWorkerProviderStatus(worker *extensionsv1alpha1.Worker) *v1alpha1.WorkerStatus {
-	workerProviderStatus, ok := worker.Status.ProviderStatus.Object.(*v1alpha1.WorkerStatus)
-	Expect(ok).To(BeTrue())
-	return workerProviderStatus
+	ps := worker.Status.ProviderStatus
+	Expect(ps).NotTo(BeNil())
+
+	// If the object was already decoded (e.g. set directly by actuator before status patch).
+	if ps.Object != nil {
+		workerProviderStatus, ok := ps.Object.(*v1alpha1.WorkerStatus)
+		Expect(ok).To(BeTrue())
+		return workerProviderStatus
+	}
+
+	// Decode from Raw bytes (happens after fake client JSON round-trip on the stored copy).
+	workerStatus := &v1alpha1.WorkerStatus{}
+	Expect(json.Unmarshal(ps.Raw, workerStatus)).To(Succeed())
+	return workerStatus
+}
+
+// readBackWorkerStatus reads the Worker back from the fake client and returns its provider status.
+// Use this when the in-memory worker might not reflect the status updated via Status().Patch().
+func readBackWorkerStatus(ctx context.Context, c client.Client, worker *extensionsv1alpha1.Worker) *v1alpha1.WorkerStatus {
+	updated := &extensionsv1alpha1.Worker{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(worker), updated); err != nil {
+		// Fallback to in-memory object if not in the store (e.g. worker has no name in some tests).
+		return decodeWorkerProviderStatus(worker)
+	}
+	if updated.Status.ProviderStatus == nil {
+		// Status not stored (e.g. actuator set it on in-memory obj but fake client didn't persist it).
+		return decodeWorkerProviderStatus(worker)
+	}
+	return decodeWorkerProviderStatus(updated)
 }
 
 func encode(obj runtime.Object) []byte {
 	data, _ := json.Marshal(obj)
 	return data
-}
-
-func expectWorkerProviderStatusUpdateToSucceed(ctx context.Context, statusWriter *mockclient.MockStatusWriter) {
-	statusWriter.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{}), gomock.Any()).Return(nil)
-}
-
-func expectGetSecretCallToWork(c *mockclient.MockClient, w *extensionsv1alpha1.Worker) {
-	c.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: w.Spec.SecretRef.Namespace, Name: w.Spec.SecretRef.Name}, &corev1.Secret{}).DoAndReturn(
-		func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-			secret.Data = map[string][]byte{
-				azure.ClientIDKey:       []byte("seedClient-id"),
-				azure.ClientSecretKey:   []byte("seedClient-secret"),
-				azure.SubscriptionIDKey: []byte("1234"),
-				azure.TenantIDKey:       []byte("1234"),
-			}
-			return nil
-		}).AnyTimes()
 }
 
 func makeWorker(namespace string, region string, sshKey *string, infrastructureStatus *apiazure.InfrastructureStatus, pools ...extensionsv1alpha1.WorkerPool) *extensionsv1alpha1.Worker {

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -12,12 +12,11 @@ import (
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/install"
@@ -35,16 +34,26 @@ var _ = Describe("Ensurer", func() {
 		ctx     = context.TODO()
 		ensurer cloudprovider.Ensurer
 
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-		mgr  testutils.FakeManager
-
 		secret                 *corev1.Secret
 		servicePrincipalSecret corev1.Secret
 
-		gctx          = gcontext.NewGardenContext(nil, nil)
-		labelSelector = client.MatchingLabels{"azure.provider.extensions.gardener.cloud/purpose": "tenant-service-principal-secret"}
+		gctx = gcontext.NewGardenContext(nil, nil)
 	)
+
+	// purposeLabel is the label used to identify tenant service principal secrets.
+	const purposeLabel = "azure.provider.extensions.gardener.cloud/purpose"
+	const purposeValue = "tenant-service-principal-secret"
+
+	newEnsurer := func(objs ...corev1.Secret) cloudprovider.Ensurer {
+		scheme := kubernetes.SeedScheme
+		Expect(install.AddToScheme(scheme)).To(Succeed())
+		builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+		for i := range objs {
+			builder = builder.WithObjects(&objs[i])
+		}
+		mgr := testutils.FakeManager{Client: builder.Build()}
+		return NewEnsurer(mgr, logger)
+	}
 
 	BeforeEach(func() {
 		secret = &corev1.Secret{
@@ -53,6 +62,13 @@ var _ = Describe("Ensurer", func() {
 			},
 		}
 		servicePrincipalSecret = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-principal",
+				Namespace: "default",
+				Labels: map[string]string{
+					purposeLabel: purposeValue,
+				},
+			},
 			Data: map[string][]byte{
 				"tenantID":     []byte("tenant-id"),
 				"clientID":     []byte("client-id"),
@@ -60,18 +76,7 @@ var _ = Describe("Ensurer", func() {
 			},
 		}
 
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-
-		mgr = testutils.FakeManager{Client: c}
-		scheme := kubernetes.SeedScheme
-		Expect(install.AddToScheme(scheme)).To(Succeed())
-
-		ensurer = NewEnsurer(mgr, logger)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
+		ensurer = newEnsurer()
 	})
 
 	Describe("#EnsureCloudProviderSecret", func() {
@@ -90,11 +95,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add clientID and clientSecret", func() {
-			c.EXPECT().List(gomock.Any(), &corev1.SecretList{}, labelSelector).
-				DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					list.Items = []corev1.Secret{servicePrincipalSecret}
-					return nil
-				})
+			ensurer = newEnsurer(servicePrincipalSecret)
 
 			err := ensurer.EnsureCloudProviderSecret(ctx, gctx, secret, nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -106,22 +107,16 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should fail as service principal secret matching to the tenant id exists", func() {
-			c.EXPECT().List(gomock.Any(), &corev1.SecretList{}, labelSelector).
-				DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					list.Items = []corev1.Secret{}
-					return nil
-				})
+			// No service principal secret pre-populated → list returns empty
 
 			err := ensurer.EnsureCloudProviderSecret(ctx, gctx, secret, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fail as multiple service principal secrets matching to the tenant id exists", func() {
-			c.EXPECT().List(gomock.Any(), &corev1.SecretList{}, labelSelector).
-				DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					list.Items = []corev1.Secret{servicePrincipalSecret, servicePrincipalSecret}
-					return nil
-				})
+			sps2 := servicePrincipalSecret.DeepCopy()
+			sps2.Name = "svc-principal-2"
+			ensurer = newEnsurer(servicePrincipalSecret, *sps2)
 
 			err := ensurer.EnsureCloudProviderSecret(ctx, gctx, secret, nil)
 			Expect(err).To(HaveOccurred())
@@ -129,22 +124,14 @@ var _ = Describe("Ensurer", func() {
 
 		It("should fail as multiple service principal secrets matching to the tenant id exists", func() {
 			servicePrincipalSecret.Data["tenantID"] = []byte("some-different-tenant-id")
-			c.EXPECT().List(gomock.Any(), &corev1.SecretList{}, labelSelector).
-				DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					list.Items = []corev1.Secret{servicePrincipalSecret}
-					return nil
-				})
+			ensurer = newEnsurer(servicePrincipalSecret)
 
 			err := ensurer.EnsureCloudProviderSecret(ctx, gctx, secret, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should not add workload identity config to the secret if it is not labeled correctly", func() {
-			c.EXPECT().List(gomock.Any(), &corev1.SecretList{}, labelSelector).
-				DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					list.Items = []corev1.Secret{servicePrincipalSecret}
-					return nil
-				})
+			ensurer = newEnsurer(servicePrincipalSecret)
 			secret.Labels = map[string]string{"workloadidentity.security.gardener.cloud/provider": "foo"}
 			expected := secret.DeepCopy()
 			Expect(ensurer.EnsureCloudProviderSecret(ctx, gctx, secret, nil)).To(Succeed())

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -21,20 +21,16 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
 	"github.com/gardener/gardener/pkg/utils/version"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-azure/pkg/azure"
 )
@@ -51,11 +47,10 @@ func TestController(t *testing.T) {
 
 var _ = Describe("Ensurer ", func() {
 	var (
-		ctx  = context.TODO()
-		ctrl *gomock.Controller
+		ctx = context.TODO()
 
 		ensurer genericmutator.Ensurer
-		c       *mockclient.MockClient
+		scheme  *runtime.Scheme
 		mgr     testutils.FakeManager
 
 		dummyContext = gcontext.NewGardenContext(nil, nil)
@@ -112,17 +107,12 @@ var _ = Describe("Ensurer ", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
-		c = mockclient.NewMockClient(ctrl)
-
+		c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 		mgr = testutils.FakeManager{Client: c}
-
 		ensurer = NewEnsurer(mgr, logger)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
@@ -359,11 +349,7 @@ var _ = Describe("Ensurer ", func() {
 	})
 
 	Describe("#EnsureKubeletServiceUnitOptions", func() {
-		var (
-			acrCmKey = client.ObjectKey{Namespace: namespace, Name: azure.CloudProviderAcrConfigName}
-
-			oldUnitOptions []*unit.UnitOption
-		)
+		var oldUnitOptions []*unit.UnitOption
 
 		BeforeEach(func() {
 			oldUnitOptions = []*unit.UnitOption{
@@ -377,6 +363,14 @@ var _ = Describe("Ensurer ", func() {
 		})
 
 		It("should modify existing elements of kubelet.service unit options", func() {
+			acrCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderAcrConfigName},
+				Data:       map[string]string{},
+			}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(acrCM).Build()
+			mgr = testutils.FakeManager{Client: c}
+			ensurer = NewEnsurer(mgr, logger)
+
 			newUnitOptions := []*unit.UnitOption{
 				{
 					Section: "Service",
@@ -387,13 +381,6 @@ var _ = Describe("Ensurer ", func() {
 			}
 			newUnitOptions[0].Value += ` \
     --cloud-provider=external`
-
-			acrCM := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderAcrConfigName},
-				Data:       map[string]string{},
-			}
-			c.EXPECT().Get(ctx, acrCmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(acrCM))
-
 			newUnitOptions[0].Value += ` \
     --azure-container-registry-config=/var/lib/kubelet/acr.conf`
 
@@ -444,18 +431,12 @@ var _ = Describe("Ensurer ", func() {
 
 	Describe("#EnsureKubeletCloudProviderConfig", func() {
 		var (
-			objKey = client.ObjectKey{Namespace: namespace, Name: azure.CloudProviderDiskConfigName}
-			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderDiskConfigName},
-				Data:       map[string][]byte{"abc": []byte("xyz"), azure.CloudProviderConfigMapKey: []byte(cloudProviderConfigContent)},
-			}
-
 			existingData = ptr.To("[LoadBalancer]\nlb-version=v2\nlb-provider:\n")
 			emptydata    = ptr.To("")
 		)
 
 		It("cloud provider secret does not exist", func() {
-			c.EXPECT().Get(ctx, objKey, &corev1.Secret{}).Return(apierrors.NewNotFound(schema.GroupResource{}, secret.Name))
+			// Secret not pre-populated → fake client returns not-found
 
 			err := ensurer.EnsureKubeletCloudProviderConfig(ctx, dummyContext, nil, emptydata, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -463,7 +444,13 @@ var _ = Describe("Ensurer ", func() {
 		})
 
 		It("should create element containing cloud provider config content with secret", func() {
-			c.EXPECT().Get(ctx, objKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderDiskConfigName},
+				Data:       map[string][]byte{"abc": []byte("xyz"), azure.CloudProviderConfigMapKey: []byte(cloudProviderConfigContent)},
+			}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+			mgr = testutils.FakeManager{Client: c}
+			ensurer = NewEnsurer(mgr, logger)
 
 			err := ensurer.EnsureKubeletCloudProviderConfig(ctx, dummyContext, nil, emptydata, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -471,7 +458,13 @@ var _ = Describe("Ensurer ", func() {
 		})
 
 		It("should modify existing element containing cloud provider config content", func() {
-			c.EXPECT().Get(ctx, objKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: azure.CloudProviderDiskConfigName},
+				Data:       map[string][]byte{"abc": []byte("xyz"), azure.CloudProviderConfigMapKey: []byte(cloudProviderConfigContent)},
+			}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+			mgr = testutils.FakeManager{Client: c}
+			ensurer = NewEnsurer(mgr, logger)
 
 			err := ensurer.EnsureKubeletCloudProviderConfig(ctx, dummyContext, nil, existingData, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -490,6 +483,7 @@ var _ = Describe("Ensurer ", func() {
 		})
 
 		BeforeEach(func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			mgr = testutils.FakeManager{Client: c}
 			ensurer = NewEnsurer(mgr, logger)
 			DeferCleanup(testutils.WithVar(&ImageVector, imagevector.ImageVector{{
@@ -506,7 +500,10 @@ var _ = Describe("Ensurer ", func() {
 					Namespace: deployment.Namespace,
 				},
 			}
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(secret), secret).DoAndReturn(clientGet(secret))
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+			mgr = testutils.FakeManager{Client: c}
+			ensurer = NewEnsurer(mgr, logger)
+
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s132, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shootk8s132, deployment.Namespace, "provider-azure", "foo:bar")
@@ -519,13 +516,15 @@ var _ = Describe("Ensurer ", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cloudprovider",
 					Namespace: deployment.Namespace,
+					Labels: map[string]string{
+						"security.gardener.cloud/purpose": "workload-identity-token-requestor",
+					},
 				},
 			}
-			returnedSecret := secret.DeepCopy()
-			returnedSecret.Labels = map[string]string{
-				"security.gardener.cloud/purpose": "workload-identity-token-requestor",
-			}
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(secret), secret).DoAndReturn(clientGet(returnedSecret))
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+			mgr = testutils.FakeManager{Client: c}
+			ensurer = NewEnsurer(mgr, logger)
+
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s132, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shootk8s132, deployment.Namespace, "provider-azure", "foo:bar")
@@ -572,6 +571,7 @@ var _ = Describe("Ensurer ", func() {
 		})
 
 		BeforeEach(func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			mgr = testutils.FakeManager{Client: c}
 			ensurer = NewEnsurer(mgr, logger)
 		})
@@ -664,17 +664,5 @@ func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sVersion string,
 		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--feature-gates=", "VolumeAttributesClass=true", ","))
 	} else {
 		Expect(c.Command).NotTo(ContainElement(HavePrefix("--feature-gates")))
-	}
-}
-
-func clientGet(result runtime.Object) interface{} {
-	return func(_ context.Context, _ client.ObjectKey, obj runtime.Object, _ ...client.GetOption) error {
-		switch obj.(type) {
-		case *corev1.Secret:
-			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
-		case *corev1.ConfigMap:
-			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
-		}
-		return nil
 	}
 }


### PR DESCRIPTION
* Replace github.com/gardener/gardener/third_party/mock/controller-runtime/client (dropped in gardener v1.144) with sigs.k8s.io/controller-runtime/pkg/client/fake across all affected test files.
* Pre-populate fakeclient with WithObjects/WithStatusSubresource instead of using MockClient/MockStatusWriter EXPECT() calls.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind cleanup
/platform azure

**What this PR does / why we need it**:
This PR follows the cleanup process outlined in https://github.com/gardener/gardener/issues/14572.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Migrate test mock clients to fakeclient following https://github.com/gardener/gardener/pull/14799
```