### PR TITLE
Disable rendering of `ServiceMonitor` if the controller is disabled

### DIFF
--- a/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/servicemonitor.yaml
+++ b/charts/internal/seed-controlplane/charts/remedy-controller-azure/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.replicas) 0 }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -20,3 +21,4 @@ spec:
       action: keep
       regex: ^(azure_read_requests_total|azure_write_requests_total|cleaned_azure_public_ips_total|reapplied_azure_virtual_machines_total|azure_virtual_machine_states|rest_client_requests_total|controller_runtime_reconcile_total|workqueue_adds_total|workqueue_depth|workqueue_longest_running_processor_seconds|workqueue_queue_duration_seconds_bucket|workqueue_queue_duration_seconds_sum|workqueue_queue_duration_seconds_count|workqueue_retries_total|workqueue_unfinished_work_seconds|workqueue_work_duration_seconds_bucket|workqueue_work_duration_seconds_sum|workqueue_work_duration_seconds_count|process_max_fds|process_open_fds)$
   honorLabels: false
+{{- end }}


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement
/platform azure

**What this PR does / why we need it**:

This PR is analogous to https://github.com/gardener/gardener-extension-provider-azure/pull/1522 but for the `ServiceMonitor` that configures scraping of the `Remedy` controller by the shoot Prometheus.

Without this, enabling the `PrometheusHealthCheck` feature gate introduced by https://github.com/gardener/gardener/pull/13341 sets the `ObservabilityComponentsHealthy` shoot condition to false when the `Remedy` controller is disabled since the scrape target pool is empty.

**Special notes for your reviewer**:

Please know that I didn't set up a [remote cluster setup](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/development/remote-setup.md) to deploy this change.

/cc @istvanballok @rickardsjp @AndreasBurger 

**Release note**:

```other operator
The `ServiceMonitor` that configures scraping of the `Remedy` controller by the shoot Prometheus is not rendered if the controller is disabled. 
```
