### PR TITLE
Update gardener to `v1.144.5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/elastic/crd-ref-docs v0.3.0
 	github.com/gardener/etcd-druid/api v0.36.4
-	github.com/gardener/gardener v1.144.2
-	github.com/gardener/gardener/pkg/apis v1.144.2
+	github.com/gardener/gardener v1.144.5
+	github.com/gardener/gardener/pkg/apis v1.144.5
 	github.com/gardener/machine-controller-manager v0.62.1
 	github.com/gardener/remedy-controller v0.14.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -193,10 +193,10 @@ github.com/gardener/cert-management v0.23.0 h1:kD88XcPn6C4zLc8EYtrHyb+/45Iyaozhb
 github.com/gardener/cert-management v0.23.0/go.mod h1:Mehn8XY+iAkm8XOBbNGHmbMft8fP9ZEJFWzWSonPkfc=
 github.com/gardener/etcd-druid/api v0.36.4 h1:o/17ciPrbh/w+igKMUuglW7N9XLjoMh7AvRKTzsBEVs=
 github.com/gardener/etcd-druid/api v0.36.4/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
-github.com/gardener/gardener v1.144.2 h1:Xo4bYdbFmoKM/GtUqARDDXRO9Yye8J5c5OSEfrdU0Ts=
-github.com/gardener/gardener v1.144.2/go.mod h1:RBqX3h3eiMtEUG7oDZqVM+wOYT1T1sr7c1WPs3akTeE=
-github.com/gardener/gardener/pkg/apis v1.144.2 h1:Wgwt+0GUzRy3unkIrfzaY5UgpzPbonwlPNDvpRf25nI=
-github.com/gardener/gardener/pkg/apis v1.144.2/go.mod h1:we6hJ8r80nL1rkXzVnOQwey4q77pQXHN3pvoBgeak8g=
+github.com/gardener/gardener v1.144.5 h1:lvFKr0EkuqxVnlV+stPDfXezEMstRp+6qGnxo38n73Q=
+github.com/gardener/gardener v1.144.5/go.mod h1:RBqX3h3eiMtEUG7oDZqVM+wOYT1T1sr7c1WPs3akTeE=
+github.com/gardener/gardener/pkg/apis v1.144.5 h1:HxSLNFoeMdmLpMQ82cJhlX3AqpHJYM05phDHh2NzSs0=
+github.com/gardener/gardener/pkg/apis v1.144.5/go.mod h1:we6hJ8r80nL1rkXzVnOQwey4q77pQXHN3pvoBgeak8g=
 github.com/gardener/machine-controller-manager v0.62.1 h1:TQ4Qs9aaYTqSkqFownIaEAvnrYoNpBMcp7ZMYVEgUWM=
 github.com/gardener/machine-controller-manager v0.62.1/go.mod h1:ICsymXK4VHm7NVr8Mpl6USvYcTZjUNSk6+XaVu/dd74=
 github.com/gardener/remedy-controller v0.14.0 h1:KQv6HXka/jWcnb0Bsl99iAEmu4X0mEWLkoywYsF0uI8=


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Update gardener to `v1.144.5` to include some bugfixes especially https://github.com/gardener/gardener/pull/15227.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The dependency `github.com/gardener/gardener` has been updated from `v1.144.2` to `v1.144.5`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Gardener dependency to version 1.144.5, incorporating the latest available fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->