### PR TITLE
Add Support for Machine Preservation

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -202,6 +202,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				}, disks)
 			)
 
+			if pool.MachineControllerManagerSettings != nil {
+				machineDeployment.AutoPreserveFailedMachineMax = ptr.Deref(pool.MachineControllerManagerSettings.AutoPreserveFailedMachineMax, 0)
+			}
+
 			networkConfig := map[string]any{
 				"vnet":   infrastructureStatus.Networks.VNet.Name,
 				"subnet": subnetName,
@@ -247,6 +251,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					MaxSurge:       ptr.To(worker.DistributePositiveIntOrPercent(zone.index, pool.MaxSurge, zone.count, pool.Maximum)),
 				}
 				machineClassSpec["zone"] = zone.name
+				if pool.MachineControllerManagerSettings != nil {
+					machineDeployment.AutoPreserveFailedMachineMax = worker.DistributeOverZones(zone.index, ptr.Deref(pool.MachineControllerManagerSettings.AutoPreserveFailedMachineMax, 0), zone.count)
+				}
 			}
 
 			machineDeploymentStrategy := machinev1alpha1.MachineDeploymentStrategy{

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1094,6 +1094,49 @@ var _ = Describe("Machines", func() {
 					Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation]).To(Equal("3m0s"))
 					Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
 				})
+
+				It("should distribute autoPreserveFailedMachineMax across zones", func() {
+					w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+						AutoPreserveFailedMachineMax: ptr.To(int32(4)),
+					}
+					workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+					expectedUserDataSecretRefRead()
+
+					result, err := workerDelegate.GenerateMachineDeployments(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).NotTo(BeNil())
+					Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(2)))
+					Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(2)))
+				})
+
+				It("should set autoPreserveFailedMachineMax to 0 per zone when machineControllerManagerSettings is nil", func() {
+					w.Spec.Pools[0].MachineControllerManagerSettings = nil
+					workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+					expectedUserDataSecretRefRead()
+
+					result, err := workerDelegate.GenerateMachineDeployments(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).NotTo(BeNil())
+					Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+					Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+				})
+
+				It("should set autoPreserveFailedMachineMax to 0 per zone when autoPreserveFailedMachineMax is nil", func() {
+					w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+						AutoPreserveFailedMachineMax: nil,
+					}
+					workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+					expectedUserDataSecretRefRead()
+
+					result, err := workerDelegate.GenerateMachineDeployments(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).NotTo(BeNil())
+					Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+					Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+				})
 			})
 
 			Describe("workers with in-place updates strategy", func() {
@@ -1387,18 +1430,20 @@ var _ = Describe("Machines", func() {
 
 			It("should set expected machineControllerManager settings on machine deployment", func() {
 				var (
-					testDrainTimeout    = metav1.Duration{Duration: 10 * time.Minute}
-					testHealthTimeout   = metav1.Duration{Duration: 20 * time.Minute}
-					testCreationTimeout = metav1.Duration{Duration: 30 * time.Minute}
-					testMaxEvictRetries = int32(30)
-					testNodeConditions  = []string{"ReadonlyFilesystem", "KernelDeadlock", "DiskPressure"}
+					testDrainTimeout                 = metav1.Duration{Duration: 10 * time.Minute}
+					testHealthTimeout                = metav1.Duration{Duration: 20 * time.Minute}
+					testCreationTimeout              = metav1.Duration{Duration: 30 * time.Minute}
+					testMaxEvictRetries              = int32(30)
+					testNodeConditions               = []string{"ReadonlyFilesystem", "KernelDeadlock", "DiskPressure"}
+					testAutoPreserveFailedMachineMax = int32(1)
 				)
 				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
-					MachineDrainTimeout:    &testDrainTimeout,
-					MachineCreationTimeout: &testCreationTimeout,
-					MachineHealthTimeout:   &testHealthTimeout,
-					MaxEvictRetries:        &testMaxEvictRetries,
-					NodeConditions:         testNodeConditions,
+					MachineDrainTimeout:          &testDrainTimeout,
+					MachineCreationTimeout:       &testCreationTimeout,
+					MachineHealthTimeout:         &testHealthTimeout,
+					MaxEvictRetries:              &testMaxEvictRetries,
+					NodeConditions:               testNodeConditions,
+					AutoPreserveFailedMachineMax: &testAutoPreserveFailedMachineMax,
 				}
 				workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
 
@@ -1416,6 +1461,33 @@ var _ = Describe("Machines", func() {
 				Expect(resultSettings.MachineHealthTimeout).To(Equal(&testHealthTimeout))
 				Expect(resultSettings.MaxEvictRetries).To(Equal(&testMaxEvictRetries))
 				Expect(resultSettings.NodeConditions).To(Equal(&resultNodeConditions))
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(testAutoPreserveFailedMachineMax))
+			})
+
+			It("should set autoPreserveFailedMachineMax to 0 when machineControllerManagerSettings is nil", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = nil
+				workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+				expectedUserDataSecretRefRead()
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+			})
+
+			It("should set autoPreserveFailedMachineMax to 0 when autoPreserveFailedMachineMax is nil", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					AutoPreserveFailedMachineMax: nil,
+				}
+				workerDelegate := wrapNewWorkerDelegate(c, chartApplier, w, cluster, nil)
+
+				expectedUserDataSecretRefRead()
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
 			})
 		})
 	})


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement
/platform azure

**What this PR does / why we need it**:

This PR adds support for the machine preservation feature (introduced in g/g: v1.147 and MCM: v0.62.0 ) by setting the `AutoPreserveFailedMachineMax` field in the `MachineDeployment.Spec`. The value for this field is derived by distributing `MachineControllerManagerSettings.AutoPreserveFailedMachineMax` defined at the worker pool level, across the zones of the worker pool (similar to `worker.Maximum` and `worker.Minimum`).

g/g PR: https://github.com/gardener/gardener/pull/14767
usage doc: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_machine_preservation.md

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for machine preservation by distributing the value of `worker[].machineControllerManager.autoPreserveFailedMachineMax` across zones.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of the automatic failed-machine preservation limit in machine deployments.
  * Configured limits are now distributed appropriately across zones.
  * When the setting is unavailable or unspecified, deployments consistently default to preserving zero failed machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->