### PR TITLE
Add support for Kubernetes 1.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support | Conformance test results                                                                                                                                                                                               |
 |-----------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Kubernetes 1.36 | 1.36.0+ | N/A                                                                                                                                                                                                                    |
 | Kubernetes 1.35 | 1.35.0+ | [![Gardener v1.35 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.35%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.35%20Azure) |
 | Kubernetes 1.34 | 1.34.0+ | [![Gardener v1.34 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.34%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.34%20Azure) |
 | Kubernetes 1.33 | 1.33.0+ | [![Gardener v1.33 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.33%20Azure/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.33%20Azure) |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -44,7 +44,6 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
-# max-supported-k8s
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager
@@ -59,7 +58,23 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-  targetVersion: '>= 1.35'
+  targetVersion: 1.35.x
+# max-supported-k8s
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager
+  tag: v1.36.3
+  labels:
+  - name: gardener.cloud/cve-categorisation
+    value:
+      network_exposure: protected
+      authentication_enforced: false
+      user_interaction: gardener-operator
+      confidentiality_requirement: high
+      integrity_requirement: high
+      availability_requirement: low
+    signing: false
+  targetVersion: '>= 1.36'
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager
@@ -105,7 +120,6 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
-# max-supported-k8s
 - name: cloud-node-manager
   sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
   repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager
@@ -120,7 +134,23 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-  targetVersion: '>= 1.35'
+  targetVersion: 1.35.x
+# max-supported-k8s
+- name: cloud-node-manager
+  sourceRepository: github.com/kubernetes-sigs/cloud-provider-azure
+  repository: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager
+  tag: v1.36.3
+  labels:
+  - name: gardener.cloud/cve-categorisation
+    value:
+      network_exposure: protected
+      authentication_enforced: false
+      user_interaction: gardener-operator
+      confidentiality_requirement: high
+      integrity_requirement: high
+      availability_requirement: low
+    signing: false
+  targetVersion: '>= 1.36'
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: registry.k8s.io/sig-storage/csi-attacher


### PR DESCRIPTION
**How to categorize this PR?**

/area open-source usability
/kind enhancement
/platform azure
/topology garden seed shoot

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.36 to the extension.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#14653

**Special notes for your reviewer**:

- Functionality validations:
  - [ ] Create new clusters with versions < 1.36
  - [ ] Create new clusters with version = 1.36
  - [ ] Upgrade old clusters from version 1.35 to version 1.36
  - [ ] Delete clusters with versions < 1.36
  - [ ] Delete clusters with version = 1.36

**Release note**:
```feature user
This extension now supports shoot clusters with Kubernetes version 1.36.
You should consider the Kubernetes release notes before upgrading to 1.36.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support information for Kubernetes 1.36.

* **Updates**
  * Updated Azure cloud controller and node manager images for Kubernetes 1.36, using version 1.36.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->