### PR TITLE
doc: fix capabilityFlavors in core CloudProfile examples

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -36,7 +36,7 @@ The `machineCapabilities` feature allows you to:
 The capability system uses **automatic defaulting** from `.spec.machineCapabilities`:
 
 - **`.spec.machineCapabilities`**: Defines all available capability keys and their possible values (e.g., `architecture: [amd64, arm64]`, `azure-networking: [basic, accelerated]`)
-- Any capability **not explicitly specified** in `.spec.machineImages[].versions[].capabilityFlavors[].capabilities` or `.spec.machineTypes[].capabilities` automatically gets **all values** from `.spec.machineCapabilities`
+- Any capability **not explicitly specified** in `.spec.machineImages[].versions[].capabilityFlavors[]` or `.spec.machineTypes[].capabilities` automatically gets **all values** from `.spec.machineCapabilities`
 - If no capabilities are defined all will be defaulted.
 
 **Required Capability:**


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Each entry of `.spec.machineImages[].versions[].capabilityFlavours[]` is itself the capability map, no `capabilities` keyword here


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The yaml was correct already (openstack had a wrong yaml additionally, so this PR is smaller than https://github.com/gardener/gardener-extension-provider-openstack/pull/1402) 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated machine image capability defaulting guidance to use the current `capabilityFlavors[]` path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->